### PR TITLE
Update contributing docs for ocaml version bump (from 4.12 to 4.14)

### DIFF
--- a/docs/contributing/semgrep-core-contributing.md
+++ b/docs/contributing/semgrep-core-contributing.md
@@ -11,8 +11,8 @@ The following explains how to build `semgrep-core` so you can make and test chan
 ```bash
 brew install opam
 opam init
-opam switch create 4.12.0 ocaml-base-compiler.4.12.0
-opam switch 4.12.0
+opam switch create 4.14.0 ocaml-base-compiler.4.14.0
+opam switch 4.14.0
 eval $(opam env)
 ```
 


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

This makes the corresponding contributing documentation change for https://github.com/returntocorp/semgrep/pull/5455.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
