### PR TITLE
Recommend diff scans and full scans on separate branches

### DIFF
--- a/docs/contributing/semgrep-core-contributing.md
+++ b/docs/contributing/semgrep-core-contributing.md
@@ -73,7 +73,7 @@ make build    # or just `make`
 
 After making either of these targets, `semgrep` will run with all your local changes, OCaml and Python both.
 
-(Note: Because this updates the `semgrep` binary, if you do not have your Python environment configured properly, you will encounter errors when running these commands. Follow the procedure under [Development](#development))
+NOTE: Because this updates the `semgrep` binary, if you do not have your Python environment configured properly, you will encounter errors when running these commands. Follow the procedure under [Development](#development)
 
 ## Development 
 

--- a/docs/semgrep-app/notifications.md
+++ b/docs/semgrep-app/notifications.md
@@ -106,7 +106,7 @@ semgrep:
     GITLAB_TOKEN: $PAT
 ```
 
-Note: GitLab MR comments are only available to logged-in semgrep.dev users, requiring both a Semgrep deployment ID and a Semgrep API token.
+NOTE: GitLab MR comments are only available to logged-in semgrep.dev users, requiring both a Semgrep deployment ID and a Semgrep API token.
 
 ### Webhooks
 

--- a/docs/semgrep-ci/configuration-reference.md
+++ b/docs/semgrep-ci/configuration-reference.md
@@ -31,7 +31,7 @@ since branching off from your `main` branch, set
 SEMGREP_BASELINE_REF=main
 ```
 
-It is not recommended to do diff-aware scans on any branches that are also doing full-project scans. This is because Semgrep App assumes that all previous findings have been fixed if the branch they are on is re-scanned and they do not show up.
+NOTE: performing a diff scan after a full-project scan of the same branch will close the full-project scan's findings. This is because all findings are marked as fixed if the branch they are on is re-scanned and they are no longer reported. Therefore, it is best to perform diff scans on branches other than your `main` branch.
 
 ## Connect to Semgrep App (`SEMGREP_APP_TOKEN`)
 

--- a/docs/semgrep-ci/configuration-reference.md
+++ b/docs/semgrep-ci/configuration-reference.md
@@ -31,6 +31,8 @@ since branching off from your `main` branch, set
 SEMGREP_BASELINE_REF=main
 ```
 
+It is not recommended to do diff-aware scans on any branches that are also doing full-project scans. This is because Semgrep App assumes that all previous findings have been fixed if the branch they are on is re-scanned and they do not show up.
+
 ## Connect to Semgrep App (`SEMGREP_APP_TOKEN`)
 
 Instead of `SEMGREP_RULES`, you can configure which rules to run with Semgrep App.

--- a/docs/semgrep-ci/overview.md
+++ b/docs/semgrep-ci/overview.md
@@ -11,7 +11,7 @@ import MoreHelp from "/src/components/MoreHelp"
 
 [Semgrep CI](https://github.com/returntocorp/semgrep-action) (aka Semgrep Action or `semgrep-agent`) is a specialized Docker image for running Semgrep in CI environments. It can also optionally connect to [Semgrep App](https://semgrep.dev/manage) for centralized rule and findings management.
 
-- **Scan every commit**. Semgrep CI rapidly scans modified files on pull and merge requests, protecting developer productivity. In most successful configurations, full project scans are reserved for specific branches, such as trunk branches, and diff-aware scans are done on other branches before merging them into the trunk.
+- **Scan every commit**. Semgrep CI rapidly scans modified files on pull and merge requests, protecting developer productivity. Usually, full-project scans are reserved for special branches, such as trunk branches, and diff-aware scans are done on other branches before merging them into the trunk.
 - **Block new bugs**. You shouldn’t have to fix existing bugs just to adopt a tool. Semgrep CI reports newly introduced issues on pull and merge requests, scanning them at their base and HEAD commits to compare findings. Developers are signficantly more likely to fix the issues they introduced themselves on PRs and MRs.
 - **Get findings where you work**. Semgrep CI can connect to [Semgrep App](https://semgrep.dev/manage) to present findings in Slack, on PRs and MRs via inline comments, email, and through 3rd party services.
 

--- a/docs/semgrep-ci/overview.md
+++ b/docs/semgrep-ci/overview.md
@@ -11,7 +11,7 @@ import MoreHelp from "/src/components/MoreHelp"
 
 [Semgrep CI](https://github.com/returntocorp/semgrep-action) (aka Semgrep Action or `semgrep-agent`) is a specialized Docker image for running Semgrep in CI environments. It can also optionally connect to [Semgrep App](https://semgrep.dev/manage) for centralized rule and findings management.
 
-- **Scan every commit**. Semgrep CI rapidly scans modified files on pull and merge requests, protecting developer productivity. Longer full project scans are configurable on merges to specific branches.
+- **Scan every commit**. Semgrep CI rapidly scans modified files on pull and merge requests, protecting developer productivity. In most successful configurations, full project scans are reserved for specific branches, such as trunk branches, and diff-aware scans are done on other branches before merging them into the trunk.
 - **Block new bugs**. You shouldn’t have to fix existing bugs just to adopt a tool. Semgrep CI reports newly introduced issues on pull and merge requests, scanning them at their base and HEAD commits to compare findings. Developers are signficantly more likely to fix the issues they introduced themselves on PRs and MRs.
 - **Get findings where you work**. Semgrep CI can connect to [Semgrep App](https://semgrep.dev/manage) to present findings in Slack, on PRs and MRs via inline comments, email, and through 3rd party services.
 
@@ -24,7 +24,7 @@ Semgrep CI runs fully in your build environment: **your code is never sent anywh
 
 Semgrep CI behaves like other static analysis and linting tools: it runs a set of user-configured rules and returns a non-zero exit code if there are findings, resulting in its job showing a ✅ or ❌.
 
-Start by copying the below relevant template for your CI provider. Read through the comments in the template to adjust when and what Semgrep CI scans, selecting pull and merge requests, merges to branches, or both.
+Start by copying the below relevant template for your CI provider. Read through the comments in the template to adjust when and what Semgrep CI scans, selecting pull and merge requests, full scans on your trunk branch, or both.
 
 Once Semgrep CI is running, explore the [Semgrep Registry](https://semgrep.dev/explore) to find and add more project-specific rules.
 
@@ -62,7 +62,7 @@ For full project scans:
 docker run -v $(pwd):/src --workdir /src returntocorp/semgrep-agent:v1 semgrep-agent --config auto --config <other rule or rulesets>
 ```
 
-Set the `--baseline-ref` flag to the git ref (branch name, tag, or commit hash) to use as a baseline. Semgrep will scan only the files modified in your branch and output the difference in findings between the baseline branch and the new branch. For example, to report findings newly added since branching off from your `main` branch, run
+Set the `--baseline-ref` flag to the git ref (branch name, tag, or commit hash) to use it as a baseline. Semgrep will scan only the files modified in your branch and output the difference in findings between the baseline branch and the new branch. If you are using Semgrep App, it will also close all prior findings on that branch that it no longer finds, treating them as fixed. Therefore, doing full scans and diff scans on the same branch is not recommended. For example, to report findings newly added since branching off from your `main` branch, run
 
 ```sh
 semgrep-agent --baseline-ref main


### PR DESCRIPTION
Make it clearer what the recommended setup is in terms of when diff-scans are used and when full scans are used.

We have had multiple users configure Semgrep incorrectly, and have poor experiences with the app as a result.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
