### PR TITLE
Remove the default Google Analytics plugin

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -155,10 +155,6 @@ module.exports = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
-        googleAnalytics: {
-          trackingID: 'UA-106134149-12',
-          anonymizeIP: true,
-        },
         gtag: {
           // You can also use your "G-" Measurement ID here.
           trackingID: 'G-1851JH9FSR',


### PR DESCRIPTION
because GA can now be handled by Google Tag Manager (GTM)

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
