### PR TITLE
Fix and revert markdown-link-check.yml

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - uses: gaurav-nelson/github-action-markdown-link-check@1
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: "yes"        
           use-verbose-mode: "yes"

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -9,8 +9,8 @@ jobs:
       - uses: actions/checkout@master
       - uses: gaurav-nelson/github-action-markdown-link-check@1
         with:
+          use-quiet-mode: "yes"        
           use-verbose-mode: "yes"
-          use-quiet-mode: "yes"
           base-branch: "main"
           check-modified-files-only: "yes"
           config-file: ".mlc_config.json"

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -7,13 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      # (ssantillan) Uncomment this line and remove labeneko line when
-      # https://github.com/gaurav-nelson/github-action-markdown-link-check/issues/132
-      # is fixed.
-      # - uses: gaurav-nelson/github-action-markdown-link-check@1.0.13
-      - uses: labeneko/github-action-markdown-link-check@02373ae78d2b9882098e0fd4e6c9b25cdc212b01
-          use-quiet-mode: "yes"
+      - uses: gaurav-nelson/github-action-markdown-link-check@1
+        with:
           use-verbose-mode: "yes"
+          use-quiet-mode: "yes"
           base-branch: "main"
           check-modified-files-only: "yes"
           config-file: ".mlc_config.json"


### PR DESCRIPTION
The mentioned issue was fixed upstream and the 'with:' was accidentally removed which causes run issues now. Fixed both and lifted the version pin (on @v1 no breaking changes should happen).

# Thanks for improving Semgrep Docs 

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
