### PR TITLE
Suggest to search the Semgrep Registry when searching docs returns no results

### DIFF
--- a/docs/search_js.js
+++ b/docs/search_js.js
@@ -1,0 +1,21 @@
+function replaceEmptySearchResults() {
+  let emptyResults = document.getElementById('mkdocs-search-results');
+  let updatedResults = '<p>Sorry, no results found in the docs. Try searching the <a href="https://semgrep.dev/r">Semgrep Registry</a> for related rules.</p>';
+  emptyResults.innerHTML = updatedResults;
+}
+
+let hasSearchResults = document.getElementById('mkdocs-search-results');
+
+if (hasSearchResults) {
+  const config = { attributes: true, childList: true, subtree: true };
+  const callback = function(mutationsList) {
+    for(const mutation of mutationsList) {
+        if (mutation.target.innerHTML === '<p>No results found</p>') {
+          replaceEmptySearchResults();
+        }
+    }
+  };
+
+  const observer = new MutationObserver(callback);
+  observer.observe(hasSearchResults, config);
+}

--- a/docs/search_js.js
+++ b/docs/search_js.js
@@ -1,6 +1,6 @@
 function replaceEmptySearchResults() {
   let emptyResults = document.getElementById('mkdocs-search-results');
-  let updatedResults = '<p>Sorry, no results found in the docs. Try searching the <a href="https://semgrep.dev/r">Semgrep Registry</a> for related rules.</p>';
+  let updatedResults = '<p>Sorry, no results found in the docs. Try searching the <a href="https://semgrep.dev/r">Semgrep Registry</a> for related rules or ask a question in the <a href="https://r2c.dev/slack">community Slack</a>.</p>';
   emptyResults.innerHTML = updatedResults;
 }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ google_analytics:
   - UA-106134149-12
   - auto
 extra_css: [extra.css]
+extra_javascript: [search_js.js]
 plugins:
   - search
   - redirects:


### PR DESCRIPTION
When one searches the docs and there are no results found, there may still be results available in the Semgrep Registry. This overrides the default “no results found” message with a message that includes a suggestion to go search in the Registry.