### PR TITLE
Sync language support status with index page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -61,8 +61,8 @@ Semgrep supports 20+ languages.
 | Python     |                            | OCaml                      |
 | Ruby       |                            | PHP                        |
 | Scala      |                            | Rust                       |
-| TypeScript |                            | Solidity                   |
-| TSX        |                            | YAML                       |
+| TSX        |                            | Solidity                   |
+| TypeScript |                            | YAML                       |
 |            |                            | Generic (ERB, Jinja, etc.) |
 
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@ Semgrep is developed and commercially supported by [r2c, a software security com
 Semgrep supports 20+ languages.
 
 <!--  coupling: if you modify this table, copy paste it also to status.md -->
+<!--  for readability, please keep each column in alphabetical order -->
 
 <div id="language-support-table">
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -25,9 +25,9 @@ import MoreHelp from "/src/components/MoreHelp"
 | JSX        |                            | Lua                        |
 | Python     |                            | OCaml                      |
 | Ruby       |                            | PHP                        |
-| TypeScript |                            | Rust                       |
-| TSX        |                            | Solidity                   |
-| Scala      |                            | YAML                       |
+| Scala      |                            | Rust                       |
+| TypeScript |                            | Solidity                   |
+| TSX        |                            | YAML                       |
 |            |                            | Generic (ERB, Jinja, etc.) |
 
 ## Support expectations

--- a/docs/status.md
+++ b/docs/status.md
@@ -15,6 +15,7 @@ import MoreHelp from "/src/components/MoreHelp"
 
 <!-- coupling: if you modify this table, copy paste it also in index.md -->
 <!-- coupling: should match what is in semgrep-core/tests/Test.ml Maturity level testing -->
+<!-- for readability, please keep each column in alphabetical order -->
 | GA ✅      | Beta 🐛                     | Experimental 🚧            |
 |:---------- |:---------------------------|:---------------------------|
 | C#         | Kotlin                     | Bash                       |

--- a/docs/status.md
+++ b/docs/status.md
@@ -27,8 +27,8 @@ import MoreHelp from "/src/components/MoreHelp"
 | Python     |                            | OCaml                      |
 | Ruby       |                            | PHP                        |
 | Scala      |                            | Rust                       |
-| TypeScript |                            | Solidity                   |
-| TSX        |                            | YAML                       |
+| TSX        |                            | Solidity                   |
+| TypeScript |                            | YAML                       |
 |            |                            | Generic (ERB, Jinja, etc.) |
 
 ## Support expectations


### PR DESCRIPTION
As a side-effect, this alphabetizes Scala before TS/TSX.

I almost missed Scala support because it was below TypeScript, then found that `index.md` had been updated and this one hadn't.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
