### PR TITLE
Change Check_semgrep.ml to Check_pattern.ml

### DIFF
--- a/docs/contributing/adding-a-language.md
+++ b/docs/contributing/adding-a-language.md
@@ -305,7 +305,7 @@ for step-by-step instructions.
 
 Now that you have added your new language 'X' to pfff, do the following:
 1. Add the new pfff submodule to semgrep-core.
-2. In `Check_semgrep.ml`, add 'X' to `lang_has_no_dollar_ids`/ If the grammar
+2. In `Check_pattern.ml`, add 'X' to `lang_has_no_dollar_ids`/ If the grammar
    has no dollar identifiers, add it above 'true'. Otherwise, add it above 'false'.
 3. In `synthesizing/Pretty_print_generic.ml`, add 'X' to the appropriate functions:
    * print_bool


### PR DESCRIPTION
This is where I found the `lang_has_no_dollar_ids` function. I assume it got renamed at some point.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
