### PR TITLE
Add tutorial reference to rule references

### DIFF
--- a/docs/writing-rules/pattern-logic.md
+++ b/docs/writing-rules/pattern-logic.md
@@ -1,6 +1,9 @@
 # Rule syntax
 
-This document provides a reference for Semgrep YAML rule syntax.
+!!! info
+    Getting started with rule writing? Try the [Semgrep Tutorial](https://semgrep.dev/learn) 🎓
+
+This document describes Semgrep's YAML rule syntax.
 
 [TOC]
 

--- a/docs/writing-rules/pattern-syntax.md
+++ b/docs/writing-rules/pattern-syntax.md
@@ -1,5 +1,8 @@
 # Pattern syntax
 
+!!! info
+    Getting started with rule writing? Try the [Semgrep Tutorial](https://semgrep.dev/learn) 🎓
+
 This document describes Semgrep’s pattern syntax. You can also see pattern [examples by language](pattern-examples.md). In the command line, patterns are specified with the flag `--pattern` (or `-e`). Multiple
 coordinating patterns may be specified in a configuration file. See
 [rule syntax](pattern-logic.md) for more information.


### PR DESCRIPTION
This change helps new users who are looking at some of the more daunting reference pages be aware of the tutorial and the getting started "paved road".