### PR TITLE
Updated sample CI configuration for Buildkite

### DIFF
--- a/docs/semgrep-ci/sample-ci-configs.md
+++ b/docs/semgrep-ci/sample-ci-configs.md
@@ -236,29 +236,23 @@ pipeline {
 
 ```yaml
 - label: ":semgrep: Semgrep"
-  command: semgrep ci
+  commands:
+    - export SEMGREP_BASELINE_REF=""
+    - export SEMGREP_REPO_URL="$(echo "$BUILDKITE_REPO" | sed -e 's#.\{4\}$##')"
+    - export SEMGREP_BRANCH=${BUILDKITE_BRANCH}
+    - export SEMGREP_COMMIT=${BUILDKITE_COMMIT}
+    - export SEMGREP_PR_ID=${BUILDKITE_PULL_REQUEST}
+    - echo "$BUILDKITE_REPO" | sed 's#https://github.com/##' | sed 's#.git##'
+    - export SEMGREP_REPO_NAME="$(echo "$BUILDKITE_REPO" | sed -e 's#https://github.com/##' | sed -e 's#.git##')"
+    - semgrep ci 
+  
   plugins:
     - docker#v3.7.0:
         image: returntocorp/semgrep
-        workdir: /<org_name>/<repo_name>
         environment:
           # Scan with rules set in Semgrep App's rule board
           # Make a token at semgrep.dev/orgs/-/settings/tokens
-          - "SEMGREP_APP_TOKEN=${SEMGREP_APP_TOKEN}"
-
-        # == Optional settings in the `environment:` block
-
-        # Instead of `SEMGREP_APP_TOKEN:`, set hard-coded rulesets, 
-        # viewable in logs.
-        #   - "SEMGREP_RULES=p/default" # more at semgrep.dev/explore
-        #   - "SEMGREP_JOB_URL=${BUILDKITE_BUILD_URL}"
-        #   - "SEMGREP_BRANCH=${BUILDKITE_BRANCH}"
-        #   - "SEMGREP_REPO_NAME=<org_name>/<repo_name>"
-        #   - "SEMGREP_REPO_URL=<github_url>"
-
-        # Never fail the build due to findings.
-        # Instead, just collect findings for semgrep.dev/manage/findings
-        #   - "SEMGREP_AUDIT_ON=unknown"
+          - "SEMGREP_APP_TOKEN"
 
         # Change job timeout (default is 1800 seconds; set to 0 to disable)
         #   - "SEMGREP_TIMEOUT=300"

--- a/docs/semgrep-ci/sample-ci-configs.md
+++ b/docs/semgrep-ci/sample-ci-configs.md
@@ -234,7 +234,7 @@ pipeline {
 
 ## Buildkite
 
-```yaml
+```
 - label: ":semgrep: Semgrep"
   commands:
     - export SEMGREP_BASELINE_REF=""

--- a/docs/semgrep-ci/sample-ci-configs.md
+++ b/docs/semgrep-ci/sample-ci-configs.md
@@ -253,9 +253,6 @@ pipeline {
           # Scan with rules set in Semgrep App's rule board
           # Make a token at semgrep.dev/orgs/-/settings/tokens
           - "SEMGREP_APP_TOKEN"
-
-        # Change job timeout (default is 1800 seconds; set to 0 to disable)
-        #   - "SEMGREP_TIMEOUT=300"
 ```
 
 ### Feature support


### PR DESCRIPTION
Updated sample CI configuration for Buildkite after doing some testing and adding official integration support into the app.

Opted for no highlighting due to the funky pound sign highlighting: 

<img width="1511" alt="image" src="https://user-images.githubusercontent.com/50721067/175619962-5f868ad3-1ca0-41cb-82ad-883b1cf2e8f7.png">



# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
