### PR TITLE
added yarn script dev to prevent replacements script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Contributions to the docs are welcome! To start contributing, first please make 
 1. Clone the repo.
 2. Install: `yarn install`.
 3. There are two options to run the docs locally:
-    A. Enter `yarn dev` and then go to `<http://localhost:3000/>`. This option is for contributors and writers.
-    B. Enter `yarn start` and then go to: `<http://localhost:3000/>`. This option is for displaying an accurate preview of the live documentation.It runs a script that replaces certain identifiers with code or file templates. These replacements ensure that certain code or file templates are up-to-date.
+    1. Enter `yarn dev` and then go to `<http://localhost:3000/>`. This option is for contributors and writers.
+    2. Enter `yarn start` and then go to: `<http://localhost:3000/>`. This option is for displaying an accurate preview of the live documentation.It runs a script that replaces certain identifiers with code or file templates. These replacements ensure that certain code or file templates are up-to-date.
 
 ## Preview production build
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ Contributions to the docs are welcome! To start contributing, first please make 
 
 ## Building docs locally
 
-1. Clone the repo
-2. Install: `yarn install`
-3. Run locally: `yarn start` and then go to: `<http://localhost:3000/>`
+1. Clone the repo.
+2. Install: `yarn install`.
+3. There are two options to run the docs locally:
+    A. Enter `yarn dev` and then go to `<http://localhost:3000/>`. This option is for contributors and writers.
+    B. Enter `yarn start` and then go to: `<http://localhost:3000/>`. This option is for displaying an accurate preview of the live documentation.It runs a script that replaces certain identifiers with code or file templates. These replacements ensure that certain code or file templates are up-to-date.
 
 ## Preview production build
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "docusaurus": "docusaurus",
     "start": "bash run-build-scripts && docusaurus start",
     "build": "bash run-build-scripts && docusaurus build",
+    "dev": "docusaurus start",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure
- [x] This change has no security implications or else you have pinged the security team

### Usage
This PR creates a `yarn dev` command which is identical to yarn start without running the replacements script. Use when developing docs. Run `yarn start` if you want to see the final form of the docs (with replacements).
