### PR TITLE
remove equivalence_eq from maturity

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -95,7 +95,6 @@ The following thresholds define each maturity level:
         * `deep_expr_operator`
         * `dots_method_chaining`
         * `equivalence_constant_propagation`
-        * `equivalence_eq`
         * `equivalence_naming_import` (language dependent)
         * `metavar_anno` (language dependent)
         * `metavar_key_value`


### PR DESCRIPTION
User-defined equivalences have been deprecated for a long time,
so equivalence_eq is not relevant anymore

test plan:
nope


# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs