### PR TITLE
Remove Semgrep CI as a separate Semgrep ecosystem

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -32,11 +32,10 @@ Its rules look like the code you already write; no abstract syntax trees, regex 
 
 The Semgrep ecosystem includes:
 
-* [Semgrep](getting-started/) - the open-source command line tool at the heart of everything
-* [Semgrep CI](semgrep-ci/overview/) - a specialized Docker image for running Semgrep in CI environments
-* [Semgrep Playground](https://semgrep.dev/editor) - an online interactive tool for writing and sharing rules
-* [Semgrep Registry](https://semgrep.dev/explore) - 2,000+ community-driven rules covering security, correctness, and performance bugs
-* [Semgrep App](https://semgrep.dev/manage) - deploy, manage, and monitor Semgrep at scale with free and paid tiers
+* [Semgrep](getting-started/) - The open-source command line tool at the heart of everything. You can run it also in [CI environment](semgrep-ci/overview/)!
+* [Semgrep Playground](https://semgrep.dev/editor) - An online interactive tool for writing and sharing rules.
+* [Semgrep Registry](https://semgrep.dev/explore) - 2,000+ community-driven rules covering security, correctness, and performance bugs.
+* [Semgrep App](https://semgrep.dev/manage) - Deploy, manage, and monitor Semgrep at scale with free and paid tiers.
 
 Semgrep is developed and commercially supported by [r2c, a software security company](https://r2c.dev).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,10 +32,10 @@ Its rules look like the code you already write; no abstract syntax trees, regex 
 
 The Semgrep ecosystem includes:
 
-* [Semgrep](getting-started/) - The open-source command line tool at the heart of everything. You can run it also in [CI environment](semgrep-ci/overview/)!
+* [Semgrep](getting-started/) - The open-source command line tool at the heart of everything.
 * [Semgrep Playground](https://semgrep.dev/editor) - An online interactive tool for writing and sharing rules.
 * [Semgrep Registry](https://semgrep.dev/explore) - 2,000+ community-driven rules covering security, correctness, and performance bugs.
-* [Semgrep App](https://semgrep.dev/manage) - Deploy, manage, and monitor Semgrep at scale with free and paid tiers.
+* [Semgrep App](https://semgrep.dev/manage) - Deploy, manage, and monitor Semgrep at scale with free and paid tiers. Integrates with CI providers such as GitHub, GitLab, CircleCI, and more.
 
 Semgrep is developed and commercially supported by [r2c, a software security company](https://r2c.dev).
 


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
