### PR TITLE
Allow `generic` for extract mode

### DIFF
--- a/docs/experiments/extract-mode.md
+++ b/docs/experiments/extract-mode.md
@@ -96,7 +96,7 @@ The `extract` key is required in extract mode. The value must be a metavariable 
 
 ### `dest-language`
 
-The `dest-language` key is required in extract mode. The value must be a [language tag](../../writing-rules/rule-syntax/#language-extensions-and-tags) other than `generic`.
+The `dest-language` key is required in extract mode. The value must be a [language tag](../../writing-rules/rule-syntax/#language-extensions-and-tags).
 
 ### `reduce`
 


### PR DESCRIPTION
Corresponds to changes from: <https://github.com/returntocorp/semgrep/pull/5749>

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
