### PR TITLE
Capitalize ScanMyCode

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -48,6 +48,6 @@ Add yours [with a pull request](https://github.com/returntocorp/semgrep-docs)!
 - [mobsfscan](https://github.com/MobSF/mobsfscan)
 - [nodejsscan](https://github.com/ajinabraham/nodejsscan)
 - [SALUS](https://github.com/coinbase/salus/blob/master/docs/scanners/semgrep.md)
-- [Scanmycode CE (Community Edition)](https://github.com/marcinguy/scanmycode-ce) 
+- [ScanMyCode CE (Community Edition)](https://github.com/marcinguy/scanmycode-ce) 
 
 <MoreHelp />


### PR DESCRIPTION
I'm updating the capitalization of Scanmycode to ScanMyCode after receiving feedback that `scanmy` was mistaken for `scammy`. This doesn't match the capitalization used by the underlying project, but I think is a valuable change given that these are Semgrep-hosted docs for our user base.

@marcinguy, are you comfortable with this change based on concerns on how it reads?