### PR TITLE
Rename "CI Integrations" to "Notifications"

### DIFF
--- a/docs/managing-policy.md
+++ b/docs/managing-policy.md
@@ -28,14 +28,14 @@ You can remove items from your policy by hovering over them in the rules tab and
 
 # Changing policy actions
 
-[Third-party notifications](integrations.md),
-posting [inline pull request comments](integrations.md#pull-request-comments),
+[Third-party notifications](notifications.md),
+posting [inline pull request comments](notifications.md#pull-request-comments),
 and blocking the build are all configured on a per-policy basis.
 
-1. Visit [Dashboard > Integrations](https://semgrep.dev/manage/integrations) to configure the services and name each of your integration channels. See [Integrations](integrations.md) for detailed instructions.
+1. Visit [Dashboard > Integrations](https://semgrep.dev/manage/integrations) to configure the services and name each of your integration channels. See [Integrations](notifications.md) for detailed instructions.
 2. Attach existing integration channels on either [Dashboard > Integrations](https://semgrep.dev/manage/integrations) or an individual policy page.
 
-You can also toggle on and off the abilities to post [pull request comments](integrations.md#pull-request-comments) or to block the build on findings. Don't forget to click Save when you are finished editing!
+You can also toggle on and off the abilities to post [pull request comments](notifications.md#pull-request-comments) or to block the build on findings. Don't forget to click Save when you are finished editing!
 
 ![Changing the integrations and actions of a policy](img/policy-actions.png "Changing the integrations and actions of a policy")
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -72,7 +72,7 @@ Interested in GitLab merge request comments? [Sign up for the beta here.](https:
 
 ## Webhooks
 
-Webhook notifications are a paid feature in our Semgrep Team tier.
+Webhook notifications are a paid feature in the Semgrep Team tier.
 
 To receive webhook notifications about Semgrep findings on pull requests and code pushes, visit [Dashboard > Integrations](https://semgrep.dev/manage/integrations) and select 'Add integration' or 'Setup First Integration,' and then choose 'Webhook'. Enter a target URL, give the notification channel a name of your choosing, and then click 'Save'.
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -68,7 +68,7 @@ If you are using Github Actions to run Semgrep, no extra changes are needed to g
 
 ## GitLab merge request comments
 
-Merge request comments on GitLab are coming soon. [Sign up for the beta here.](https://go.r2c.dev/join-gitlab-beta)
+Interested in GitLab merge request comments? [Sign up for the beta here.](https://go.r2c.dev/join-gitlab-beta)
 
 ## Webhooks
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -2,16 +2,33 @@
 append_help_link: true
 ---
 
-# CI Integrations
+# Notifications
 
-Semgrep CI provides integrations with 3rd party services like Slack and GitHub. When integrations are configured, you can receive notifications about Semgrep CI findings and failures. To configure these and learn more, visit [Dashboard > Integrations](https://semgrep.dev/manage/integrations).
+Semgrep CI integrates with 3rd party services when connected to Semgrep App.
+When integrations are configured, you can receive notifications about Semgrep CI findings and failures.
 
-- [CI Integrations](#ci-integrations)
-  - [Slack](#slack)
-  - [Email](#email)
-  - [Pull request comments](#pull-request-comments)
+[TOC]
 
-### Slack
+# De-duplication
+
+Notifications are sent only the first time a given finding is seen.
+
+Because of Semgrep CI's diff-awareness, you will not be notified
+when a pull request has a finding that existed on the base branch already,
+even if that line is moved or re-indented.
+
+Semgrep App also keeps track of notifications that have already been sent,
+so consecutive scans of the same changes in the same pull request
+won't send duplicate notifications.
+
+# Notification channels
+
+## Slack
+
+<p style="text-align: center; font-size: 12px">
+    <img width="600px" src="../img/slack-notification.png" alt="Screenshot of a Slack notification describing the details of a finding"/><br/>
+    A Slack notification triggered by new findings in a pull request
+</p>
 
 To receive Slack notifications about Semgrep findings on pull requests and code pushes, visit [Dashboard > Integrations](https://semgrep.dev/manage/integrations) and select 'Add integration' or 'Setup First Integration' and then choose 'Slack'. Give your channel a name, and then follow the setup instructions on the page to retrieve your Webhook URL.
 
@@ -21,18 +38,16 @@ Use the 'Test' button to send a test notification and ensure that your channel i
 
 ![A correctly configured Slack webhook will send a notification like this](img/test-notification.png "Correctly configured webhook will send a notification like this")
 
-### Email
+## Email
 
 To receive email notifications about Semgrep findings on pull requests and code pushes, visit [Dashboard > Integrations](https://semgrep.dev/manage/integrations) and select 'Add integration' or 'Setup First Integration,' and then choose 'Email'. Enter your email address, give the channel a name of your choosing, and then click 'Save'.
 
 On each scan that has at least one finding, you will receive one email from Semgrep with a summary of all of the findings from that scan.
 
-### Pull request comments
+## GitHub pull request comments
 
-<!-- prettier-ignore-start -->
 !!! info
     This feature is currently only available for GitHub.
-<!-- prettier-ignore-end -->
 
 Pull request comments are left when
 
@@ -51,7 +66,11 @@ If you are using Github Actions to run Semgrep, no extra changes are needed to g
 - `SEMGREP_PR_ID` is set to the PR number of the pull request on Github (e.g. `2900`)
 - `SEMGREP_REPO_NAME` is set to the repo name (e.g. `returntocorp/semgrep`)
 
-### Webhooks
+## GitLab merge request comments
+
+Merge request comments on GitLab are coming soon. [Sign up for the beta here.](https://go.r2c.dev/join-gitlab-beta)
+
+## Webhooks
 
 Webhook notifications are a paid feature in our Semgrep Team tier.
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -46,9 +46,6 @@ On each scan that has at least one finding, you will receive one email from Semg
 
 ## GitHub pull request comments
 
-!!! info
-    This feature is currently only available for GitHub.
-
 Pull request comments are left when
 
 1. Semgrep finds a result in CI, and

--- a/docs/semgrep-ci.md
+++ b/docs/semgrep-ci.md
@@ -147,11 +147,11 @@ whether you're a developer or part of a security team.
 
 Notifications require connection to Semgrep App. You can get notified about new findings via:
 
-- [GitHub pull request comments](integrations.md#pull-request-comments)
+- [GitHub pull request comments](notifications.md#pull-request-comments)
 - GitLab merge request comments ([sign up for the beta here](https://go.r2c.dev/join-gitlab-beta))
-- [Slack messages](integrations.md#slack)
-- [emails](integrations.md#email)
-- [webhooks](integrations.md#webhooks) (paid feature in Semgrep App)
+- [Slack messages](notifications.md#slack)
+- [emails](notifications.md#email)
+- [webhooks](notifications.md#webhooks) (paid feature in Semgrep App)
 
 To set up notifications:
 
@@ -160,15 +160,8 @@ To set up notifications:
 as a policy action. Only the rules in these policies will trigger notifications.
 
 !!! note
-    Notifications will be sent only the first time a given finding is seen.
-
-    Because of Semgrep CI's diff-awareness, you will not be notified
-    when a pull request has a finding that existed on the base branch already,
-    even if that line is moved or re-indented.
-
-    Semgrep App also keeps track of notifications that have already been sent,
-    so consecutive scans of the same changes in the same pull request
-    won't send duplicate notifications.
+    Notifications are sent only the first time a given finding is seen.
+    [See how notifications are de-duplicated](notifications.md/#de-duplication)
 
 ### Security Dashboards
 
@@ -273,7 +266,7 @@ You can customize the ruleset you're using to ignore some of its rules by [editi
 
 ### Getting notifications instead of blocking builds
 
-Some rules point out hotspots that require careful review but are not certain to be insecure code. You might want to disable blocking when scanning with such rules, and instead use a [CI integration](integrations.md) to get notifications.
+Some rules point out hotspots that require careful review but are not certain to be insecure code. You might want to disable blocking when scanning with such rules, and instead use a [CI integration](notifications.md) to get notifications.
 
 You can set this up by [changing the actions of the Semgrep App policy](managing-policy.md#changing-policy-actions) used for your scans.
 

--- a/docs/writing-rules/rule-ideas.md
+++ b/docs/writing-rules/rule-ideas.md
@@ -14,7 +14,7 @@ Not sure what to write a rule for? Below are some common questions, ideas, and t
 
 _Time to write this rule: **5 minutes**_
 
-You can use Semgrep and its GitHub integration to [automate PR comments](../integrations.md) that you frequently make in code reviews. Writing a custom rule for the code pattern you want to target is usually straightforward. If you want to understand the Semgrep syntax, see the [documentation](pattern-syntax.md) or try the [tutorial](https://semgrep.dev/learn). 
+You can use Semgrep and its GitHub integration to [automate PR comments](../notifications.md) that you frequently make in code reviews. Writing a custom rule for the code pattern you want to target is usually straightforward. If you want to understand the Semgrep syntax, see the [documentation](pattern-syntax.md) or try the [tutorial](https://semgrep.dev/learn). 
 
 <p align="center" style="font-size: 12px">
     <img src="../../img/semgrep-ci.gif" alt="A reviewer writes a Semgrep rule and adds it to an organization-wide policy."/></br>
@@ -123,5 +123,3 @@ Try answering these questions to uncover important rules for your project.
 1. What issues were caused by misconfigurations in Infrastructure-as-Code files (JSON)?
 1. What are some “invariants” that should hold about your code - things that should always or never be true (e.g. every admin route checks if user is admin)?
 1. What methods/APIs are deprecated and you’re trying to move away from?
-
-                                                                                                                                                                                                                                                 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,7 +23,7 @@ nav:
       - semgrep-ci.md
       - sample-ci-configs.md
       - managing-policy.md
-      - CI Integrations: integrations.md
+      - notifications.md
 
   - "Security Cheat Sheets":
       - "Django XSS": "cheat-sheets/django-xss.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,3 +67,4 @@ plugins:
         "writing-rules/pattern-logic.md": "writing-rules/rule-syntax.md"
         "writing-rules/index.md": "writing-rules/overview.md"
         "semgrep-ci/managing-policy.md": "managing-policy.md"
+        "integrations.md": "notifications.md"


### PR DESCRIPTION
Made this change because CI Integrations sounds like it's about which CI providers Semgrep CI can run in. We already use "Notifications" on the main Semgrep CI docs page.