### PR TITLE
Adding Jenkins example CI provider

### DIFF
--- a/docs/sample-ci-configs.md
+++ b/docs/sample-ci-configs.md
@@ -168,6 +168,64 @@ workflows:
 
 </p>
 
+# Jenkins
+With diff-scan trigger only for jobs, use webhooks to integrate to Github
+<p>
+  
+```Groovy
+pipeline {
+  agent {
+    kubernetes {
+      yaml """
+        apiVersion: v1
+        kind: Pod
+        spec:
+          containers:
+          - name: semgrep
+            image: 'returntocorp/semgrep-agent:v1'
+            command:
+            - cat
+            tty: true
+        """
+      defaultContainer 'semgrep'
+    }
+  }
+
+  environment {
+
+    // secrets for Semgrep org ID and auth token
+    SEMGREP_APP_TOKEN     = credentials('SEMGREP_APP_TOKEN')
+    SEMGREP_DEPLOYMENT_ID = credentials('SEMGREP_DEPLOYMENT_ID')
+    
+    // environment variables for semgrep_agent (for findings / analytics page)
+    // remove .git at the end
+    SEMGREP_REPO_URL = env.GIT_URL.replaceFirst(/^(.*).git$/,'$1')
+    SEMGREP_BRANCH = "${CHANGE_BRANCH}"
+    SEMGREP_JOB_URL = "${BUILD_URL}"
+    // remove SCM URL + .git at the end
+    SEMGREP_REPO_NAME = env.GIT_URL.replaceFirst(/^https:\/\/github.com\/(.*).git$/, '$1')
+    
+    SEMGREP_COMMIT = "${GIT_COMMIT}"
+    SEMGREP_PR_ID = "${env.CHANGE_ID}"
+    BASELINE_BRANCH = "${env.CHANGE_TARGET}"
+
+  }
+
+  stages {
+    stage('Semgrep_agent') {
+      when {
+        expression { env.CHANGE_ID && env.BRANCH_NAME.startsWith("PR-") }
+      }
+      steps{
+        sh 'env && git fetch origin $BASELINE_BRANCH && python -m semgrep_agent --baseline-ref origin/$BASELINE_BRANCH --publish-token $SEMGREP_APP_TOKEN --publish-deployment $SEMGREP_DEPLOYMENT_ID'
+      }
+   }
+  }
+}
+```
+</p>
+
+
 # Other providers
 
 To run Semgrep CI on any other provider,


### PR DESCRIPTION
Read and agreed semgrep's Code of Conduct

Description:
Adapted and tweaked from @daghan https://github.com/daghan/lets-be-bad-guys (thank you again !)
Adding a simple example Jenkins CI declarative, with diff-scan enabled, in the documentation 😃 