### PR TITLE
Remove universal analytics and add GA4 analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ Contributions to the docs are welcome! To start contributing, first please make 
 
 ### Developing docs locally
 
-1. Install mkdocs: `pip install mkdocs==1.1.2`
+1. Install mkdocs: `pip install mkdocs==1.2.1`
 2. Install required plugins: `pip install mkdocs-redirects mkdocs-meta-descriptions-plugin`
 3. Clone the repo
 4. Run the docs locally with `mkdocs serve` and then go to: <http://127.0.0.1:8000/>
 
 If you use `pipx` to manage virtual environments,
 you can install the required apps with
-`pipx install mkdocs==1.1.2 && pipx inject mkdocs mkdocs-redirects mkdocs-meta-descriptions-plugin`
+`pipx install mkdocs==1.2.1 && pipx inject mkdocs mkdocs-redirects mkdocs-meta-descriptions-plugin`
 
 ## Creating content
 

--- a/custom_theme/404.html
+++ b/custom_theme/404.html
@@ -53,16 +53,15 @@
   {%- block extrahead %} {% endblock %}
 
   {%- block analytics %}
-  {% if config.google_analytics %}
-  <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    {%- if config.theme.analytics.gtag %}
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ config.theme.analytics.gtag }}"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-      ga('create', '{{ config.google_analytics[0] }}', '{{ config.google_analytics[1] }}');
-      ga('send', 'pageview');
-  </script>
+      gtag('config', '{{ config.theme.analytics.gtag }}');
+    </script>
   {% endif %}
   <script>
     window['_fs_debug'] = false;

--- a/custom_theme/404.html
+++ b/custom_theme/404.html
@@ -53,7 +53,7 @@
   {%- block extrahead %} {% endblock %}
 
   {%- block analytics %}
-    {%- if config.theme.analytics.gtag %}
+    {% if config.theme.analytics.gtag %}
     <script async src="https://www.googletagmanager.com/gtag/js?id={{ config.theme.analytics.gtag }}"></script>
     <script>
       window.dataLayer = window.dataLayer || [];

--- a/custom_theme/base.html
+++ b/custom_theme/base.html
@@ -54,16 +54,15 @@
   {%- block extrahead %} {% endblock %}
 
   {%- block analytics %}
-  {% if config.google_analytics %}
-  <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  {%- if config.theme.analytics.gtag %}
+      <script async src="https://www.googletagmanager.com/gtag/js?id={{ config.theme.analytics.gtag }}"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
 
-      ga('create', '{{ config.google_analytics[0] }}', '{{ config.google_analytics[1] }}');
-      ga('send', 'pageview');
-  </script>
+        gtag('config', '{{ config.theme.analytics.gtag }}');
+      </script>
   {% endif %}
   <script>
     window['_fs_debug'] = false;

--- a/custom_theme/base.html
+++ b/custom_theme/base.html
@@ -54,7 +54,7 @@
   {%- block extrahead %} {% endblock %}
 
   {%- block analytics %}
-  {%- if config.theme.analytics.gtag %}
+  {% if config.theme.analytics.gtag %}
       <script async src="https://www.googletagmanager.com/gtag/js?id={{ config.theme.analytics.gtag }}"></script>
       <script>
         window.dataLayer = window.dataLayer || [];

--- a/custom_theme/cheat-sheet-base.html
+++ b/custom_theme/cheat-sheet-base.html
@@ -54,7 +54,7 @@
   {%- block extrahead %} {% endblock %}
 
   {%- block analytics %}
-  {%- if config.theme.analytics.gtag %}
+  {% if config.theme.analytics.gtag %}
       <script async src="https://www.googletagmanager.com/gtag/js?id={{ config.theme.analytics.gtag }}"></script>
       <script>
         window.dataLayer = window.dataLayer || [];

--- a/custom_theme/cheat-sheet-base.html
+++ b/custom_theme/cheat-sheet-base.html
@@ -54,16 +54,15 @@
   {%- block extrahead %} {% endblock %}
 
   {%- block analytics %}
-  {% if config.google_analytics %}
-  <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  {%- if config.theme.analytics.gtag %}
+      <script async src="https://www.googletagmanager.com/gtag/js?id={{ config.theme.analytics.gtag }}"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
 
-      ga('create', '{{ config.google_analytics[0] }}', '{{ config.google_analytics[1] }}');
-      ga('send', 'pageview');
-  </script>
+        gtag('config', '{{ config.theme.analytics.gtag }}');
+      </script>
   {% endif %}
   {%- endblock %}
 </head>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,12 +51,11 @@ theme:
     - yaml
     - rust
     - django
+  analytics:
+      gtag: G-1851JH9FSR
 markdown_extensions:
   - admonition
   - toc
-google_analytics:
-  - UA-106134149-12
-  - auto
 extra_css: [extra.css]
 extra_javascript: [search_js.js]
 plugins:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,7 +52,7 @@ theme:
     - rust
     - django
   analytics:
-      gtag: G-1851JH9FSR
+    gtag: G-1851JH9FSR
 markdown_extensions:
   - admonition
   - toc


### PR DESCRIPTION
According to [this note from mkdocs](https://www.mkdocs.org/about/release-notes/#backward-incompatible-changes-in-12):

> So long as the old "UA-" ID and new "G-" ID are properly linked in your Google account, and you are using the "G-" ID, the data will be made available in both the old and new formats by Google Analytics.

Note I’m not able to get this working locally yet. I don’t see the GA tag loading on the local page and when running in verbose mode, I see what seems to be mkdocs not picking up the new gtag configuration:
```
Loaded theme configuration for 'readthedocs' from '/usr/local/lib/python3.9/site-packages/mkdocs/themes/readthedocs/mkdocs_theme.yml': {'static_templates': ['404.html'], 'locale': 'en',
            'include_search_page': True, 'search_index_only': False, 'highlightjs': True, 'hljs_languages': [], 'analytics': {'gtag': None}, 'include_homepage_in_sidebar': True,
            'prev_next_buttons_location': 'bottom', 'navigation_depth': 4, 'titles_only': False, 'sticky_navigation': True, 'collapse_navigation': True}
```

@underyx perhaps it’s something wrong with my yaml? I’m intending to follow what’s [described here](https://www.mkdocs.org/user-guide/choosing-your-theme/#readthedocs).
