### PR TITLE
Un-nest sidebar links to simplify nav menu, fixes #68

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,23 +2,19 @@ site_name: Semgrep Docs
 site_url: https://semgrep.dev/docs/
 strict: true
 nav:
-  - Semgrep:
-      - Home: index.md
-      - getting-started.md
-      - Writing rules:
-          - writing-rules/overview.md
-          - Syntax:
-              - writing-rules/pattern-syntax.md
-              - writing-rules/rule-syntax.md
-          - Examples:
-              - writing-rules/pattern-examples.md
-              - writing-rules/rule-ideas.md
-          - writing-rules/testing-rules.md
-      - running-rules.md
-      - ignoring-findings.md
-      - managing-policy.md
-      - integrations.md
-      - Experiments 🧪: experiments/overview.md
+  - Home: index.md
+  - getting-started.md
+  - "Writing rules": writing-rules/overview.md
+  - writing-rules/pattern-syntax.md
+  - writing-rules/rule-syntax.md
+  - writing-rules/pattern-examples.md
+  - writing-rules/rule-ideas.md
+  - writing-rules/testing-rules.md
+  - running-rules.md
+  - ignoring-findings.md
+  - managing-policy.md
+  - integrations.md
+  - Experiments 🧪: experiments/overview.md
   - "Security Cheat Sheets":
       - "Django XSS": "cheat-sheets/django-xss.md"
       - "Flask XSS": "cheat-sheets/flask-xss.md"


### PR DESCRIPTION
Preview: ![Screen Shot 2021-02-01 at 4 09 18 PM](https://user-images.githubusercontent.com/302941/106534167-4f246280-64a8-11eb-9119-de361fef41f4.png)

Also note [this comment](https://github.com/returntocorp/semgrep-docs/issues/68#issuecomment-771259333) from @chmccreery: 

> “I like it! The sections don't all make sense to me immediately (where would I go for Semgrep Action documentation, for example?), but otherwise I am not bothered by the lower amount of nesting.

cc @underyx and @dlukeomalley 