### PR TITLE
Misc bug fixes

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -1,6 +1,7 @@
 ---
 slug: cli-usage
 append_help_link: true
+description: "Reference for the Semgrep command line tool including options and exit code behavior."
 ---
 
 import MoreHelp from "/src/components/MoreHelp"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,5 +1,6 @@
 ---
 slug: contributing
+description: "Semgrep is LGPL-licensed and contributions are welcome. Get started by filing an issue, fixing a bug, contributing rules to the registry, adding a feature, or updating the docs. You can also contribute by helping others in the r2c Community Slack!"
 ---
 
 # Contributing

--- a/docs/experiments/generic-pattern-matching.md
+++ b/docs/experiments/generic-pattern-matching.md
@@ -3,10 +3,7 @@ append_help_link: true
 ---
 
 # Generic pattern matching
-
-[TOC]
-
-# Introduction
+## Introduction
 Semgrep can match matches generic patterns in languages that it doesn’t yet support. You can use generic pattern matching for languages that don’t yet have a parser, configuration files, and other structured data, such as HTML or XML. Generic pattern matching is experimental.
 
 As an example, consider this rule:
@@ -48,7 +45,7 @@ Generic pattern matching has the following properties:
 * Common ASCII braces `()`, `[]`, and `{}` introduce secondary nesting but only within single lines. Therefore, misinterpreted or mismatched braces don't disturb the structure of the rest of document.
 * The document must be at least as indented as the pattern: any indentation specified in the pattern must be honored in the document.
 
-# Caveats and limitations
+## Caveats and limitations
 
 Spacegrep should work fine with any human-readable text, as long as it’s primarily based on ASCII symbols. In practice, it might work great with some languages and less well with others. In general, it’s possible or even easy to write code in weird ways that will prevent Spacegrep from matching. Note it’s not good for detecting malicious code. For example, in HTML one can write `&#x48;&#x65;&#x6C;&#x6C;&#x6F`; instead of `Hello` and this is not something Spacegrep would match if the pattern is `Hello`, unlike if it had full HTML support.
 
@@ -59,7 +56,7 @@ With respect to Semgrep operators and features:
 * pattern operators like either/not/inside are supported
 * inline regular expressions for strings (`"=~/word.*/"`) is not supported 
 
-# Command line example
+## Command line example
 
 Sample pattern `exec.pat` contains: `exec(...)`
 
@@ -99,14 +96,14 @@ exec (
 print("exec(bar)")
 ```
 
-# Semgrep Registry rules for generic pattern matching
+## Semgrep Registry rules for generic pattern matching
 You can peruse [existing generic rules](https://semgrep.dev/r?lang=generic&sev=ERROR,WARNING,INFO&tag=dgryski.semgrep-go,hazanasec.semgrep-rules,ajinabraham.njsscan,best-practice,security,java-spring,go-stdlib,ruby-stdlib,java-stdlib,js-node,nodejsscan,owasp,dlint,react,performance,compatibility,portability,correctness,maintainability,secuirty,mongodb,experimental,caching,robots-denied,missing-noreferrer,missing-noopener) in the Semgrep registry. In general, short patterns on structured data will perform the best.
 
-# Cheat sheet
+## Cheat sheet
 Some examples of what will and will not match on the `generic` tab of the Semgrep cheat sheet below:
 
 <iframe src="https://semgrep.dev/embed/cheatsheet" scrolling="0" width="100%" height="800"  frameBorder="0"></iframe>
 <br />
 
-# Hidden bonus
+## Hidden bonus
 In the Semgrep code the generic pattern matching implementation is called **spacegrep** because it tokenizes based on whitespace (and because it sounds cool 😎).

--- a/docs/experiments/generic-pattern-matching.md
+++ b/docs/experiments/generic-pattern-matching.md
@@ -1,5 +1,6 @@
 ---
 append_help_link: true
+description: "Semgrep can match matches generic patterns in languages that it doesn’t yet support. You can use generic pattern matching for languages that don’t yet have a parser, configuration files, and other structured data, such as HTML or XML. Generic pattern matching is experimental."
 ---
 
 # Generic pattern matching

--- a/docs/experiments/overview.md
+++ b/docs/experiments/overview.md
@@ -6,9 +6,7 @@ append_help_link: true
 
 This document describes experimental features and how to try them. Have fun, [file bugs](https://github.com/returntocorp/semgrep/issues/new/choose), tweak the code, and most importantly share your thoughts! 
 
-[TOC]
-
-# Autofix
+## Autofix
 
 Hands down the best way to enforce a code standard is to just automatically fix it. Semgrep's rule format supports a `fix:` key that supports metavariable replacement, much like message fields. This allows for value capture and rewriting.
 
@@ -30,7 +28,7 @@ rules:
   severity: WARNING
 ```
 
-## Autofix with regular expression replacement
+### Autofix with regular expression replacement
 
 A variant on the experimental `fix` key is `fix-regex`, which applies regular expression replacements (think `sed`) to matches found by Semgrep.
 
@@ -75,7 +73,7 @@ rules:
   <img src="https://web-assets.r2c.dev/inline-autofix-regex.gif" width="100%" alt="Apply Semgrep autofix direclty to a file"/>
 </p>
 
-# Equivalences
+## Equivalences
 
 Equivalences enable defining equivalent code patterns (i.e. a commutative property: `$X + $Y <==> $Y + $X`). Equivalence rules use the `equivalences` top-level key and one `equivalence` key for each equivalence.
 
@@ -83,7 +81,7 @@ For example:
 
 <iframe src="https://semgrep.dev/embed/editor?snippet=jNnn" border="0" frameBorder="0" width="100%" height="435"></iframe>
 
-# Data-flow analysis
+## Data-flow analysis
 
 Semgrep can perform intra-procedural flow-sensitive analyses. The data-flow engine still has several limitations, therefore expect both false positives and false negatives. False positives could be removed by using [pattern-not](../writing-rules/rule-syntax.md#pattern-not).
 
@@ -96,7 +94,7 @@ A non-exhaustive list of current limitations:
 
 As of now, data-flow analysis is used for [taint tracking](#taint-tracking) and [constant propagation](#constant-propagation).
 
-## Taint tracking
+### Taint tracking
 
 Semgrep supports intra-file [taint tracking](https://en.wikipedia.org/wiki/Taint_checking). Taint tracking rules must specify `mode: taint`. Additionally, the following operators are enabled:
 
@@ -108,7 +106,7 @@ For example:
 
 <iframe src="https://semgrep.dev/embed/editor?snippet=2blB" border="0" frameBorder="0" width="100%" height="435"></iframe>
 
-## Constant propagation
+### Constant propagation
 
 Semgrep supports intra-procedural constant propagation. This tracks whether a variable must carry a constant value at each point in the program.
 
@@ -116,6 +114,6 @@ For example:
 
 <iframe src="https://semgrep.dev/embed/editor?snippet=XLpw" border="0" frameBorder="0" width="100%" height="435"></iframe>
 
-# Generic pattern matching
+## Generic pattern matching
 
 See [generic pattern matching](../generic-pattern-matching/).

--- a/docs/experiments/overview.md
+++ b/docs/experiments/overview.md
@@ -118,4 +118,4 @@ For example:
 
 # Generic pattern matching
 
-See [generic pattern matching](generic-pattern-matching.md).
+See [generic pattern matching](../generic-pattern-matching/).

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -2,7 +2,7 @@
 slug: extensions
 append_help_link: true
 description: >-
-  Learn how to extend Semgrep use to an editor, in pre-commit, and in other tools.
+  Learn how to use Semgrep in an editor, in pre-commit, and in other tools.
 ---
 
 import MoreHelp from "/src/components/MoreHelp"

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -33,7 +33,7 @@ Probably! If you have a typical consulting service and running semgrep-rules is 
 
 #### What is your support policy?
 
-Help is available for all users, free or otherwise, through the [r2c Community Slack](https://r2c.dev/slack). Semgrep Team tier customers receive 8\*5 email/phone/Slack support with committed SLAs. See [Support](support.md) for more details.
+Help is available for all users, free or otherwise, through the [r2c Community Slack](https://r2c.dev/slack). Semgrep Team tier customers receive 8\*5 email/phone/Slack support with committed SLAs. See [Support](../support/) for more details.
 
 ## Billing / Pricing
 
@@ -69,7 +69,7 @@ As Semgrep evolves, a query like `foo("password")` becomes smarter. In the origi
 
 **3. Integrated: Semgrep understands git and other version-control systems**
 
-It’s easy to write a new Semgrep rule and have it only apply _going forward_. You can [mute findings](ignoring-findings.md) of course, but we have [built-in support for this with Semgrep CI](semgrep-ci/overview.md) and GitHub/GitLab/etc. integrations.
+It’s easy to write a new Semgrep rule and have it only apply _going forward_. You can [mute findings](../ignoring-findings/) of course, but we have [built-in support for this with Semgrep CI](semgrep-ci/overview/) and GitHub/GitLab/etc. integrations.
 
 **4. Portable: If you write a Semgrep rule, it runs anywhere**
 
@@ -93,7 +93,7 @@ Both Semgrep and CodeQL use static analysis to find bugs, but there are a few di
 - Semgrep is LGPL-2.1 and free to run anywhere; CodeQL is not open source and you must pay to run it on any non-open-source code
 
 - Semgrep supports autofixes; CodeQL does not.
-- Semgrep focuses on speed and ease of use. Because it doesn’t require a buildable environment, it doesn’t have some of the analysis features like interprocedural dataflow analysis that CodeQL does. (Semgrep does have [limited intraproceedural dataflow and a taint-tracking mode](experiments/overview.md))
+- Semgrep focuses on speed and ease of use. Because it doesn’t require a buildable environment, it doesn’t have some of the analysis features like interprocedural dataflow analysis that CodeQL does. (Semgrep does have [limited intraproceedural dataflow and a taint-tracking mode](/experiments/overview/))
 - Both have publicly available rules
 - Semgrep rules look like the source code you’re writing; CodeQL has a separate domain-specific-language for writing queries.
 - Semgrep has an online, hosted free plan; both have a hosted paid plan
@@ -142,11 +142,11 @@ Semgrep CI makes network requests in accordance with the data storage mentioned 
 
 #### How do I configure Semgrep for different projects?
 
-Semgrep App provides centralized policy management. See [Managing CI policy](semgrep-app/managing-policy.md) for more details.
+Semgrep App provides centralized policy management. See [Managing CI policy](../semgrep-app/managing-policy/) for more details.
 
 #### What is a policy?
 
-A policy is a simple collection of rules and a definition of what to do with rule results: fail the Semgrep CI run and/or send non-blocking notifications to third-party services like Slack. Please see [Managing CI policy](semgrep-app/managing-policy.md) for more details.
+A policy is a simple collection of rules and a definition of what to do with rule results: fail the Semgrep CI run and/or send non-blocking notifications to third-party services like Slack. Please see [Managing CI policy](../semgrep-app/managing-policy/) for more details.
 
 ## Monitoring
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,9 +43,9 @@ $ semgrep -e '$X == $X' --lang=py path/to/src
 $ semgrep --config=p/ci path/to/src
 ```
 
-See [CLI Reference](cli-usage.md) for command line options and exit codes.
+See [CLI Reference](../cli-usage/) for command line options and exit codes.
 
-Visit [Running rules](running-rules.md) to learn more or try Semgrep on known vulnerable test projects:
+Visit [Running rules](../running-rules/) to learn more or try Semgrep on known vulnerable test projects:
 
 <details><summary>Expand for sample projects! 🎉</summary>
 <p>
@@ -90,10 +90,10 @@ Semgrep rules can cover a wide range of use cases:
 - Identifying authentication violations
 - Lightweight vulnerability detection
 - Scanning configuration files
-- And more! Check out more use cases [here](writing-rules/rule-ideas.md).
+- And more! Check out more use cases [here](../writing-rules/rule-ideas/).
 
 
-Visit [Writing Rules > Getting started](writing-rules/overview.md) for an in-depth guide and reference material.
+Visit [Writing Rules > Getting started](../writing-rules/overview/) for an in-depth guide and reference material.
 
 This rule is used to find and discourage `print(...)` in production code. You can edit this rule here or visit the [Playground](https://semgrep.dev/editor) to write and deploy your own rule.
 
@@ -107,11 +107,11 @@ This rule is used to find and discourage `print(...)` in production code. You ca
 ## Run Semgrep continuously
 
 Finally, Semgrep is at its best when used to continuously scan code.
-Check out [Semgrep CI](semgrep-ci/overview.md) to learn how to get results where you already work:
+Check out [Semgrep CI](../semgrep-ci/overview/) to learn how to get results where you already work:
 GitHub, GitLab, Slack, Jira, and more.
 To get results even earlier in the development process,
 such as in a Git pre-commit hook or VS Code,
-check the available [Semgrep extensions](extensions.md).
+check the available [Semgrep extensions](../extensions/).
 
 For teams running Semgrep on multiple projects, see [Semgrep App](https://semgrep.dev/manage). Its free and paid tiers let users:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,7 @@
 ---
 slug: getting-started
 append_help_link: true
+description: "Start by running Semgrep locally to scan your code. It runs offline on uncompiled code: no code leaves your machine."
 ---
 
 # Getting started

--- a/docs/ignoring-findings.md
+++ b/docs/ignoring-findings.md
@@ -1,6 +1,7 @@
 ---
 slug: ignoring-findings
 append_help_link: true
+description: "Semgrep allows for ignoring findings in code. Learn how to ignore findings from all Semgrep rules, a single rule, or multiple rules. You can also specify ignore files to cause Semgrep to skip scanning of file or paths."
 ---
 
 import MoreHelp from "/src/components/MoreHelp"

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ description: >-
 </p>
 <h3 align="center">Static analysis at ludicrous speed<br />Find bugs and enforce code standards</h3>
 
-Semgrep is a fast, open-source, static analysis tool for finding bugs and enforcing code standards at editor, commit, and CI time. [Get started →](getting-started.md)
+Semgrep is a fast, open-source, static analysis tool for finding bugs and enforcing code standards at editor, commit, and CI time. [Get started →](getting-started/)
 
 Semgrep analyzes code locally on your computer or in your build environment: **code is never uploaded**.
 
@@ -29,8 +29,8 @@ Its rules look like the code you already write; no abstract syntax trees, regex 
 
 The Semgrep ecosystem includes:
 
-* [Semgrep](getting-started.md) - the open-source command line tool at the heart of everything
-* [Semgrep CI](semgrep-ci/overview.md) - a specialized Docker image for running Semgrep in CI environments
+* [Semgrep](getting-started/) - the open-source command line tool at the heart of everything
+* [Semgrep CI](semgrep-ci/overview/) - a specialized Docker image for running Semgrep in CI environments
 * [Semgrep Playground](https://semgrep.dev/editor) - an online interactive editor for writing and sharing rules
 * [Semgrep Registry](https://semgrep.dev/explore) - 1,000+ community-driven rules covering security, correctness, and performance bugs
 * [Semgrep App](https://semgrep.dev/manage) - deploy, manage, and monitor Semgrep at scale with free and paid tiers
@@ -57,7 +57,7 @@ Semgrep supports 17+ languages.
 | TypeScript |                            |              |
 | TSX        |                            |              |
 
-To determine alpha, beta, or general availability (GA) status we scan a wide corpus of projects and measure the parse rate of each language. For more details see [the breakdown of all supported languages](status.md).
+To determine alpha, beta, or general availability (GA) status we scan a wide corpus of projects and measure the parse rate of each language. For more details see [the breakdown of all supported languages](language-support/).
 
 ## History
 

--- a/docs/managing-findings.md
+++ b/docs/managing-findings.md
@@ -1,6 +1,7 @@
 ---
 slug: managing-findings
 append_help_link: true
+description: "A finding is the core result of Semgrep's analysis. Findings are generated when a Semgrep rule matches a piece of code. Learn how to interact with findings that come from running Semgrep in the command-line, in CI, and through Semgrep App."
 ---
 
 import MoreHelp from "/src/components/MoreHelp"

--- a/docs/managing-findings.md
+++ b/docs/managing-findings.md
@@ -9,7 +9,7 @@ import MoreHelp from "/src/components/MoreHelp"
 
 ## Findings
 
-A finding is the core result of Semgrep's analysis. Findings are generated when a Semgrep rule matches a piece of code. After matching, a finding can make its way through 3 parts of the Semgrep ecosystem: [Semgrep](https://github.com/returntocorp/semgrep), [Semgrep CI](semgrep-ci/overview.md), and [Semgrep App](https://semgrep.dev/manage).
+A finding is the core result of Semgrep's analysis. Findings are generated when a Semgrep rule matches a piece of code. After matching, a finding can make its way through 3 parts of the Semgrep ecosystem: [Semgrep](https://github.com/returntocorp/semgrep), [Semgrep CI](../semgrep-ci/overview/), and [Semgrep App](https://semgrep.dev/manage).
 
 ## Semgrep
 
@@ -45,11 +45,11 @@ severity:warning rule:finding-test: Finding test 2
 1:print(1 == 1)
 ```
 
-For more information on writing rules, see [Rule syntax](writing-rules/rule-syntax.md).
+For more information on writing rules, see [Rule syntax](../writing-rules/rule-syntax/).
 
 ## Semgrep CI
 
-[Semgrep CI](semgrep-ci/overview.md), designed to continuously scan commits and builds, improves on Semgrep findings to track the lifetime of an individual finding. A Semgrep CI finding is defined by a 4-tuple:
+[Semgrep CI](../semgrep-ci/overview/), designed to continuously scan commits and builds, improves on Semgrep findings to track the lifetime of an individual finding. A Semgrep CI finding is defined by a 4-tuple:
 
 ```
 (rule ID, file path, syntactic context, index)
@@ -63,7 +63,7 @@ These pieces of state correspond to:
 1. `index`: an index into identical findings within a file. This is used to disambiguate findings.
 
 :::info
-`syntactic context` is normalized by removing indentation, [`nosemgrep`](ignoring-findings.md#ignoring-findings-via-inline-comments) comments, and whitespace.
+`syntactic context` is normalized by removing indentation, [`nosemgrep`](../ignoring-findings/#ignoring-findings-via-inline-comments) comments, and whitespace.
 :::
 
 These are hashed and returned as the syntactic identifier: `syntactic_id`. This is how Semgrep CI uniquely identifies findings and tracks them across state transitions. Semgrep CI does not store or transmit code contents. The `syntactic context` is hashed using a one-way hashing function making it impossible to recover the original contents.
@@ -119,6 +119,6 @@ Track high, or low, performing policies, rulesets, and rules:
 The "rate" for any state is `(state total / total of all states)`, e.g., `fix rate = (fixed / (fixed + open + muted))`.
 :::
 
-For more information on blocking vs. non-blocking visit [Managing CI policy](semgrep-app/managing-policy.md).
+For more information on blocking vs. non-blocking visit [Managing CI policy](../semgrep-app/managing-policy/).
 
 <MoreHelp />

--- a/docs/running-rules.md
+++ b/docs/running-rules.md
@@ -7,7 +7,7 @@ import MoreHelp from "/src/components/MoreHelp"
 
 # Running rules
 
-Existing and custom Semgrep rules can be run locally via the Semrgep command line tool or continuously with Semgrep CI. See [Getting started](getting-started.md) for their respective installation and setup.
+Existing and custom Semgrep rules can be run locally via the Semrgep command line tool or continuously with Semgrep CI. See [Getting started](../getting-started/) for their respective installation and setup.
 
 
 ## Run registry rules
@@ -25,10 +25,10 @@ Rulesets can be added to Semgrep CI scans using their "Add to Policy" button on 
 ## Run local rules
 
 :::tip
-See [Writing rules > Getting started](writing-rules/overview.md) to learn how to write rules.
+See [Writing rules > Getting started](../writing-rules/overview/) to learn how to write rules.
 :::
 
-Local rules can be ephemeral using the `-e` or `--pattern` flag or run from YAML rule files conforming to the [Rule syntax](writing-rules/rule-syntax.md) schema.
+Local rules can be ephemeral using the `-e` or `--pattern` flag or run from YAML rule files conforming to the [Rule syntax](../writing-rules/rule-syntax/) schema.
 
 Check for Python `==` where the left and right hand sides are the same (often a bug): 
 
@@ -47,7 +47,7 @@ You may find that some files that were previously parsed are now skipped; this w
 
 ## Findings
 
-* See [Managing findings](managing-findings.md) for information on Semgrep findings.
-* See [Ignoring findings](ignoring-findings.md) for details on suppressing rule output.
+* See [Managing findings](../managing-findings/) for information on Semgrep findings.
+* See [Ignoring findings](../ignoring-findings/) for details on suppressing rule output.
 
 <MoreHelp />

--- a/docs/semgrep-app/managing-policy.md
+++ b/docs/semgrep-app/managing-policy.md
@@ -30,14 +30,14 @@ You can remove items from your policy by hovering over them in the rules tab and
 
 ## Changing policy actions
 
-[Third-party notifications](notifications.md),
-posting [inline pull request comments](notifications.md#pull-request-comments),
+[Third-party notifications](../notifications/),
+posting [inline pull request comments](../notifications/#pull-request-comments),
 and blocking the build are all configured on a per-policy basis.
 
-1. Visit [Dashboard > Integrations](https://semgrep.dev/manage/integrations) to configure the services and name each of your integration channels. See [Integrations](notifications.md) for detailed instructions.
+1. Visit [Dashboard > Integrations](https://semgrep.dev/manage/integrations) to configure the services and name each of your integration channels. See [Integrations](../notifications/) for detailed instructions.
 2. Attach existing integration channels on either [Dashboard > Integrations](https://semgrep.dev/manage/integrations) or an individual policy page.
 
-You can also toggle on and off the abilities to post [pull request comments](notifications.md#pull-request-comments) or to block the build on findings. Don't forget to click Save when you are finished editing!
+You can also toggle on and off the abilities to post [pull request comments](../notifications/#pull-request-comments) or to block the build on findings. Don't forget to click Save when you are finished editing!
 
 ![Changing the integrations and actions of a policy](../img/policy-actions.png "Changing the integrations and actions of a policy")
 
@@ -52,7 +52,7 @@ semgrep --config <path/to/yaml> <path/to/code>
 ```
 
 :::tip
-See [Getting started](getting-started.md) for instructions on downloading and running Semgrep locally.
+See [Getting started](/getting-started/) for instructions on downloading and running Semgrep locally.
 :::
 
 ## Assigning a policy to a project

--- a/docs/semgrep-app/notifications.md
+++ b/docs/semgrep-app/notifications.md
@@ -1,6 +1,7 @@
 ---
 slug: notifications
 append_help_link: true
+description: "Semgrep CI integrates with 3rd party services when connected to Semgrep App. Learn how to get Slack or email alerts about findings and failures, how to get merge or pull request comments in your CI/CD pipeline, or how to integrate using webhooks."
 ---
 
 import MoreHelp from "/src/components/MoreHelp"

--- a/docs/semgrep-app/notifications.md
+++ b/docs/semgrep-app/notifications.md
@@ -60,7 +60,7 @@ An inline GitHub pull request comment.
 
 Note that [Semgrep App](https://semgrep.dev/manage) uses the permissions requested by [the Semgrep GitHub App](https://github.com/marketplace/semgrep-dev) to leave PR comments.
 
-If you are using Github Actions to run Semgrep, no extra changes are needed to get PR comments. If you are using another CI provider, in addition to the environment variables you set after following [sample CI configurations](semgrep-ci/sample-ci-configs.md) you need to ensure that the following environment variables are correctly defined:
+If you are using Github Actions to run Semgrep, no extra changes are needed to get PR comments. If you are using another CI provider, in addition to the environment variables you set after following [sample CI configurations](/semgrep-ci/sample-ci-configs/) you need to ensure that the following environment variables are correctly defined:
 
 - `SEMGREP_COMMIT` is set to the full commit hash of the code being scanned (e.g. `d8875d6a63bba2b377a57232e404d2e367dce82d`)
 - `SEMGREP_PR_ID` is set to the PR number of the pull request on Github (e.g. `2900`)

--- a/docs/semgrep-ci/configuration-reference.md
+++ b/docs/semgrep-ci/configuration-reference.md
@@ -1,5 +1,6 @@
 ---
 slug: configuration-reference
+description: "Reference for running Semgrep CI in your CI job or on the command line using semgrep-agent. Learn how to select rules to scan with, enable diff-aware scanning, connect to Semgrep App, and more."
 ---
 
 import MoreHelp from "/src/components/MoreHelp"

--- a/docs/semgrep-ci/overview.md
+++ b/docs/semgrep-ci/overview.md
@@ -201,15 +201,15 @@ For example, in GitLab CI/CD:
 # ...
 ```
 
-Key names and configuration format for specific CI providers are available in the [sample CI configurations](sample-ci-configs.md).
+Key names and configuration format for specific CI providers are available in the [sample CI configurations](../sample-ci-configs/).
 
 ### Custom rules
 
 :::info
-See [Writing rules](../writing-rules/overview.md) to learn how to write custome rules.
+See [Writing rules](/writing-rules/overview/) to learn how to write custome rules.
 :::
 
-Your own custom rules can be added to your Semgrep CI configuration just like [Registry rules](#registry-rules-and-rulesets) by:
+Your own custom rules can be added to your Semgrep CI configuration just like [Registry rules](#registry-rules-and-rulesets/) by:
 
 1. Including their [Playground](https://semgrep.dev/editor) share ID (e.g. `s/susan:named-rule`)
 2. Adding the directory or file path to the local file containing the rule
@@ -239,7 +239,7 @@ Semgrep CI supports a `.semgrepignore` file that follows the `.gitignore` syntax
 
 By default Semgrep CI skips files and directories such as `tests/`, `node_modules/`, and `vendor/`. The full list of ignored items is in [the `.semgrepignore` template file](https://github.com/returntocorp/semgrep-action/blob/v1/src/semgrep_agent/templates/.semgrepignore), which is used by Semgrep CI when no explicit `.semgrepignore` file is found in the root of your project.
 
-For information on ignoring individual findings in code, see the [ignoring findings page](../ignoring-findings.md).
+For information on ignoring individual findings in code, see the [ignoring findings page](/ignoring-findings/).
 
 ### Audit scans
 
@@ -267,13 +267,13 @@ To use your Semgrep App account, set `--publish-deployment` and `--publish-token
 
 #### Ignoring specific rules in a ruleset or policy
 
-You can customize the ruleset you're using to ignore some of its rules by [editing the Semgrep App policy](../semgrep-app/managing-policy.md#editing-a-policy) used for your scans.
+You can customize the ruleset you're using to ignore some of its rules by [editing the Semgrep App policy](/semgrep-app/managing-policy/#editing-a-policy) used for your scans.
 
 #### Getting notifications instead of blocking builds
 
-Some rules point out hotspots that require careful review but are not certain to be insecure code. You might want to disable blocking when scanning with such rules, and instead use a [CI integration](../semgrep-app/notifications.md) to get notifications.
+Some rules point out hotspots that require careful review but are not certain to be insecure code. You might want to disable blocking when scanning with such rules, and instead use a [CI integration](/semgrep-app/notifications/) to get notifications.
 
-You can set this up by [changing the actions of the Semgrep App policy](../semgrep-app/managing-policy.md#changing-policy-actions) used for your scans.
+You can set this up by [changing the actions of the Semgrep App policy](/semgrep-app/managing-policy/#changing-policy-actions) used for your scans.
 
 <MoreHelp />
 

--- a/docs/semgrep-ci/sample-ci-configs.md
+++ b/docs/semgrep-ci/sample-ci-configs.md
@@ -1,6 +1,7 @@
 ---
 slug: sample-ci-configs
 append_help_link: true
+description: "The sample configuration files below run Semgrep CI on continuous integration platforms such as GitHub, GitLab, Jenkins, Buildkite, CircleCI, and other providers."
 ---
 
 import MoreHelp from "/src/components/MoreHelp"

--- a/docs/semgrep-ci/sample-ci-configs.md
+++ b/docs/semgrep-ci/sample-ci-configs.md
@@ -317,7 +317,7 @@ To run Semgrep CI on any other provider,
 use the `returntocorp/semgrep-agent:v1` Docker image,
 and run the `semgrep-agent` command.
 
-Using the [configuration reference](configuration-reference.md),
+Using the [configuration reference](../configuration-reference/),
 you can run Semgrep in the following CI providers:
 
 - AppVeyor

--- a/docs/trophy-case.md
+++ b/docs/trophy-case.md
@@ -1,5 +1,6 @@
 ---
 slug: trophy-case
+description: "This is a list of vulnerabilities found and security fixes made with Semgrep."
 ---
 
 # Semgrep trophy case

--- a/docs/troubleshooting/gitlab-sast.md
+++ b/docs/troubleshooting/gitlab-sast.md
@@ -19,7 +19,7 @@ Please visit [GitLab’s SAST troubleshooting guide](https://docs.gitlab.com/ee/
 
 ## If the `semgrep-sast` CI job is slow
 
-The `semgrep-sast` job should take less than a minute to scan a large project with 50k lines of Python and TypeScript code. If you see worse performance, please [reach out](../support.md) to the Semgrep maintainers for help with tracking down the cause. Long runtimes are typically caused by just one rule or source code file taking too long. You can also try these solutions:
+The `semgrep-sast` job should take less than a minute to scan a large project with 50k lines of Python and TypeScript code. If you see worse performance, please [reach out](/support/) to the Semgrep maintainers for help with tracking down the cause. Long runtimes are typically caused by just one rule or source code file taking too long. You can also try these solutions:
 
 ### Solution #1: Review global CI job configuration
 
@@ -51,7 +51,7 @@ You can use a comma separated list to ignore multiple patterns: `SAST_EXCLUDED_P
 
 ### Solution #3: Upgrade to Semgrep CI
 
-To improve performance by 10x on a typical project, you can use our own CI agent [Semgrep CI](../semgrep-ci/overview.md) directly by adding the job definition as shown on the [GitLab + Semgrep](https://semgrep.dev/for/gitlab) page.
+To improve performance by 10x on a typical project, you can use our own CI agent [Semgrep CI](/semgrep-ci/overview/) directly by adding the job definition as shown on the [GitLab + Semgrep](https://semgrep.dev/for/gitlab) page.
 
 Semgrep CI skips scanning unchanged files in merge requests but still lets you keep your GitLab SAST workflow.
 
@@ -82,6 +82,6 @@ Semgrep is made by a small team, and you can directly guide our work by answerin
 
 If you’re a GitLab customer and suspect there’s an issue with GitLab, please [contact GitLab support](https://about.gitlab.com/support/) and open a support ticket. Users of GitLab’s free plans should open a thread in the [GitLab Community Forum](https://forum.gitlab.com/).
 
-If you suspect the issue is with Semgrep, please check the [Semgrep Support page](../support.md) to get help from the Semgrep maintainers & community via Slack, email, or phone.
+If you suspect the issue is with Semgrep, please check the [Semgrep Support page](/support/) to get help from the Semgrep maintainers & community via Slack, email, or phone.
 
 <MoreHelp />

--- a/docs/troubleshooting/rules.md
+++ b/docs/troubleshooting/rules.md
@@ -46,7 +46,7 @@ While the most common reason for pattern parse errors is the aboe, other things 
 
 ## If your rule doesn't match where it should
 
-In general, it helps to test the patterns within your rule in isolation. If you scan for the patterns one by one and they each find what you expect, the issue is with the boolean logic within your rule. Review the [rule syntax](../writing-rules/rule-syntax.md) to make sure the operators are meant to behave like you expect. If you managed to find a pattern that behaves incorrectly, continue debugging with the section below.
+In general, it helps to test the patterns within your rule in isolation. If you scan for the patterns one by one and they each find what you expect, the issue is with the boolean logic within your rule. Review the [rule syntax](/writing-rules/rule-syntax/) to make sure the operators are meant to behave like you expect. If you managed to find a pattern that behaves incorrectly, continue debugging with the section below.
 
 ## If your pattern doesn't match where it should
 
@@ -61,6 +61,6 @@ When using `metavariable-regex`, the regex will match against all characters of 
 
 ## How to get help
 
-Please check the [Support](../support.md) page to get help from the Semgrep maintainers & community, via Slack, GitHub, email, or phone.
+Please check the [Support](/support/) page to get help from the Semgrep maintainers & community, via Slack, GitHub, email, or phone.
 
 <MoreHelp />

--- a/docs/troubleshooting/semgrep-app.md
+++ b/docs/troubleshooting/semgrep-app.md
@@ -38,13 +38,13 @@ Many CI providers have a time limit for how long a job can run. Semgrep CI also 
 
 <!-- TODO: explain self-serve benchmarking -->
 
-- Please [reach out](../support.md) to the Semgrep maintainers for help with tracking down the cause. Semgrep scans most large projects with hundreds of rules within a few minutes, and long runtimes are typically caused by just one rule or source code file taking too long.
-- To drastically cut run times, you can use Semgrep CI's diff-aware scanning to skip scanning unchanged files. For more details, see [Semgrep CI's behavior](../semgrep-ci/overview.md#behavior).
-- You can skip scanning large and complex source code files (such as minified JS or generated code) if you know their path by adding a `.semgrepignore` file. See [how to ignore files & directories in Semgrep CI](../semgrep-ci/overview.md#ignoring-files-directories).
+- Please [reach out](/support/) to the Semgrep maintainers for help with tracking down the cause. Semgrep scans most large projects with hundreds of rules within a few minutes, and long runtimes are typically caused by just one rule or source code file taking too long.
+- To drastically cut run times, you can use Semgrep CI's diff-aware scanning to skip scanning unchanged files. For more details, see [Semgrep CI's behavior](/semgrep-ci/overview/#behavior).
+- You can skip scanning large and complex source code files (such as minified JS or generated code) if you know their path by adding a `.semgrepignore` file. See [how to ignore files & directories in Semgrep CI](/semgrep-ci/overview.md#ignoring-files-directories).
 - You can increase Semgrep CI's own run time limit by setting a `semgrep-agent --timeout <seconds>` flag, or by setting a `SEMGREP_TIMEOUT=<seconds>` environment variable. To fully disable the time limit, set this value to `0`.
 
 ## How to get help
 
-Please check the [Support](../support.md) page to get help from the Semgrep maintainers & community, via Slack, GitHub, email, or phone.
+Please check the [Support](/support/) page to get help from the Semgrep maintainers & community, via Slack, GitHub, email, or phone.
 
 <MoreHelp />

--- a/docs/troubleshooting/semgrep-app.md
+++ b/docs/troubleshooting/semgrep-app.md
@@ -1,5 +1,6 @@
 ---
 slug: semgrep-app
+description: "Not seeing what you expect in Semgrep App? Follow these troubleshooting steps or find out how to get one-on-one help."
 ---
 
 import MoreHelp from "/src/components/MoreHelp"

--- a/docs/writing-rules/overview.md
+++ b/docs/writing-rules/overview.md
@@ -1,7 +1,7 @@
 ---
 id: overview
 description: >-
-  Learn how to use Semgrep’s intuitive syntax to write rules specific to your codebase.
+  Learn how to use Semgrep’s intuitive syntax to write rules specific to your codebase. You can write and share rules directly from your browser using the Semgrep Playground, or write rules in your terminal and run them on the command line.
 ---
 
 # Getting started
@@ -11,6 +11,7 @@ description: >-
 If you want the best introduction to writing Semgrep rules, use the interactive, example-based [Semgrep rule tutorial](https://semgrep.dev/learn).
 
 ### Do it live!
+
 You can write and share rules directly from the [Playground](https://semgrep.dev/editor). You can also write rules in your terminal and run them with the Semgrep command line tool.
 
 You can write rules that do things like:

--- a/docs/writing-rules/overview.md
+++ b/docs/writing-rules/overview.md
@@ -18,7 +18,7 @@ You can write rules that do things like:
 - Automate code review comments
 - Identify secure coding violations
 - Scan configuration files
-- And more! Check out more use cases [here](rule-ideas.md).
+- And more! Check out more use cases [here](../rule-ideas/).
 
 This rule detects the use of `is` when comparing Python strings. `is` checks reference equality, not value equality, and can exhibit nondeterministic behavior.
 
@@ -29,6 +29,6 @@ This rule detects the use of `is` when comparing Python strings. `is` checks ref
 - [Pattern syntax](pattern-syntax.mdx) describes what Semgrep patterns can do
 in detail, and provides example use cases of the ellipsis
 operator, metavariables, and more.<br/>
-- [Rule syntax](rule-syntax.md) describes Semgrep YAML rule files, which can have multiple patterns, detailed output messages, and autofixes. The syntax allows the composition of individual patterns with boolean operators.
+- [Rule syntax](../rule-syntax/) describes Semgrep YAML rule files, which can have multiple patterns, detailed output messages, and autofixes. The syntax allows the composition of individual patterns with boolean operators.
 
-Looking for ideas on what rules to write? See [Rule examples](rule-ideas.md) for common use cases and prompts to help you start writing rules from scratch.
+Looking for ideas on what rules to write? See [Rule examples](../rule-ideas/) for common use cases and prompts to help you start writing rules from scratch.

--- a/docs/writing-rules/pattern-syntax.mdx
+++ b/docs/writing-rules/pattern-syntax.mdx
@@ -11,9 +11,9 @@ import MoreHelp from "/src/components/MoreHelp";
 Getting started with rule writing? Try the [Semgrep Tutorial](https://semgrep.dev/learn) 🎓
 :::
 
-This document describes Semgrep’s pattern syntax. You can also see pattern [examples by language](pattern-examples.md). In the command line, patterns are specified with the flag `--pattern` (or `-e`). Multiple
+This document describes Semgrep’s pattern syntax. You can also see pattern [examples by language](../pattern-examples/). In the command line, patterns are specified with the flag `--pattern` (or `-e`). Multiple
 coordinating patterns may be specified in a configuration file. See
-[rule syntax](rule-syntax.md) for more information.
+[rule syntax](../rule-syntax/) for more information.
 
 ## Pattern matching
 
@@ -314,7 +314,7 @@ The YAML `|` operator allows for [multiline strings](https://yaml-multiline.info
 You can use `"$X"` to match any string literal. This is similar
 to using `"..."`, but the content of the string is stored in the
 metavariable `$X`, which can then be used in a message
-or in a [`metavariable-regexp`](./rule-syntax.md#metavariable-regex).
+or in a [`metavariable-regexp`](../rule-syntax/#metavariable-regex).
 
 You can also use `/$X/` and `:$X` to respectively match
 any regular expressions or atoms (in languages that support
@@ -491,7 +491,7 @@ Semgrep performs associative-commutative (AC) matching. For example, `... && B &
 
 Under AC-matching metavariables behave similarly to `...`. For example, `A | $X` can match `A | B | C` in four different ways (`$X` can bind to `B`, or `C`, or `B | C`). In order to avoid a combinatorial explosion, Semgrep will only perform AC-matching with metavariables if the number of potential matches is _small_, otherwise it will produce just one match (if possible) where each metavariable is bound to a single operand.
 
-Using [`options`](./rule-syntax.md#options) it is possible to entirely disable AC-matching. It is also possible to treat boolean AND and OR operators (e.g., `&&` in `||` in C-family languages) as commutative, which can be useful despite not being semantically accurate.
+Using [`options`](../rule-syntax/#options) it is possible to entirely disable AC-matching. It is also possible to treat boolean AND and OR operators (e.g., `&&` in `||` in C-family languages) as commutative, which can be useful despite not being semantically accurate.
 
 ## Deep expression operator
 
@@ -572,7 +572,7 @@ you can just match the header of a conditional with `if ($E)`,
 or just the try part of an exception statement with `try { ... }`.
 
 This is especially useful when used in a
-[pattern-inside](./rule-syntax.md#pattern-inside) to restrict the
+[pattern-inside](../rule-syntax/#pattern-inside) to restrict the
 context in which to search for other things.
 
 ### Other partial constructs
@@ -587,7 +587,7 @@ function `foo`. In the same way, you can just match a class header
 ### String matching
 
 :::warning
-String matching has been deprecated. You should use [`metavariable-regexp`](rule-syntax.md#metavariable-regex) instead.
+String matching has been deprecated. You should use [`metavariable-regexp`](../rule-syntax/#metavariable-regex) instead.
 :::
 
 Search string literals within code with [Perl Compatible Regular Expressions (PCRE)](https://learnxinyminutes.com/docs/pcre/).

--- a/docs/writing-rules/pattern-syntax.mdx
+++ b/docs/writing-rules/pattern-syntax.mdx
@@ -1,6 +1,7 @@
 ---
 append_help_link: true
 slug: pattern-syntax
+description: "Learn Semgrep's pattern syntax to search code for a given code pattern. If you're just getting started writing Semgrep rules, check out the Semgrep Tutorial at https://semgrep.dev/learn"
 ---
 
 import MoreHelp from "/src/components/MoreHelp";

--- a/docs/writing-rules/rule-ideas.md
+++ b/docs/writing-rules/rule-ideas.md
@@ -13,7 +13,7 @@ Not sure what to write a rule for? Below are some common questions, ideas, and t
 
 _Time to write this rule: **5 minutes**_
 
-You can use Semgrep and its GitHub integration to [automate PR comments](../semgrep-app/notifications.md) that you frequently make in code reviews. Writing a custom rule for the code pattern you want to target is usually straightforward. If you want to understand the Semgrep syntax, see the [documentation](pattern-syntax.mdx) or try the [tutorial](https://semgrep.dev/learn). 
+You can use Semgrep and its GitHub integration to [automate PR comments](/semgrep-app/notifications/) that you frequently make in code reviews. Writing a custom rule for the code pattern you want to target is usually straightforward. If you want to understand the Semgrep syntax, see the [documentation](../pattern-syntax/) or try the [tutorial](https://semgrep.dev/learn). 
 
 ![A reviewer writes a Semgrep rule and adds it to an organization-wide policy](../img/semgrep-ci.gif)
 <br />

--- a/docs/writing-rules/rule-syntax.md
+++ b/docs/writing-rules/rule-syntax.md
@@ -1,6 +1,7 @@
 ---
 append_help_link: true
 slug: rule-syntax
+description: "This document describes Semgrep’s YAML rule syntax including required and optional fields. Just getting started with Semgrep rule writing? Check out the Semgrep Tutorial at https://semgrep.dev/learn"
 ---
 
 import MoreHelp from "/src/components/MoreHelp"

--- a/docs/writing-rules/testing-rules.md
+++ b/docs/writing-rules/testing-rules.md
@@ -1,6 +1,7 @@
 ---
 append_help_link: true
 slug: testing-rules
+description: "Semgrep provides a convenient testing mechanism for your rules. You can simply write code and provide a few annotations to let Semgrep know where you are or aren't expecting findings."
 ---
 
 import MoreHelp from "/src/components/MoreHelp"

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -128,6 +128,7 @@ module.exports = {
       // You can also use your "G-" Measurement ID here.
       trackingID: 'G-1851JH9FSR',
     },
+    image: 'https://semgrep.dev/thumbnail.png'
   },
   scripts: [
     {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,7 +5,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 module.exports = {
   title: 'Semgrep',
   tagline: 'Lightweight static analysis for many languages. Find bug variants with patterns that look like source code.',
-  url: 'https://semgrep.dev/',
+  url: 'https://semgrep.dev',
   baseUrl: '/docs/',
   onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -20,10 +20,10 @@ module.exports = {
         src: 'img/semgrep-icon-text-horizontal.svg',
       },
       items: [
-        { to: 'https://semgrep.dev/explore', label: 'Rules', position: 'left' },
-        { to: 'https://semgrep.dev/editor', label: 'Playground', position: 'left' },
-        { to: 'https://semgrep.dev/manage', label: 'Dashboard', position: 'left' },
-        { to: 'https://semgrep.dev/docs/', label: 'Docs', position: 'left' },
+        { to: 'https://semgrep.dev/explore', label: 'Rules', position: 'left', target: '_self' },
+        { to: 'https://semgrep.dev/editor', label: 'Playground', position: 'left', target: '_self' },
+        { to: 'https://semgrep.dev/manage', label: 'Dashboard', position: 'left', target: '_self' },
+        { to: 'https://semgrep.dev/docs/', label: 'Docs', position: 'left', target: '_self' },
       ],
     },
     footer: {
@@ -51,15 +51,18 @@ module.exports = {
           items: [
             {
               label: 'Docs',
-              to: 'https://semgrep.dev/docs/',
+              to: '/docs/',
+              target: '_self'
             },
             {
               label: 'Examples',
-              to: 'https://semgrep.dev/docs/writing-rules/rule-ideas/',
+              to: '/docs/writing-rules/rule-ideas/',
+              target: '_self'
             },
             {
               label: 'Tour',
               to: 'https://semgrep.dev/learn',
+              target: '_self'
             },
           ],
         },
@@ -69,6 +72,7 @@ module.exports = {
             {
               label: 'Privacy',
               to: 'https://semgrep.dev/privacy',
+              target: '_self'
             },
             {
               label: 'Issues',
@@ -77,6 +81,7 @@ module.exports = {
             {
               label: 'Terms of service',
               to: 'https://semgrep.dev/terms',
+              target: '_self'
             },
           ],
         },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -23,7 +23,7 @@ module.exports = {
         { to: 'https://semgrep.dev/explore', label: 'Rules', position: 'left' },
         { to: 'https://semgrep.dev/editor', label: 'Playground', position: 'left' },
         { to: 'https://semgrep.dev/manage', label: 'Dashboard', position: 'left' },
-        { to: 'https://semgrep.dev/docs', label: 'Docs', position: 'left' },
+        { to: 'https://semgrep.dev/docs/', label: 'Docs', position: 'left' },
       ],
     },
     footer: {

--- a/sidebars.js
+++ b/sidebars.js
@@ -35,6 +35,11 @@ module.exports = {
         'extensions',
         'faq',
         'metrics',
+        {
+          type: 'doc',
+          id: 'experiments/overview',
+          label: 'Experiments 🧪'
+        }
       ],
     },
     {


### PR DESCRIPTION
- Prevents some meta tags being generated with URLs that have a double slash like `https://semgre.dev//docs/foo`
- Standardizes link format to prevent unnecessary redirects
- Adds experiments page to the sidebar
- Adds social card images (using the same image that’s used in the rest of semgrep.dev)
- Updates meta descriptions for several pages