### PR TITLE
Allow two-character search queries

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,7 +45,8 @@ google_analytics:
   - auto
 extra_css: [extra.css]
 plugins:
-  - search
+  - search:
+      min_search_length: 2
   - redirects:
       redirect_maps:
         "writing-rules/pattern-logic.md": "writing-rules/rule-syntax.md"


### PR DESCRIPTION
The default minimum search length is three characters. This changes the minimum length to two characters, allowing users to search for terms like `CI` for which we have useful search results 🔍 