### PR TITLE
fix: metavar-analysis discoverability

### DIFF
--- a/docs/experiments/metavariable-analysis.md
+++ b/docs/experiments/metavariable-analysis.md
@@ -19,7 +19,7 @@ RegEx denial of service is caused by poorly-constructed regular expressions that
 
 <iframe src="https://semgrep.dev/embed/editor?snippet=5Lwk" border="0" frameBorder="0" width="100%" height="435"></iframe>
 
-## Entropygi
+## Entropy
 
 ```yaml
 metavariable-analysis:

--- a/docs/experiments/metavariable-analysis.md
+++ b/docs/experiments/metavariable-analysis.md
@@ -17,9 +17,9 @@ metavariable-analysis:
 ```
 RegEx denial of service is caused by poorly-constructed regular expressions that exhibit exponential runtime when fed specifically-crafted inputs. The `redos` analyzer uses known RegEx antipatterns to determine if the target expression is potentially vulnerable to catastrophic backtracking.
 
-<iframe src="https://semgrep.dev/embed/editor?snippet=4DQ7" border="0" frameBorder="0" width="100%" height="435"></iframe>
+<iframe src="https://semgrep.dev/embed/editor?snippet=5Lwk" border="0" frameBorder="0" width="100%" height="435"></iframe>
 
-## Entropy
+## Entropygi
 
 ```yaml
 metavariable-analysis:
@@ -28,4 +28,4 @@ metavariable-analysis:
 ```
 Entropy is a common approach for detecting secret strings - many existing tools leverage a combination of entropy calculations and RegEx for secret detection. This analyzer returns `true` if a metavariable has high entropy (randomness) relative to the English language.
 
-<iframe src="https://semgrep.dev/embed/editor?snippet=KgZP" border="0" frameBorder="0" width="100%" height="435"></iframe>
+<iframe src="https://semgrep.dev/embed/editor?snippet=GgZG" border="0" frameBorder="0" width="100%" height="435"></iframe>

--- a/docs/experiments/metavariable-analysis.md
+++ b/docs/experiments/metavariable-analysis.md
@@ -15,7 +15,7 @@ metavariable-analysis:
     analyzer: redos
     metavariable: $VARIABLE
 ```
-RegEx denial of service is caused by poorly-constructed regular expressions that exhibit exponential runtime when fed specifically-crafted inputs. The `redos` analyzer uses known regex antipatterns to determine if the target expression is potentially vulnerable to catastrophic backtracking.
+RegEx denial of service is caused by poorly-constructed regular expressions that exhibit exponential runtime when fed specifically-crafted inputs. The `redos` analyzer uses known RegEx antipatterns to determine if the target expression is potentially vulnerable to catastrophic backtracking.
 
 <iframe src="https://semgrep.dev/embed/editor?snippet=4DQ7" border="0" frameBorder="0" width="100%" height="435"></iframe>
 

--- a/docs/experiments/metavariable-analysis.md
+++ b/docs/experiments/metavariable-analysis.md
@@ -1,0 +1,31 @@
+---
+slug: metavariable-analysis
+append_help_link: true
+description: "metavariable-analysis allows Semgrep users to check metavariables for common problematic properties, such as RegEx denial of service (ReDoS) and high-entropy values."
+---
+
+# Metavariable analysis
+
+Metavariable analysis was created to support some metavariable inspection techniques that are difficult to express with existing rules but have "simple" binary classifier behavior. Currently, this syntax supports two analyzers: `redos` and `entropy`
+
+## ReDoS
+
+```yaml
+metavariable-analysis:
+    analyzer: redos
+    metavariable: $VARIABLE
+```
+RegEx denial of service is caused by poorly-constructed regular expressions that exhibit exponential runtime when fed specifically-crafted inputs. The `redos` analyzer uses known regex antipatterns to determine if the target expression is potentially vulnerable to catastrophic backtracking.
+
+<iframe src="https://semgrep.dev/embed/editor?snippet=4DQ7" border="0" frameBorder="0" width="100%" height="435"></iframe>
+
+## Entropy
+
+```yaml
+metavariable-analysis:
+    analyzer: entropy
+    metavariable: $VARIABLE
+```
+Entropy is a common approach for detecting secret strings - many existing tools leverage a combination of entropy calculations and RegEx for secret detection. This analyzer returns `true` if a metavariable has high entropy (randomness) relative to the English language.
+
+<iframe src="https://semgrep.dev/embed/editor?snippet=KgZP" border="0" frameBorder="0" width="100%" height="435"></iframe>

--- a/sidebars.js
+++ b/sidebars.js
@@ -52,7 +52,7 @@ module.exports = {
         {
           type: 'category',
           label: 'Experiments 🧪',
-          items: ['experiments/overview', 'experiments/generic-pattern-matching', 'experiments/join-mode', 'experiments/project-depends-on', 'experiments/symbolic-propagation']
+          items: ['experiments/overview', 'experiments/generic-pattern-matching', 'experiments/join-mode', 'experiments/project-depends-on', 'experiments/symbolic-propagation','experiments/metavariable-analysis']
         },
         'upgrading'
       ],


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

Fixes for examples based on community feedback
entry for `metavariable-analysis` in sidebar

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
