### PR TITLE
Wrap overflowing code blocks on mobile

### DIFF
--- a/docs/extra.css
+++ b/docs/extra.css
@@ -23,6 +23,13 @@ h4.code-example-heading {
   margin-bottom: 5px;
 }
 
+@media screen and (max-width: 768px) {
+  .rst-content pre code {
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+}
+
 code {
   border: none;
 }


### PR DESCRIPTION
Code blocks with lines of a certain length currently don't wrap, causing the width of the content to expand beyond what we support for mobile devices and consequently affecting the rest of the page. This PR fixes that.

Before:
![Screen Shot 2021-03-19 at 3 43 21 PM](https://user-images.githubusercontent.com/302941/111849246-570a5b80-88ca-11eb-9c5e-6b0060a17163.png)

After:
![Screen Shot 2021-03-19 at 3 44 17 PM](https://user-images.githubusercontent.com/302941/111849250-5a054c00-88ca-11eb-9d4a-666993bbf76e.png)
