### PR TITLE
Add --reviewdog format to CLI usage

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -189,6 +189,7 @@ Options:
     --emacs                       Output results in Emacs single-line format.
     --json                        Output results in JSON format.
     --junit-xml                   Output results in JUnit XML format.
+    --reviewdog                   Output results in Reviewdog JSON format.
     --sarif                       Output results in SARIF format.
     --vim                         Output results in vim single-line format.
     -q, --quiet                   Only output findings.


### PR DESCRIPTION
This PR adds the `--reviewdog` option to the CLI usage, goes along with [this pr](https://github.com/returntocorp/semgrep/pull/4870) in the main semgrep repo.

As a side note, while I created this PR, I noticed that the CLI usage is not in sync with the state of the main semgrep repo (a few switches are missing, and some wording has changed). I kept this PR related to my changes to the code, but let me know if you want me to include those changes here as well.

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
