### PR TITLE
Update "Ignoring findings" link

### DIFF
--- a/docs/running-rules.md
+++ b/docs/running-rules.md
@@ -79,6 +79,6 @@ You may find some files that Semgrep previously parsed are now skipped; this hap
 ## Findings
 
 * See [Managing findings](../managing-findings/) for information on Semgrep findings.
-* See [Ignoring findings](../ignoring-findings/) for details on suppressing rule output.
+* See [Ignoring findings](../ignoring-files-folders-code/) for details on suppressing rule output.
 
 <MoreHelp />


### PR DESCRIPTION
I've seen that link produce a 404 sometimes. Maybe the redirect doesn't kick in for some reason? Shall we prevent that alltogether?

### Security

- [-] Change has no security implications (otherwise, ping the security team)
