### PR TITLE
Update docs on .semgrepignore

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -190,6 +190,13 @@ Options:
   --help                          Show this message and exit.
 ```
 
+## Ignoring Files
+
+The Semgrep command line tool supports a `.semgrepignore` file that follows the `.gitignore` syntax and is used to skip files and directories during scanning. This is commonly used to avoid vendored and test related code. For a complete example, see the [.semgrepignore file on Semgrep’s source code](https://github.com/returntocorp/semgrep/blob/develop/.semgrepignore).
+
+If no `.semgrepignore` file is found, no default will be provided.
+
+
 ## Exit codes
 
 `semgrep` may exit with the following exit codes:

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -194,6 +194,19 @@ Options:
 
 The Semgrep command line tool supports a `.semgrepignore` file that follows the `.gitignore` syntax and is used to skip files and directories during scanning. This is commonly used to avoid vendored and test related code. For a complete example, see the [.semgrepignore file on Semgrep’s source code](https://github.com/returntocorp/semgrep/blob/develop/.semgrepignore).
 
+`.semgrepignore` syntax mirrors `.gitignore` syntax, with the following modifications:
+* "Include" patterns (lines starting with "!") are not supported.
+* "Character range" patterns (lines including a collection of characters inside brackets) are not supported.
+* An ":include ..." directive is added, which allows another file to be included in the ignore pattern list;
+    typically this included file would be the project .gitignore. No attempt at cycle detection is made.
+* Any line beginning with a colon, but not ":include ", will raise a SemgrepError.
+* "\:" is added to escape leading colons.
+
+Unsupported patterns are silently removed from the pattern list (this is done so that gitignore files may be
+included without raising errors), although the removal will be logged.
+
+For a description of `.gitignore` syntax, see [the documentation](https://git-scm.com/docs/gitignore)
+
 If no `.semgrepignore` file is found, no default will be provided.
 
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -199,7 +199,7 @@ The Semgrep command line tool supports a `.semgrepignore` file that follows the 
 * "Character range" patterns (lines including a collection of characters inside brackets) are not supported.
 * An ":include ..." directive is added, which allows another file to be included in the ignore pattern list;
     typically this included file would be the project .gitignore. No attempt at cycle detection is made.
-* Any line beginning with a colon, but not ":include ", will raise a SemgrepError.
+* Any line beginning with a colon, but not ":include ", will raise an error.
 * "\:" is added to escape leading colons.
 
 Unsupported patterns are silently removed from the pattern list (this is done so that gitignore files may be

--- a/docs/semgrep-ci/overview.md
+++ b/docs/semgrep-ci/overview.md
@@ -244,7 +244,7 @@ Semgrep CI supports a `.semgrepignore` file that follows the `.gitignore` syntax
 `.semgrepignore` is only used by Semgrep CI and the Semgrep command line tool. It is not honored by integrations like [GitLab's Semgrep SAST Analyzer](https://gitlab.com/gitlab-org/security-products/analyzers/semgrep).
 :::
 
-By default Semgrep CI skips files and directories such as `tests/`, `node_modules/`, and `vendor/`. The full list of ignored items is in [the `.semgrepignore` template file](https://github.com/returntocorp/semgrep-action/blob/v1/src/semgrep_agent/templates/.semgrepignore), which is used by Semgrep CI when no explicit `.semgrepignore` file is found in the root of your project.
+By default Semgrep CI skips files and directories such as `tests/`, `node_modules/`, and `vendor/`. (Note: this is NOT the same as Semgrep CLI, which by default skips nothing). The full list of ignored items is in [the `.semgrepignore` template file](https://github.com/returntocorp/semgrep-action/blob/v1/src/semgrep_agent/templates/.semgrepignore), which is used by Semgrep CI when no explicit `.semgrepignore` file is found in the root of your project.
 
 For information on ignoring individual findings in code, see the [ignoring findings page](/ignoring-findings/).
 

--- a/docs/semgrep-ci/overview.md
+++ b/docs/semgrep-ci/overview.md
@@ -241,7 +241,7 @@ If no configuration is provided and no `.semgrep.yml` or `.semgrep/` directory e
 Semgrep CI supports a `.semgrepignore` file that follows the `.gitignore` syntax and is used to skip files and directories during scanning. This is commonly used to avoid vendored and test related code. For a complete example, see the [.semgrepignore file on Semgrep’s source code](https://github.com/returntocorp/semgrep/blob/develop/.semgrepignore).
 
 :::caution
-`.semgrepignore` is only used by Semgrep CI and is not honored by the Semgrep command line tool or by integrations like [GitLab's Semgrep SAST Analyzer](https://gitlab.com/gitlab-org/security-products/analyzers/semgrep).
+`.semgrepignore` is only used by Semgrep CI and the Semgrep command line tool. It is not honored by integrations like [GitLab's Semgrep SAST Analyzer](https://gitlab.com/gitlab-org/security-products/analyzers/semgrep).
 :::
 
 By default Semgrep CI skips files and directories such as `tests/`, `node_modules/`, and `vendor/`. The full list of ignored items is in [the `.semgrepignore` template file](https://github.com/returntocorp/semgrep-action/blob/v1/src/semgrep_agent/templates/.semgrepignore), which is used by Semgrep CI when no explicit `.semgrepignore` file is found in the root of your project.


### PR DESCRIPTION
Once https://github.com/returntocorp/semgrep/pull/4350 is merged, the Semgrep CLI will support `.semgrepignore` files. This PR removes the warning on the Semgrep CI doc that says the CLI does not support this, and adds a section to the CLI doc that duplicates the explanation in the CI doc. Eventually we plan to remove this functionality from Semgrep CI, and when we do that we can remove the duplication in the docs.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
