### PR TITLE
List Scala as GA

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -19,7 +19,7 @@ import MoreHelp from "/src/components/MoreHelp"
 |:---------- |:---------------------------|:---------------------------|
 | C#         | Kotlin                     | Bash                       |
 | Go         | Terraform                  | C                          |
-| Java       | Scala                      | C++                        |
+| Java       |                            | C++                        |
 | JavaScript |                            | Dockerfile                 |
 | JSON       |                            | Hack                       |
 | JSX        |                            | Lua                        |
@@ -27,7 +27,7 @@ import MoreHelp from "/src/components/MoreHelp"
 | Ruby       |                            | PHP                        |
 | TypeScript |                            | Rust                       |
 | TSX        |                            | Solidity                   |
-|            |                            | YAML                       |
+| Scala      |                            | YAML                       |
 |            |                            | Generic (ERB, Jinja, etc.) |
 
 ## Support expectations


### PR DESCRIPTION
Scala was recently officially promoted to GA: https://github.com/returntocorp/semgrep/pull/4973

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
