### PR TITLE
link to other tools that use semgrep

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -232,7 +232,8 @@ docker run -v $(pwd):/src --workdir /src returntocorp/semgrep-agent:v1 python -m
 
 # Semgrep as an engine
 
-Many other tools use Semgrep inside, but are maintained by others outside r2c!
+Many other tools have functionality powered by Semgrep.
+Add yours [with a pull request](https://github.com/returntocorp/semgrep-docs)!
 
 * [nodejsscan](https://github.com/ajinabraham/nodejsscan)
 * [libsast](https://github.com/ajinabraham/libsast)

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -229,6 +229,17 @@ docker run -v $(pwd):/src --workdir /src returntocorp/semgrep-agent:v1 python -m
     which can be changed to any value
     that `semgrep` itself understands.
 
+
+# Semgrep as an engine
+
+Many other tools use Semgrep inside, but are maintained by others outside r2c!
+
+* [NodeJSScan](https://github.com/ajinabraham/nodejsscan)
+* [libsast](https://github.com/ajinabraham/libsast)
+* [DefectDojo](https://github.com/DefectDojo/django-DefectDojo/pull/2781)
+* [Dracon](https://github.com/thought-machine/dracon)
+* [SALUS](https://github.com/coinbase/salus/blob/master/docs/scanners/semgrep.md)
+
 <!-- # Output
 
 This document describes `semgrep` output and the information provided after

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -234,7 +234,7 @@ docker run -v $(pwd):/src --workdir /src returntocorp/semgrep-agent:v1 python -m
 
 Many other tools use Semgrep inside, but are maintained by others outside r2c!
 
-* [NodeJSScan](https://github.com/ajinabraham/nodejsscan)
+* [nodejsscan](https://github.com/ajinabraham/nodejsscan)
 * [libsast](https://github.com/ajinabraham/libsast)
 * [DefectDojo](https://github.com/DefectDojo/django-DefectDojo/pull/2781)
 * [Dracon](https://github.com/thought-machine/dracon)


### PR DESCRIPTION
Documenting some of the external uses of semgrep, tagging maintainers in case they have an preferences on whether/where we link to:

- https://github.com/DefectDojo/django-DefectDojo/pull/2781 (@valentijnscholten)
- NodeJSScan / LibSast (@ajinabraham)
- SALUS (@ghbren)
- Dracon (@VJftw)