### PR TITLE
Squash broken links

### DIFF
--- a/.github/workflows/markdown-link-check-on-schedule.yml
+++ b/.github/workflows/markdown-link-check-on-schedule.yml
@@ -2,7 +2,7 @@ name: Check Markdown links
 
 on:
   schedule:
-    - cron: "31 23 * * 3"
+    - cron: "31 23 * * 4"
 
 jobs:
   markdown-link-check:

--- a/.github/workflows/markdown-link-check-on-schedule.yml
+++ b/.github/workflows/markdown-link-check-on-schedule.yml
@@ -1,0 +1,18 @@
+name: Check Markdown links
+
+on:
+  schedule:
+    - cron: "31 23 * * 3"
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: gaurav-nelson/github-action-markdown-link-check@1.0.13
+        with:
+          use-quiet-mode: "yes"
+          use-verbose-mode: "yes"
+          base-branch: "main"
+          check-modified-files-only: "no"
+          config-file: ".mlc_config.json"

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -6,9 +6,11 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
-      with:
-        use-quiet-mode: 'yes'
-        use-verbose-mode: 'yes'
-        config-file: '.mlc_config.json'
+      - uses: actions/checkout@master
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: "yes"
+          use-verbose-mode: "yes"
+          base-branch: "main"
+          check-modified-files-only: "no"
+          # config-file: ".mlc_config.json"

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - uses: gaurav-nelson/github-action-markdown-link-check@1.0.13
         with:
           use-quiet-mode: "yes"
           use-verbose-mode: "yes"

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -13,4 +13,4 @@ jobs:
           use-verbose-mode: "yes"
           base-branch: "main"
           check-modified-files-only: "no"
-          # config-file: ".mlc_config.json"
+          config-file: ".mlc_config.json"

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -12,5 +12,5 @@ jobs:
           use-quiet-mode: "yes"
           use-verbose-mode: "yes"
           base-branch: "main"
-          check-modified-files-only: "no"
+          check-modified-files-only: "yes"
           config-file: ".mlc_config.json"

--- a/.mlc_config.json
+++ b/.mlc_config.json
@@ -9,5 +9,6 @@
     {
       "pattern": "^https://www.baeldung.com/" // when automated tests hit this, site returns a CAPTCHA
     }
-  ]
+  ],
+  "aliveStatusCodes": [429, 200]
 }

--- a/.mlc_config.json
+++ b/.mlc_config.json
@@ -1,14 +1,18 @@
 {
   "ignorePatterns": [
     {
-      "pattern": "^http://localhost:"
-    }, 
-    {
-      "pattern": "^http://127.0.0.1:"
+      "pattern": "^https*://127.0.0.1"
     },
     {
-      "pattern": "^https://www.baeldung.com/" // when automated tests hit this, site returns a CAPTCHA
+      "pattern": "^http://localhost:"
+    },
+    {
+      "pattern": "https://gitlab.com/-/*"
     }
   ],
-  "aliveStatusCodes": [429, 200]
+  "timeout": "20s",
+  "retryOn429": true,
+  "retryCount": 2,
+  "fallbackRetryDelay": "30s",
+  "aliveStatusCodes": [200, 206, 301, 400, 429]
 }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Contributions to the docs are welcome! To start contributing, first please make 
 
 1. Clone the repo
 2. Install: `yarn install`
-3. Run the docs locally with `yarn start` and then go to: <http://localhost:3000/>
+3. Run the docs locally with `yarn start` and then go to: `<http://localhost:3000/>`
 
 ## Build and preview
 

--- a/docs/experiments/join-mode/recursive-joins.md
+++ b/docs/experiments/join-mode/recursive-joins.md
@@ -1,6 +1,6 @@
 # Recursive joins
 
-Join mode is an extension of Semgrep that runs multiple rules at once and only returns results if certain conditions are met. Join mode is an experimental mode that enables you to cross file boundaries, allowing you to write rules for whole codebases instead of individual files. More information is available in [Join mode overview](/docs/experiments/join-mode/overview).
+Join mode is an extension of Semgrep that runs multiple rules at once and only returns results if certain conditions are met. Join mode is an experimental mode that enables you to cross file boundaries, allowing you to write rules for whole codebases instead of individual files. More information is available in [Join mode overview](./overview/).
 
 Recursive join mode has a recursive operator, `-->`, which executes a recursive query on the given condition. This recursive operator allows you to write a Semgrep rule that effectively crawls the codebase on a condition you specify, letting you build chains such as function call chains or class inheritance chains.
 

--- a/docs/experiments/overview.md
+++ b/docs/experiments/overview.md
@@ -75,7 +75,7 @@ rules:
 
 ## Generic pattern matching
 
-See [generic pattern matching](../generic-pattern-matching/).
+See [generic pattern matching](./generic-pattern-matching/).
 
 ## Deprecated experiments
 

--- a/docs/ignoring-files-folders-code.md
+++ b/docs/ignoring-files-folders-code.md
@@ -32,7 +32,7 @@ Without user customization, Semgrep refers to the following to define ignored fi
 * Semgrep's default `.semgrepignore` file
 * Your repository's `.gitignore` file (if it exists)
 
-In the absence of a user-generated `.semgrepignore`, Semgrep will refer to [its repository's default template](://github.com/returntocorp/semgrep/blob/develop/semgrep/semgrep/templates/.semgrepignore):
+In the absence of a user-generated `.semgrepignore`, Semgrep will refer to [its repository's default template](https://github.com/returntocorp/semgrep/blob/develop/semgrep/semgrep/templates/.semgrepignore):
 
 ```
 DEFAULT_SEMGREPIGNORE_TEXT

--- a/docs/status.md
+++ b/docs/status.md
@@ -103,7 +103,7 @@ The following thresholds define each maturity level:
 
 Visit the cheat sheet generation script and associated semgrep-core test files to learn more about each feature:
 
-* [generation script](https://github.com/returntocorp/semgrep/blob/develop/scripts/generate_cheatsheet.py)
+* [generation script](https://github.com/returntocorp/semgrep/blob/develop/scripts/generate_test_matrix.py)
 * [semgrep-core test files](https://github.com/returntocorp/semgrep/tree/develop/semgrep-core/tests)
 ## Language parse rates
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -103,7 +103,7 @@ The following thresholds define each maturity level:
 
 Visit the cheat sheet generation script and associated semgrep-core test files to learn more about each feature:
 
-* [generation script](https://github.com/returntocorp/semgrep/blob/develop/scripts/generate_test_matrix.py)
+* [generation script](https://github.com/returntocorp/semgrep/blob/develop/scripts/generate_cheatsheet.py)
 * [semgrep-core test files](https://github.com/returntocorp/semgrep/tree/develop/semgrep-core/tests)
 ## Language parse rates
 


### PR DESCRIPTION
This PR squashes a few broken links. It also updates the Markdown link checker so that it’s more reliable and, besides checking every PR, so it also runs once weekly to help prevent link rot.
