### PR TITLE
Promote 'metavariable-comparison' from experimental

### DIFF
--- a/docs/experiments/overview.md
+++ b/docs/experiments/overview.md
@@ -188,64 +188,6 @@ def test(arg):
    eval(z)
 ```
 
-# `metavariable-comparison`
-
-The `metavariable-comparison` operator compares metavariables against a basic [Python comparison](https://docs.python.org/3/reference/expressions.html#comparisons)
-expression. This is useful for filtering results based on a [metavariable's](../writing-rules/pattern-syntax.md#metavariables) numeric value.
-
-Example:
-
-The `metavariable-comparison` operator is a mapping which requires the
-`metavariable` and `comparison` keys. It can be combined with other pattern operators:
-
-```yaml
-rules:
-  - id: superuser-port
-    patterns:
-      - pattern: set_port($ARG)
-      - metavariable-comparison:
-          metavariable: '$ARG'
-          comparison: '$ARG < 1024'
-    message: "module setting superuser port"
-    languages: [python]
-    severity: ERROR
-```
-
-This will catch code like `set_port(80)` or `set_port(443)`, but not `set_port(8080)`.
-
-The `metavariable-comparison` operator also takes optional `base: int` and
-`strip: bool` keys. These keys set the integer base the metavariable value
-should be interpreted as and remove quotes from the metavariable value,
-respectively.
-
-For example, `base`:
-
-```
-- pattern: set_permissions($ARG)
-- metavariable-comparison:
-    metavariable: '$ARG'
-    comparison: '$ARG > 0o600'
-    base: 8
-```
-
-This will interpret metavariable values found in code as octal, so `0700`
-will be detected, but `0500` will not.
-
-For example, `strip`:
-
-```
-- pattern: to_integer($ARG)
-- metavariable-comparison:
-    metavariable: '$ARG'
-    comparison: '$ARG > 2147483647'
-    strip: true
-```
-
-This will remove quotes (`'`, `"`, and `` ` ``) from both ends of the
-metavariable content. So `"2147483648"` will be detected but `"2147483646"`
-will not. This is useful when you expect strings to contain integer or float
-data.
-
 # Generic pattern matching
 
 See [generic pattern matching](generic-pattern-matching.md).


### PR DESCRIPTION
`metavariable-comparison` has been hanging out in experimental for 4 months. Since then we've added it to 15 rules:

```
$ rg 'metavariable-comparison' | wc -l
15
```

My concern is that people won't find it if it's hiding under experiments, and may resort to `pattern-where-python`. Lets bring this thing out for primetime :+1: 