### PR TITLE
Add Google Anayltics (Universal Analytics)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -150,6 +150,10 @@ module.exports = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
+        googleAnalytics: {
+          trackingID: 'UA-106134149-12',
+          anonymizeIP: true,
+        },
         gtag: {
           // You can also use your "G-" Measurement ID here.
           trackingID: 'G-1851JH9FSR',


### PR DESCRIPTION
because GA4 lacks many features of Universal Analytics, and UA will still be around for another ~18 months

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [X] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
