### PR TITLE
Use --skip-file-extensions in the semgrep pre-commit hook

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -29,7 +29,7 @@ repos:
   hooks:
     - id: semgrep
       # See semgrep.dev/rulesets to select a ruleset and copy its URL
-      args: ['--config', '<SEMGREP_RULESET_URL>', '--error']
+      args: ['--config', '<SEMGREP_RULESET_URL>', '--error', '--skip-unknown-extensions']
 ```
 
 ### Version management


### PR DESCRIPTION
Should help prevent issues like https://github.com/returntocorp/semgrep/issues/4310 in the future. Using this updated pre-commit hook, semgrep will not scan files with unknown file extensions during a pre-commit scan.
 
### Security

- [x] Change has no security implications (otherwise, ping the security team)
