### PR TITLE
make the left navbar thinner

### DIFF
--- a/docs/extra.css
+++ b/docs/extra.css
@@ -280,3 +280,21 @@ div[role="navigation"] hr {
 .lang-container {
   margin-top: 50px;
 }
+
+.wy-side-scroll {
+  width: 250px;
+  overflow-y: hidden;
+  overflow-x: hidden;
+}
+
+.wy-side-nav-search {
+  width: 250px;
+}
+
+.wy-nav-side  {
+  width: 250px;
+}
+
+.wy-nav-content-wrap {
+  margin-left: 250px;
+}


### PR DESCRIPTION
the CSS changes seem a bit brittle so I don't know if we actually want this, but it gives us a lot more space for content when I have my browser taking up 50% of my screen, which a good number of people might when reading our docs.

before then after:
<img width="821" alt="Screen Shot 2020-10-27 at 9 02 21 AM" src="https://user-images.githubusercontent.com/409041/97312271-87b9fd80-1822-11eb-8e79-ead2b1576d40.png">
<img width="819" alt="Screen Shot 2020-10-27 at 9 02 11 AM" src="https://user-images.githubusercontent.com/409041/97312272-87b9fd80-1822-11eb-840e-b274173255d0.png">
