### PR TITLE
Show the example file for GitHub Actions by default

### DIFF
--- a/docs/sample-ci-configs.md
+++ b/docs/sample-ci-configs.md
@@ -16,8 +16,8 @@ and instead use the `--config` flag
 to set which rules to scan with.
 
 !!! danger
-    `SEMGREP_APP_TOKEN` is a secret value: **do not hardcode it and leak credentials!**
-    Use your CI provider's secret or environment variable management feature to store it.
+`SEMGREP_APP_TOKEN` is a secret value: **do not hardcode it and leak credentials!**
+Use your CI provider's secret or environment variable management feature to store it.
 
 [TOC]
 
@@ -35,7 +35,6 @@ You can also copy the file contents
 and commit them to `.github/workflows/semgrep.yml` manually,
 or write your own workflow file based on this sample:
 
-<details><summary>Sample GitHub Actions workflow file</summary>
 <p>
 
 ```yaml
@@ -78,7 +77,6 @@ jobs:
 ```
 
 </p>
-</details>
 
 # GitLab CI
 


### PR DESCRIPTION
Rather than placing it in an expando-details element

Preview:
![Screen Shot 2021-03-19 at 3 51 05 PM](https://user-images.githubusercontent.com/302941/111849482-efa0db80-88ca-11eb-9155-f1aeef07b44c.png)
