### PR TITLE
fix typo (Ruby, not Python)

### DIFF
--- a/docs/cheat-sheets/rails-xss.md
+++ b/docs/cheat-sheets/rails-xss.md
@@ -16,7 +16,7 @@ short_config_url: p/minusworld.ruby-on-rails-xss
 pdf: https://web-assets.r2c.dev/security-cheat-sheets/xss/r2c-security-cheat-sheet-xss-prevention-for-ruby-on-rails.pdf
 conditions:
   - id: "1"
-    description: "Server code: Unescaped variable enters template engine in Python code"
+    description: "Server code: Unescaped variable enters template engine in Ruby code"
     condition_details:
       - control: "A"
         short_description: "Using <code>html_safe()</code>"


### PR DESCRIPTION
Hi — this is a very cool project! Very trivial PR here, hope you don't mind. I showed my team the Rails XSS use case specifically, and in doing so noticed (and fixed) a typo.

![XSS_Prevention_for_Ruby_on_Rails_-_Semgrep_Docs](https://user-images.githubusercontent.com/974/115814527-78bb9e80-a3b2-11eb-8b58-807a74a9266a.png)
