### PR TITLE
docs(taint-mode): fix link

### DIFF
--- a/docs/writing-rules/data-flow/taint-mode.md
+++ b/docs/writing-rules/data-flow/taint-mode.md
@@ -146,5 +146,5 @@ The following example demonstrates the use of source and sink metavariable unifi
 <iframe src="https://semgrep.dev/embed/editor?snippet=obRd" border="0" frameBorder="0" width="100%" height="432"></iframe>
 
 :::info
-Semgrep used to have a different behavior, for more information, see [release notes for version 0.87.0](http://localhost:3000/docs/release-notes/#version-0870).
+Semgrep used to have a different behavior, for more information, see [release notes for version 0.87.0](https://semgrep.dev/docs/release-notes/#version-0870).
 :::


### PR DESCRIPTION
Fix to use actual url instead of localhost.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
