### PR TITLE
Add search as an explicit plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ google_analytics:
   - auto
 extra_css: [extra.css]
 plugins:
+  - search
   - redirects:
       redirect_maps:
         "writing-rules/pattern-logic.md": "writing-rules/rule-syntax.md"


### PR DESCRIPTION
By adding the redirects plugin, we now also need to specify other plugins even if they’re part of the theme and weren’t previously listed in the plugins section.

This fixes #37.

Screenshot of working search + result:
<img width="1490" alt="Screen Shot 2020-11-09 at 4 21 40 PM" src="https://user-images.githubusercontent.com/302941/98611875-b49cf480-22a7-11eb-9aeb-a972ca4b26ef.png">
