### PR TITLE
Update webhook to match recent deletions

### DIFF
--- a/docs/semgrep-app/notifications.md
+++ b/docs/semgrep-app/notifications.md
@@ -123,12 +123,8 @@ Semgrep App will send a POST request containing an array of all the scan's findi
   {
     "semgrep_finding": {
       "id": "241dbe518caf15f800131d2d0c70bf08",
-      "mute_date": null,
-      "assigned_date": null,
       "ref": "refs/pull/2658/merge",
       "start_date": "None",
-      "fix_date": null,
-      "end_date": null,
       "check_id": "log-exc-info",
       "path": "server/semgrep_app/handlers/registry.py",
       "line": 185,
@@ -147,7 +143,7 @@ Semgrep App will send a POST request containing an array of all the scan's findi
       "references": ["https://tomcat.apache.org/tomcat-5.5-doc/servletapi/"],
       "source": "https://semgrep.dev/r/java.servlets.security.cookie-issecure-false.cookie-issecure-false",
       "technology": ["servlet",  "tomcat"],
-      "vulnerability": "Insecure Transport"},
+      "vulnerability": "Insecure Transport",
       "metadata": {
         "dev.semgrep.actions": [],
         "semgrep.policy": {


### PR DESCRIPTION
These changes reflect the specific changes I made to `webhook.py` recently. Additionally, I am looking for evidence that the fields “category”,  “license”, “owasp”, “references”, “source”, “technology” and “vulnerability” exist in the webhook, as I don't see them anywhere in `webhook.py`. Maybe I am missing something, though! 

### Security

- [x] Change has no security implications (otherwise, ping the security team)
