### PR TITLE
use short link (/p) for cheatsheet configs

### DIFF
--- a/custom_theme/cheat-sheet-base.html
+++ b/custom_theme/cheat-sheet-base.html
@@ -132,7 +132,7 @@
               />
               </a> -->
             <p>
-              Semgrep ruleset for this cheatsheet: <a class="link dim near-white" target="_blank" href="{{ page.meta.config_url }}">{{ page.meta.config_url }}</a>
+              Semgrep ruleset for this cheatsheet: <a class="link dim near-white" target="_blank" href="https://semgrep.dev/{{ page.meta.short_config_url }}">https://semgrep.dev/{{ page.meta.short_config_url }}</a>
             </p>
             <p>
               {{ page.meta.summary }}
@@ -151,7 +151,7 @@
          </div>
          <div class="ruleset-cli-command">
             <h3>Check your project for these conditions:</h3>
-            <code><span class="unselectable">$ </span>semgrep --config {{ page.meta.config_url }}</code>
+            <code><span class="unselectable">$ </span>semgrep --config {{ page.meta.short_config_url }}</code>
           </div>
         </header>
 

--- a/docs/cheat-sheets/django-xss.md
+++ b/docs/cheat-sheets/django-xss.md
@@ -11,7 +11,7 @@ mitigation_summary: |-
   In general, always use the template engine provided by Django using <code>render()</code>. If you need HTML escaping, use `mark_safe()</code>
   combined with <code>format_html()</code> and review each individual usage carefully. Once reviewed, mark with `# nosem</code>. Beware of putting data in dangerous locations in
   templates. And as always, run a security checker continuously on your code.
-config_url: https://semgrep.dev/p/minusworld.django-xss
+short_config_url: p/minusworld.django-xss
 pdf: https://web-assets.r2c.dev/security-cheat-sheets/xss/r2c-security-cheat-sheet-xss-prevention-for-django.pdf
 conditions:
   - id: "1"

--- a/docs/cheat-sheets/flask-xss.md
+++ b/docs/cheat-sheets/flask-xss.md
@@ -11,7 +11,7 @@ mitigation_summary: |-
   In general, you should use <code>render_template()</code> when showing data to users. If you need HTML escaping, use `Markup()</code> and review
   each individual usage carefully. Once reviewed, mark the line with <code># nosem</code>. Beware of putting data in dangerous locations in
   templates. And as always, run a security checker continuously on your code.
-config_url: https://semgrep.dev/p/minusworld.flask-xss
+short_config_url: p/minusworld.flask-xss
 pdf: https://web-assets.r2c.dev/security-cheat-sheets/xss/r2c-security-cheat-sheet-xss-prevention-for-flask.pdf
 conditions:
   - id: "1"

--- a/docs/cheat-sheets/java-jsp-xss.md
+++ b/docs/cheat-sheets/java-jsp-xss.md
@@ -21,7 +21,7 @@ mitigation_summary: |-
   directly to <code>HttpServletResponse</code>. This is easier to review, maintain, and
   audit for issues. And as always, develop a secure coding policy and use a security
   checker to enforce it.
-config_url: https://semgrep.dev/p/minusworld.java-httpservlet-jsp-xss
+short_config_url: p/minusworld.java-httpservlet-jsp-xss
 pdf: https://web-assets.r2c.dev/security-cheat-sheets/xss/r2c-security-cheat-sheet-xss-prevention-for-java-jsp.pdf
 conditions:
   - id: "1"

--- a/docs/cheat-sheets/rails-xss.md
+++ b/docs/cheat-sheets/rails-xss.md
@@ -12,7 +12,7 @@ mitigation_summary: |-
   If HTML escaping is needed, use <code>html_safe()</code> in Ruby code and review each individual usage carefully.
   Once reviewed, mark the line with <code># nosem</code>. Beware of putting data in dangerous locations in
   templates. And as always, run a security checker continuously on your code.
-config_url: https://semgrep.dev/p/minusworld.ruby-on-rails-xss
+short_config_url: p/minusworld.ruby-on-rails-xss
 pdf: https://web-assets.r2c.dev/security-cheat-sheets/xss/r2c-security-cheat-sheet-xss-prevention-for-ruby-on-rails.pdf
 conditions:
   - id: "1"


### PR DESCRIPTION
<img width="442" alt="Screen Shot 2021-02-05 at 8 37 36 AM" src="https://user-images.githubusercontent.com/409041/107074857-ef330200-67ae-11eb-97b8-9d36c7dcae5d.png">

shortens the CTA on all the cheatsheets