### PR TITLE
removed SEMGREP_RULES on gitlab config

### DIFF
--- a/docs/semgrep-ci/sample-ci-configs.md
+++ b/docs/semgrep-ci/sample-ci-configs.md
@@ -151,7 +151,7 @@ semgrep:
     # Get your token at semgrep.dev/orgs/-/settings/tokens.
     SEMGREP_APP_TOKEN: $SEMGREP_APP_TOKEN
     # Option 2: set hard-coded rulesets, viewable in logs.
-    SEMGREP_RULES: p/default # See more at semgrep.dev/explore.
+    # SEMGREP_RULES: p/default # See more at semgrep.dev/explore.
 
   # == Other optional settings in the `variables:` block
 


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀



Quick one-line bugfix on the GitLab sample config; logging in with a token while describing a manual ruleset at the same time will give an error:


<img width="947" alt="image" src="https://user-images.githubusercontent.com/50721067/172231011-35d35493-29c1-42a2-8e53-5ce0a18a0bb0.png">

commented out the ruleset.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ x] This change has no security implications or else you have pinged the security team
- [x ] Redirects are added if the PR changes page URLs
