### PR TITLE
fix python-command-injection markup

### DIFF
--- a/docs/cheat-sheets/python-command-injection.mdx
+++ b/docs/cheat-sheets/python-command-injection.mdx
@@ -321,7 +321,7 @@ Do not let user input into `asyncio subprocess` methods. Alternatively,
 
 #### Semgrep rule
 
-<LinkToRegistryRule ruleId="python.lang.security.audit.dangerous-asyncio-exec.dangerous-asyncio-exec" />
+<LinkToRegistryRule ruleId="python.lang.security.audit.dangerous-asyncio-exec.dangerous-asyncio-exec" /><br/>
 <LinkToRegistryRule ruleId="python.lang.security.audit.dangerous-asyncio-create-exec.dangerous-asyncio-create-exec" />
 
 ## 2. Executing\evaluating code


### PR DESCRIPTION
Small fix: add a break between two links