### PR TITLE
Remove trailing slash on config url

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,7 +5,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 module.exports = {
   title: 'Semgrep',
   tagline: 'Lightweight static analysis for many languages. Find bug variants with patterns that look like source code.',
-  url: 'https://semgrep.dev/',
+  url: 'https://semgrep.dev',
   baseUrl: '/docs/',
   onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',


### PR DESCRIPTION
The trailing slash on the config’s url would Docusaurus to construct some `<meta>` tags using URLs of the form `https://semgrep.dev//docs/managing-findings/ `.  This change removes the unnecessary trailing slash and thus these `meta` tags now use URLs of the form `https://semgrep.dev/docs/running-rules/`.