### PR TITLE
Add documentation about embeditor use

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -35,6 +35,17 @@ Probably! If you have a typical consulting service and running semgrep-rules is 
 
 Help is available for all users, free or otherwise, through the [r2c Community Slack](https://r2c.dev/slack). Semgrep Team tier customers receive 8\*5 email/phone/Slack support with committed SLAs. See [Support](../support/) for more details.
 
+#### Can I embed the live editor in my website or blog post?
+
+Yes! You can embed a special version of the editor with an `iframe`. The source is `https://semgrep.dev/embed/editor?snippet=<snippet-id>` where the `snippet-id` is either the short identifier generated when you share an editor link (this usually looks like `DzKv`) or the named identifier from a saved rule (this usually looks like `username:rule-name`).
+
+```html
+<iframe title="Semgrep example no prints" src="https://semgrep.dev/embed/editor?snippet=DzKv" width="100%" height="432px" frameborder="0"></iframe>
+
+
+<iframe title="Semgrep example no prints" src="https://semgrep.dev/embed/editor?snippet=ievans:print-to-logger" width="100%" height="432px" frameborder="0"></iframe>
+```
+
 ## Comparisons
 
 ### How is Semgrep different than $OTHER\_TOOL or $GENERIC\_[SAST](https://en.wikipedia.org/wiki/Static_application_security_testing)?

--- a/docs/status.md
+++ b/docs/status.md
@@ -16,16 +16,16 @@ import MoreHelp from "/src/components/MoreHelp"
 
 | GA ✅      | Beta 🐛                     | Experimental 🚧            |
 |:---------- |:---------------------------|:---------------------------|
-| Go         | Terraform                  | C                          |
-| Java       |                            | C#                         |
-| JavaScript |                            | Kotlin                     |
-| JSON       |                            | Lua                        |
-| JSX        |                            | OCaml                      |
-| Python     |                            | PHP                        |
-| Ruby       |                            | R                          |
-| TypeScript |                            | Rust                       |
-| TSX        |                            | YAML                       |
-|            |                            | Generic (ERB, Jinja, etc.) |
+| C#         | Terraform                  | C                          |
+| Go         |                            | Kotlin                     |
+| Java       |                            | Lua                        |
+| JavaScript |                            | OCaml                      |
+| JSON       |                            | PHP                        |
+| JSX        |                            | R                          |
+| Python     |                            | Rust                       |
+| Ruby       |                            | YAML                       |
+| TypeScript |                            | Generic (ERB, Jinja, etc.) |
+| TSX        |                            |                            |
 
 ## Support expectations
 
@@ -55,7 +55,7 @@ The following thresholds define each maturity level:
 
 * **Experimental**
     * Parse rate: 90%+
-    * Rulesets: 0+ (10+ rules)
+    * Rules: 0+
     * Features:
         * `concrete_syntax`
         * `deep_exprstmt`
@@ -68,7 +68,7 @@ The following thresholds define each maturity level:
         * `metavar_equality_var`
 * **Beta**
     * Parse rate: 99%+
-    * Rulesets: 1+ (10+ rules)
+    * Rules: 5+
     * Features:
         * All in experimental
         * `metavar_class_def`
@@ -80,7 +80,7 @@ The following thresholds define each maturity level:
         * `metavar_stmt`
 * **Generally Available (GA)**
     * Parse rate: 99.9%+
-    * Rulesets: 2+ (10+ rules)
+    * Rules: 10+
     * Features:
         * All in experimental
         * All in beta


### PR DESCRIPTION
Added a section in the FAQ about how to use the embeditor.

@pabloest If there's a better section for this, let me know! We had someone ask about how to do this during a workshop and realized we didn't have docs for this.
