### PR TITLE
Use getting started example that doesn't have quotes that get stripped

### DIFF
--- a/docs/writing-rules/overview.md
+++ b/docs/writing-rules/overview.md
@@ -16,7 +16,7 @@ You can write rules that do things like:
 
 This rule detects the use of `is` when comparing Python strings. `is` checks reference equality, not value equality, and can exhibit nondeterministic behavior.
 
-<iframe title="Semgrep example Python is comparison" src="https://semgrep.dev/embed/editor?snippet=B47A" width="100%" height="432px" frameborder="0"></iframe>
+<iframe title="Semgrep example Python is comparison" src="https://semgrep.dev/embed/editor?snippet=Ppde" width="100%" height="432px" frameborder="0"></iframe>
 
 ### Reference material
 


### PR DESCRIPTION
in simple editor.

Closes https://github.com/returntocorp/semgrep/issues/3118