### PR TITLE
Fix broken markdown in example CI configs

### DIFF
--- a/docs/sample-ci-configs.md
+++ b/docs/sample-ci-configs.md
@@ -265,7 +265,7 @@ sh 'env && git fetch origin $BASELINE_BRANCH && python -m semgrep_agent --baseli
 }
 }
 
-````
+```
 
 </p>
 
@@ -277,7 +277,7 @@ and run this command in your Docker container:
 
 ```sh
 semgrep-agent --publish-deployment $SEMGREP_DEPLOYMENT_ID --publish-token $SEMGREP_APP_TOKEN
-````
+```
 
 To get [CI context awareness](semgrep-ci.md#features),
 you can optionally provide the following environment variables:


### PR DESCRIPTION
It seems to be broken in the current documentation online, there are 4 backticks to close instead of 3, which makes the Jenkins block spill into the others
You can take a look here https://semgrep.dev/docs/sample-ci-configs/#jenkins