### PR TITLE
docs: Change flag for docker install example

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,7 +28,7 @@ python3 -m pip install semgrep
 To try Semgrep without installation run via Docker:
 
 ```sh
-docker run --rm -v "${PWD}:/src" returntocorp/semgrep --help
+docker run --rm -v "${PWD}:/src" returntocorp/semgrep --config=auto
 ```
 
 Confirm installation and run both a simple “grep-like” rule and the auto ruleset:


### PR DESCRIPTION
Changes flag for docker from --help to --config=auto on getting-started
### Security

- [x] Change has no security implications (otherwise, ping the security team)
