### PR TITLE
Add note that installing semgrep with pip can fail on M1 Macs

### DIFF
--- a/docs/contributing/semgrep-contributing.md
+++ b/docs/contributing/semgrep-contributing.md
@@ -86,6 +86,11 @@ Some people have encountered difficulties with the above. If it fails, you can a
 sudo pip install -e .
 ```
 
+If you have an M1 Mac, this may install the incorrect executable. You can run this instead
+```
+brew install semgrep
+```
+
 Now you can run `semgrep -h` from anywhere.
 
 If you have installed `semgrep-core` and `spacegrep` from source, there are convenient targets in the root Makefile that let you update all binaries. After you pull, simply run


### PR DESCRIPTION
Installing semgrep using the pip on my M1 Mac resulted in getting an executable that could not actually be run. Installing with homebrew worked fine, so I've added a note about this.