### PR TITLE
Add GTM

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -135,6 +135,10 @@ module.exports = {
     {
       src: 'https://semgrep.dev/docs/fs.js',
       async: true
+    },
+    {
+      src: '/docs/js/gtm.js',
+      async: true
     }
   ],
   presets: [

--- a/static/js/gtm.js
+++ b/static/js/gtm.js
@@ -1,0 +1,5 @@
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-WSN4QTD');


### PR DESCRIPTION
This adds Google Tag Manager, which isn’t natively supported by Docusaurus.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
