### PR TITLE
fix wrong formatting of dl dt tags

### DIFF
--- a/docs/semgrep-app/getting-started-with-semgrep-app.md
+++ b/docs/semgrep-app/getting-started-with-semgrep-app.md
@@ -162,7 +162,6 @@ Additional scan parameters include:
 <dl>
     <dt>Rule recommendation</dt>
     <dd>Select this toggle to receive rule recommendations in the Rule Board based on the framework and language of the repository. Rule recommendations are only suggestions and will not be included in a scan unless you add the recommendations into a rule board.</dd>
-
     <dt>Autofix</dt>
     <dd>Select this toggle to enable autofix, which creates suggestions in addition to PR or MR comments. For example, a rule may suggest using a function such as <code>logging.debug()</code> instead of <code>print()</code>.</dd>
     <dt>Path ignores</dt>


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

Fixes!
![2022-05-19 03_37](https://user-images.githubusercontent.com/20766840/169142428-cf2ffb84-cb6d-4453-83d6-3bd2f2000707.png)

- [x] This change has no security implications or else you have pinged the security team

