### PR TITLE
Inform the user that the secret GITHUB_TOKEN does not need to be created

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -140,7 +140,8 @@ Is your CI provider missing? Let us know by [filing an issue here](https://githu
     This feature is currently only available for GitHub.
 
 To get inline PR comments on your pull requests, set the `GITHUB_TOKEN` environment variable in your workflow file to `secrets.GITHUB_TOKEN`, which is the GitHub app installation access token.
-You can see an example of this environment variable set (commented out) in the above example workflow file.
+You can see an example of this environment variable set (commented out) in the above example workflow file. There’s no need to create this secret yourself because it’s automatically set by GitHub. It only needs to be passed to the action via the workflow file.
+
 Comments are left when Semgrep CI finds a result that blocks CI.
 Note that this feature is experimental; please reach out to support@r2c.dev to report any issues.
 


### PR DESCRIPTION
(for PR comments)

This secret is automatically made available by GitHub.