### PR TITLE
change(writing-rules): clarify pattern-inside example

### DIFF
--- a/docs/writing-rules/rule-syntax.md
+++ b/docs/writing-rules/rule-syntax.md
@@ -240,7 +240,7 @@ The `pattern-not` operator is the opposite of the `pattern` operator. It finds c
 
 The `pattern-inside` operator keeps matched findings that reside within its expression. This is useful for finding code inside other pieces of code like functions or if blocks.
 
-<iframe src="https://semgrep.dev/embed/editor?snippet=B4lR" border="0" frameBorder="0" width="100%" height="432"></iframe>
+<iframe src="https://semgrep.dev/embed/editor?snippet=Z8Dw" border="0" frameBorder="0" width="100%" height="432"></iframe>
 
 ### `pattern-not-inside`
 


### PR DESCRIPTION
**What:**
Currently, the `pattern-inside` example isn't super insightful into what `pattern-inside` actually changes.

**Why**:
This is because it shows off an example where the `pattern` would match regardless of whether the `pattern-inside` rule were to be there. I think the strength of `pattern-inside` is in showing what examples _should not_ match, if a user were to use it. For reference, this confused me over why I should use `pattern-inside`, or care about it.

**How**:
I added a `def foo` which has a `return` which is unmatched, as a result of not being in a `class`.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
