### PR TITLE
Update project depends on docs

### DIFF
--- a/docs/experiments/project-depends-on.md
+++ b/docs/experiments/project-depends-on.md
@@ -18,7 +18,7 @@ We welcome external contributors to try out the key, but keep in mind there's no
 
 ## Example
 
-Here’s an example project-depends-on rule that looks for a known vulnerable version of the AWS CLI from April 2017, but only reports the vulnerability if the `s3` module (where the vulnerability is located) is actually being used:
+Here’s an example `project-depends-on` rule that looks for a known vulnerable version of the AWS CLI from April 2017, but only reports the vulnerability if the `s3` module (where the vulnerability is located) is actually being used:
 
 ```yaml
 rules:

--- a/docs/experiments/project-depends-on.md
+++ b/docs/experiments/project-depends-on.md
@@ -48,4 +48,4 @@ rules:
 
 ## Limitations
 
-* Dependency resolution uses the source of dependency information with the *least amount of ambiguity* available. For all supported languages except Java, this is a lockfile, which lists exact version information for each dependency that a project uses. We do not scan, for example, `package.json` files, because they can contain version ranges. In the case of Java, Maven does not support the creation of lockfiles, so `pom.xml` is the least ambiguous source of information we have.
+* Dependency resolution uses the source of dependency information with the *least amount of ambiguity* available. For all supported languages except Java, this is a lockfile, which lists exact version information for each dependency that a project uses. We do not scan, for example, `package.json` files, because they can contain version ranges. In the case of Java, Maven does not support the creation of lockfiles, so `pom.xml` is the least ambiguous source of information we have, and we consider only dependencies listed with exact versions.

--- a/docs/experiments/project-depends-on.md
+++ b/docs/experiments/project-depends-on.md
@@ -14,7 +14,7 @@ We welcome external contributors to try out the key, but keep in mind there's no
 
 * `namespace`: The package registry where the third party dependency is found
 * `package`: The name of the third party dependency as it appears in a lockfile
-* `version`: A semantic version range. Uses [Python packaging specifiers](https://packaging.pypa.io/en/latest/specifiers.html) which supports almost all NPM operators, except `^`
+* `version`: A semantic version range. Uses [Python packaging specifiers](https://packaging.pypa.io/en/latest/specifiers.html) which support almost all NPM operators, except `^`
 
 ## Example
 

--- a/docs/experiments/project-depends-on.md
+++ b/docs/experiments/project-depends-on.md
@@ -13,7 +13,7 @@ We welcome external contributors to try out the key, but keep in mind there's no
 `r2c-internal-project-depends-on` patterns must specify three keys:
 
 * `namespace`: The package registry where the third party dependency is found
-* `package`: The name of the third party dependency as it appears in a lockfile
+* `package`: The name of the third party dependency as it appears in the lockfile
 * `version`: A semantic version range. Uses [Python packaging specifiers](https://packaging.pypa.io/en/latest/specifiers.html) which support almost all NPM operators, except `^`
 
 ## Example

--- a/docs/experiments/project-depends-on.md
+++ b/docs/experiments/project-depends-on.md
@@ -45,3 +45,7 @@ rules:
 | Go         | gomod      | `go.sum`                         |
 | Ruby       | gem        | `Gemfile.lock`                   |
 | Rust       | cargo      | `cargo.lock`                     |
+
+## Limitations
+
+* Dependency resolution uses the source of dependency information with the *least amount of ambiguity* available. For all supported languages except Java, this is a lockfile, which lists exact version information for each dependency that a project uses. We do not scan, for example, `package.json` files, because they can contain version ranges. In the case of Java, Maven does not support the creation of lockfiles, so `pom.xml` is the least ambiguous source of information we have.

--- a/docs/experiments/project-depends-on.md
+++ b/docs/experiments/project-depends-on.md
@@ -40,7 +40,7 @@ rules:
 | Language   | Namespace  | Scans dependencies from          |
 |:---------- |:-----------|:---------------------------------|
 | Python     | pypi       | `Pipfile.lock`                   |
-| JavaScript | npm        | `yarn.lock`, `package-lock json` |
+| JavaScript | npm        | `yarn.lock`, `package-lock.json` |
 | Java       | maven      | `pom.xml`                        |
 | Go         | gomod      | `go.sum`                         |
 | Ruby       | gem        | `Gemfile.lock`                   |

--- a/docs/experiments/project-depends-on.md
+++ b/docs/experiments/project-depends-on.md
@@ -6,9 +6,15 @@ description: "project-depends-on lets Semgrep rules only returns results if the 
 
 # project-depends-on
 
-Under this key, NPM or PyPI dependencies can be specified along with the semver range that the rule should trigger for. `project-depends-on` filters the rule unless one of the children is matched by a lockfile. In this initial release, the key is named `r2c-internal-project-depends-on` to signal that the syntax & behavior for the key is not stable and may be subject to removal or future changes. 
+Under this key, third party dependencies can be specified along with the semver range that the rule should trigger for. `project-depends-on` filters the rule unless one of the children is matched by a lockfile. In this initial release, the key is named `r2c-internal-project-depends-on` to signal that the syntax & behavior for the key is not stable and may be subject to removal or future changes. 
 
 We welcome external contributors to try out the key, but keep in mind there's no expectation of stability across releases yet.
+
+`r2c-internal-project-depends-on` patterns must specify three keys:
+
+* `namespace`: The package registry where the third party dependency is found
+* `package`: The name of the third party dependency as it appears in a lockfile
+* `version`: A semantic version range. Uses [Python packaging specifiers](https://packaging.pypa.io/en/latest/specifiers.html) which supports almost all NPM operators, except `^`
 
 ## Example
 
@@ -29,7 +35,13 @@ rules:
   languages: [python]
 ```
 
-## Limitations
+## Supported Languages
 
-* Dependency resolution supports **only Yarn, npm, and Pip lockfiles** (pipfile.lock, yarn.lock, package-json.lock)
-* Uses [Python packaging specifiers](https://packaging.pypa.io/en/latest/specifiers.html) which supports almost all NPM operators, except `^`
+| Language   | Namesapce  | Scans dependencies from          |
+|:---------- |:-----------|:---------------------------------|
+| Python     | pypi       | `Pipfile.lock`                   |
+| JavaScript | npm        | `yarn.lock`, `package-lock json` |
+| Java       | maven      | `pom.xml`                        |
+| Go         | gomod      | `go.sum`                         |
+| Ruby       | gem        | `Gemfile.lock`                   |
+| Rust       | cargo      | `cargo.lock`                     |

--- a/docs/experiments/project-depends-on.md
+++ b/docs/experiments/project-depends-on.md
@@ -6,7 +6,7 @@ description: "project-depends-on lets Semgrep rules only returns results if the 
 
 # project-depends-on
 
-Under this key, third-party dependencies can be specified along with the semver range that the rule should trigger for. `project-depends-on` filters the rule unless one of the children is matched by a lockfile. In this initial release, the key is named `r2c-internal-project-depends-on` to signal that the syntax & behavior for the key is not stable and may be subject to removal or future changes. 
+Under this key, third-party dependencies can be specified along with the semver (semantic version) range that the rule should trigger for. `project-depends-on` filters the rule unless one of the children is matched by a lockfile. In this initial release, the key is named `r2c-internal-project-depends-on` to signal that the syntax & behavior for the key is not stable and may be subject to removal or future changes. 
 
 We welcome external contributors to try out the key, but keep in mind there's no expectation of stability across releases yet.
 

--- a/docs/experiments/project-depends-on.md
+++ b/docs/experiments/project-depends-on.md
@@ -37,7 +37,7 @@ rules:
 
 ## Supported Languages
 
-| Language   | Namesapce  | Scans dependencies from          |
+| Language   | Namespace  | Scans dependencies from          |
 |:---------- |:-----------|:---------------------------------|
 | Python     | pypi       | `Pipfile.lock`                   |
 | JavaScript | npm        | `yarn.lock`, `package-lock json` |


### PR DESCRIPTION
Updates the `project-depends-on` docs to describe the required keys, and adds a table specifying the relationship between languages, namespaces, and lockfiles.

Depends on: https://github.com/returntocorp/semgrep/pull/4699

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
