### PR TITLE
We have made publishDeployment obsolete for semgrep-action

### DIFF
--- a/docs/semgrep-app/notifications.md
+++ b/docs/semgrep-app/notifications.md
@@ -91,9 +91,9 @@ For example:
 semgrep:
   image: returntocorp/semgrep-agent:v1
   script:
-    # DEPLOYMENT_ID and SEMGREP_APP_TOKEN can both be obtained from semgrep.dev/manage/settings. 
+    # SEMGREP_APP_TOKEN can be obtained from semgrep.dev/manage/settings. 
     # The SEMGREP_APP_TOKEN should be treated like a secret and not hard-coded into your code.
-    - semgrep-agent --publish-deployment $DEPLOYMENT_ID --publish-token $SEMGREP_APP_TOKEN
+    - semgrep-agent --publish-token $SEMGREP_APP_TOKEN
   rules:
   # Scan changed files in MRs, block on new issues only (existing issues ignored)
   - if: $CI_MERGE_REQUEST_IID

--- a/docs/semgrep-ci/configuration-reference.md
+++ b/docs/semgrep-ci/configuration-reference.md
@@ -33,11 +33,10 @@ SEMGREP_BASELINE_REF=main
 
 ## Connect to Semgrep App (`SEMGREP_APP_TOKEN`)
 
-Instead of `SEMGREP_RULES`, you can use rules set in Semgrep App.
-Get your credentials from [Semgrep App > Settings](https://semgrep.dev/manage/settings).
+Instead of `SEMGREP_RULES`, you can configure which rules to run with Semgrep App.
+Get your token from [Semgrep App > Settings](https://semgrep.dev/manage/settings).
 
 ```
-SEMGREP_APP_DEPLOYMENT_ID=0
 SEMGREP_APP_TOKEN=secret
 ```
 

--- a/docs/semgrep-ci/overview.md
+++ b/docs/semgrep-ci/overview.md
@@ -91,7 +91,7 @@ SEMGREP_TIMEOUT=1800  # Maximum Semgrep run time in seconds, or 0 to disable tim
 ## Run semgrep_agent
 
 ```sh
-semgrep-agent --publish-deployment $SEMGREP_DEPLOYMENT_ID --publish-token $SEMGREP_APP_TOKEN
+semgrep-agent --publish-token $SEMGREP_APP_TOKEN
 ```
 
 <br />
@@ -270,7 +270,7 @@ In providers other than GitHub Actions and GitLab CI, Semgrep CI doesn't infer a
 
 ### Semgrep App connection
 
-To use your Semgrep App account, set `--publish-deployment` and `--publish-token`. These act as your username and password for authentication. You can find the right values for these flags on the [Dashboard > Settings](https://semgrep.dev/manage/settings) page.
+To use your Semgrep App account, set `--publish-token`. This acts as your username and password for authentication. You can generate an API token on the [Dashboard > Settings](https://semgrep.dev/manage/settings) page.
 
 #### Ignoring specific rules in a ruleset or policy
 

--- a/docs/semgrep-ci/sample-ci-configs.md
+++ b/docs/semgrep-ci/sample-ci-configs.md
@@ -44,8 +44,7 @@ jobs:
         # == Optional settings in the `with:` block
 
         # Instead of `config:`, use rules set in Semgrep App.
-        # Get your credentials from semgrep.dev/manage/settings.
-        #   publishDeployment: ${{ secrets.SEMGREP_DEPLOYMENT_ID }}
+        # Get your token from semgrep.dev/manage/settings.
         #   publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}
 
         # Never fail the build due to findings on pushes.
@@ -99,8 +98,7 @@ semgrep:
   # == Optional settings in the `variables:` block
 
   # Instead of `SEMGREP_RULES:`, use rules set in Semgrep App.
-  # Get your credentials from semgrep.dev/manage/settings.
-  #   SEMGREP_APP_DEPLOYMENT_ID: $SEMGREP_APP_DEPLOYMENT_ID
+  # Get your token from semgrep.dev/manage/settings.
   #   SEMGREP_APP_TOKEN: $SEMGREP_APP_TOKEN
 
   # Receive inline MR comments (requires Semgrep App account)
@@ -165,8 +163,7 @@ environment {
     // == Optional settings in the `environment {}` block
 
     // Instead of `SEMGREP_RULES:`, use rules set in Semgrep App.
-    // Get your credentials from semgrep.dev/manage/settings.
-    //   SEMGREP_APP_DEPLOYMENT_ID: credentials('SEMGREP_APP_DEPLOYMENT_ID')
+    // Get your token from semgrep.dev/manage/settings.
     //   SEMGREP_APP_TOKEN: credentials('SEMGREP_APP_TOKEN')
     //   SEMGREP_REPO_URL = env.GIT_URL.replaceFirst(/^(.*).git$/,'$1')
     //   SEMGREP_BRANCH = "${CHANGE_BRANCH}"
@@ -222,8 +219,7 @@ environment {
         # == Optional settings in the `environment:` block
 
         # Instead of `SEMGREP_RULES:`, use rules set in Semgrep App.
-        # Get your credentials from semgrep.dev/manage/settings.
-        #   - "SEMGREP_APP_DEPLOYMENT_ID=${SEMGREP_APP_DEPLOYMENT_ID}"
+        # Get your token from semgrep.dev/manage/settings.
         #   - "SEMGREP_APP_TOKEN=${SEMGREP_APP_TOKEN}"
         #   - "SEMGREP_JOB_URL=${BUILDKITE_BUILD_URL}"
         #   - "SEMGREP_BRANCH=${BUILDKITE_BRANCH}"
@@ -261,9 +257,6 @@ jobs:
       default_branch:
         type: string
         default: main
-      semgrep_deployment_id:
-        type: integer
-        default: <my-deployment-id>
     environment:
       SEMGREP_RULES: >- # more at semgrep.dev/explore
         p/security-audit
@@ -275,8 +268,7 @@ jobs:
     # == Optional settings in the `environment:` block
 
     # Instead of `SEMGREP_RULES:`, use rules set in Semgrep App.
-    # Get your credentials from semgrep.dev/manage/settings.
-    #   SEMGREP_APP_DEPLOYMENT_ID: << parameters.semgrep_deployment_id >>
+    # Get your token from semgrep.dev/manage/settings.
     #   SEMGREP_APP_TOKEN: $SEMGREP_APP_TOKEN
     #   SEMGREP_REPO_NAME: << parameters.repo_path >>
     #   SEMGREP_REPO_URL: << pipeline.project.git_url >>


### PR DESCRIPTION
This removes publishDeployment and related environment variables from all of our instructions and example scripts!