### PR TITLE
Update information about default semgrepignore behavior

### DIFF
--- a/copy-default-semgrepignore.py
+++ b/copy-default-semgrepignore.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 
-import requests
+import subprocess
 
 FILE = "docs/cli-usage.md"
-DEFAULT = requests.get("https://raw.githubusercontent.com/returntocorp/semgrep/develop/semgrep/semgrep/templates/.semgrepignore")
+DEFAULT = subprocess.run(["curl","https://raw.githubusercontent.com/returntocorp/semgrep/develop/semgrep/semgrep/templates/.semgrepignore"],capture_output=True).stdout.decode("utf-8")
 
 with open(FILE) as file:
     filedata = file.read()
     
-filedata = filedata.replace("DEFAULT_SEMGREPIGNORE_TEXT",DEFAULT.text)
+filedata = filedata.replace("DEFAULT_SEMGREPIGNORE_TEXT",DEFAULT)
 
 with open(FILE,"w") as file:
     file.write(filedata)

--- a/copy-default-semgrepignore.py
+++ b/copy-default-semgrepignore.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+import requests
+
+FILE = "docs/cli-usage.md"
+DEFAULT = requests.get("https://raw.githubusercontent.com/returntocorp/semgrep/develop/semgrep/semgrep/templates/.semgrepignore")
+
+with open(FILE) as file:
+    filedata = file.read()
+    
+filedata = filedata.replace("DEFAULT_SEMGREPIGNORE_TEXT",DEFAULT.text)
+
+with open(FILE,"w") as file:
+    file.write(filedata)

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -208,6 +208,7 @@ included without raising errors), although the removal will be logged.
 For a description of `.gitignore` syntax, see [the documentation](https://git-scm.com/docs/gitignore)
 
 If no `.semgrepignore` file is found in the directory you are running the Semgrep CLI from, the following will be used by default:
+
 ```
 # Ignore git items
 .gitignore

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -207,7 +207,34 @@ included without raising errors), although the removal will be logged.
 
 For a description of `.gitignore` syntax, see [the documentation](https://git-scm.com/docs/gitignore)
 
-If no `.semgrepignore` file is found, no default will be provided.
+If no `.semgrepignore` file is found in the directory you are running the Semgrep CLI from, the following will be used by default:
+```
+# Ignore git items
+.gitignore
+.git/
+:include .gitignore
+
+# Common large paths
+node_modules/
+build/
+dist/
+vendor/
+.env/
+.venv/
+.tox/
+*.min.js
+
+# Common test paths
+test/
+tests/
+*_test.go
+
+# Semgrep rules folder
+.semgrep
+
+# Semgrep-action log folder
+.semgrep_logs/
+```
 
 
 ## Exit codes

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -236,6 +236,8 @@ tests/
 .semgrep_logs/
 ```
 
+If you do not want Semgrep to ignore any files in your project, you can create an empty `.semgrepignore` file.
+
 
 ## Exit codes
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -210,31 +210,7 @@ For a description of `.gitignore` syntax, see [the documentation](https://git-sc
 If no `.semgrepignore` file is found in the directory you are running the Semgrep CLI from, the following will be used by default:
 
 ```
-# Ignore git items
-.gitignore
-.git/
-:include .gitignore
-
-# Common large paths
-node_modules/
-build/
-dist/
-vendor/
-.env/
-.venv/
-.tox/
-*.min.js
-
-# Common test paths
-test/
-tests/
-*_test.go
-
-# Semgrep rules folder
-.semgrep
-
-# Semgrep-action log folder
-.semgrep_logs/
+DEFAULT_SEMGREPIGNORE_TEXT
 ```
 
 If you do not want Semgrep to ignore any files in your project, you can create an empty `.semgrepignore` file.

--- a/docs/semgrep-ci/overview.md
+++ b/docs/semgrep-ci/overview.md
@@ -240,7 +240,7 @@ Semgrep CI supports a `.semgrepignore` file that follows the `.gitignore` syntax
 `.semgrepignore` is only used by Semgrep CI and the Semgrep command line tool. It is not honored by integrations like [GitLab's Semgrep SAST Analyzer](https://gitlab.com/gitlab-org/security-products/analyzers/semgrep).
 :::
 
-By default Semgrep CI skips files and directories such as `tests/`, `node_modules/`, and `vendor/`. (Note: this is NOT the same as Semgrep CLI, which by default skips nothing). The full list of ignored items is in [the `.semgrepignore` template file](https://github.com/returntocorp/semgrep-action/blob/v1/src/semgrep_agent/templates/.semgrepignore), which is used by Semgrep CI when no explicit `.semgrepignore` file is found in the root of your project.
+By default Semgrep CI skips files and directories such as `tests/`, `node_modules/`, and `vendor/`. It uses the same default `.semgrepignore` as the CLI, which can be found in the [CLI Reference](https://semgrep.dev/docs/cli-usage/#ignoring-files). This is used by Semgrep CI when no explicit `.semgrepignore` file is found in the root of your project.
 
 For information on ignoring individual findings in code, see the [ignoring findings page](/ignoring-findings/).
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "bash copy-metrics-md && docusaurus start",
-    "build": "bash copy-metrics-md && docusaurus build",
+    "start": "python3 copy-default-semgrepignore.py && bash copy-metrics-md && docusaurus start",
+    "build": "python3 copy-default-semgrepignore.py && bash copy-metrics-md && docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",


### PR DESCRIPTION
The CLI now uses a default `.semgrepignore` file

### Security

- [x] Change has no security implications (otherwise, ping the security team)
