### PR TITLE
Remove `sudo pip install` in contributing docs

### DIFF
--- a/docs/contributing/semgrep-contributing.md
+++ b/docs/contributing/semgrep-contributing.md
@@ -114,11 +114,7 @@ You can always run `semgrep` from `semgrep/semgrep/`, which will use your latest
 pipenv install --dev
 ```
 
-Some people have encountered difficulties with the above. If it fails, you can also try (within the `semgrep/semgrep/` directory)
-
-```
-sudo pip install -e .
-```
+Some people have encountered difficulties with the above. If it fails, you can reach out to the [`semgrep` team on Slack](https://r2c.dev/slack).
 
 If you have an M1 Mac, this may install the incorrect executable. You can run this instead
 ```


### PR DESCRIPTION
`sudo pip install` can cause some file ownership and permissions issues. Removed the line and swapped it out with contact info to reach out to in case of issues (recommended by @underyx).

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
