### PR TITLE
css: adding scroll-margin and height fixes for left nav

### DIFF
--- a/docs/extra.css
+++ b/docs/extra.css
@@ -16,6 +16,7 @@ h2,
 h3,
 h4 {
   font-weight: 500;
+  scroll-margin-top: 60px;
 }
 
 h4.code-example-heading {
@@ -162,6 +163,11 @@ div.navbar {
 .wy-nav-side {
   position: fixed;
   top: 50px;
+  padding-bottom: 0;
+}
+
+.wy-menu {
+  padding-bottom: 1.5em;
 }
 
 .search-box-title {
@@ -428,6 +434,7 @@ div.cs li.cs-references {
     width: 250px;
     overflow-y: hidden;
     overflow-x: hidden;
+    height: calc(100% - 50px);
   }
 
   .wy-side-nav-search {
@@ -444,6 +451,10 @@ div.cs li.cs-references {
 }
 
 @media screen and (max-width: 768px) {
+  .wy-side-scroll {
+    height: calc(100% - 50px);
+  }
+
   nav.wy-nav-top {
     position: fixed;
     top: 50px;


### PR DESCRIPTION
As the top-navbar was added it created to bugs which are fixed by this PR, tested for mobile and desktop views: 

1. When using a ID targeted header link (either by clicking on the TOC or using an external link) the navbar hides the header from view. Adding `scroll-margin-top: 60px` fixes this issue. 
2. The left navbar is pushed down by 50px and the last link on the list is never visible. Fixing the height with `height: calc(100% - 50px);` but then the padding at the bottom acts weird. The `padding-bottom` lines makes sure that there is a padding at the end of the list which scrolls with the menu items. 