### PR TITLE
Add a tutorial on how to deal with line-based formats in generic mode

### DIFF
--- a/docs/experiments/generic-pattern-matching.md
+++ b/docs/experiments/generic-pattern-matching.md
@@ -153,8 +153,7 @@ Unfortunately, the following pattern does not match the whole line. In generic m
 password = $PASSWORD
 ```
 
-This would match the input file but would assign the value `p`
-to `$PASSWORD` instead of the full value `p@$$w0rd`.
+This pattern matches the input file but does not assign the value `p` to `$PASSWORD` instead of the full value `p@$$w0rd`.
 
 To match an arbitrary sequence of items (words, punctuation, etc.) and
 capture its value, we must use a named ellipsis. Our pattern becomes:

--- a/docs/experiments/generic-pattern-matching.md
+++ b/docs/experiments/generic-pattern-matching.md
@@ -155,37 +155,39 @@ password = $PASSWORD
 
 This pattern matches the input file but does not assign the value `p` to `$PASSWORD` instead of the full value `p@$$w0rd`.
 
-To match an arbitrary sequence of items (words, punctuation, etc.) and
-capture its value, we must use a named ellipsis. Our pattern becomes:
+To match an arbitrary sequence of items and capture their value in the this example:
 
-```
-password = $...PASSWORD
-```
+1. Use a named ellipsis, by changing the pattern to the following:
 
-Unfortunately, this doesn't work either because it captures too
-much. The value assigned to `$...PASSWORD` is now
-`p@$$w0rd`&lt;newline&gt;`server = example.com`. This is because in
-generic mode, an ellipsis extends until the end of the current block
-or up to 10 lines down, whichever comes first. To prevent this,
-specify the option `generic_ellipsis_max_span: 0` in the Semgrep
-rule. This will force the ellipsis to match within a single line.
-The [resulting
-rule](https://semgrep.dev/playground/s/returntocorp:password-in-config-file)
-is:
+    ```yaml
+    password = $...PASSWORD
+    ```
 
-```yaml
-id: password-in-config-file
-pattern: |
-  password = $...PASSWORD
-options:
-  # prevent ellipses from matching multiple lines
-  generic_ellipsis_max_span: 0
-message: |
-  password found in config file: $...PASSWORD
-languages:
-  - generic
-severity: WARNING
-```
+    This still leads Semgrep to capture too much information. The value assigned to `$...PASSWORD` are now `p@$$w0rd` and<br />
+    `server = example.com`. In generic mode, an ellipsis extends until the end of the current block or up to 10 lines below, whichever comes first. To prevent this behavior, continue with the next step.
+
+2. In the Semgrep rule, specify the following key:
+   
+    ```yaml
+    generic_ellipsis_max_span: 0
+    ```
+
+    This option forces the ellipsis operator to match patterns within a single line.
+    Example of the [resulting rule](https://semgrep.dev/playground/s/returntocorp:password-in-config-file):
+
+    ```yaml
+    id: password-in-config-file
+    pattern: |
+      password = $...PASSWORD
+    options:
+      # prevent ellipses from matching multiple lines
+      generic_ellipsis_max_span: 0
+    message: |
+      password found in config file: $...PASSWORD
+    languages:
+      - generic
+    severity: WARNING
+    ```
 
 ## Command line example
 

--- a/docs/experiments/generic-pattern-matching.md
+++ b/docs/experiments/generic-pattern-matching.md
@@ -147,9 +147,7 @@ password = p@$$w0rd
 server = example.com
 ```
 
-Unfortunately, the following pattern won't work the way we want
-because in generic mode, metavariables will only capture a single word
-(alphanumeric sequence):
+Unfortunately, the following pattern does not match the whole line. In generic mode, metavariables only capture a single word (alphanumeric sequence):
 
 ```
 password = $PASSWORD

--- a/docs/experiments/generic-pattern-matching.md
+++ b/docs/experiments/generic-pattern-matching.md
@@ -169,7 +169,7 @@ password = $...PASSWORD
 
 Unfortunately, this doesn't work either because it captures too
 much. The value assigned to `$...PASSWORD` is now
-`p@$$w0rd`@lt;newline&gt;`server = example.com`. This is because in
+`p@$$w0rd`&lt;newline&gt;`server = example.com`. This is because in
 generic mode, an ellipsis extends until the end of the current block
 or up to 10 lines down, whichever comes first. To prevent this,
 specify the option `generic_ellipsis_max_span: 0` in the Semgrep

--- a/docs/experiments/generic-pattern-matching.md
+++ b/docs/experiments/generic-pattern-matching.md
@@ -139,7 +139,11 @@ name = ...
 
 ### Handling line-based input
 
-This section explains how to use Semgrep's generic mode to match single lines of code using ellipsis metavariable. Many simple configuration formats are collections of key and value pairs delimited by newlines. For example, to extract the `password` value from the following made-up input:
+This section explains how to use Semgrep's generic mode to match
+single lines of code using an ellipsis metavariable. Many simple
+configuration formats are collections of key and value pairs delimited
+by newlines. For example, to extract the `password` value from the
+following made-up input:
 
 ```
 username = bob

--- a/docs/experiments/generic-pattern-matching.md
+++ b/docs/experiments/generic-pattern-matching.md
@@ -137,7 +137,7 @@ name = ...
   name = ...
 ```
 
-### How to handle line-based input
+### Handling line-based input
 
 Many simple configuration formats are a collection of key/value pairs
 delimited by newlines. For example, we would like to extract the

--- a/docs/experiments/generic-pattern-matching.md
+++ b/docs/experiments/generic-pattern-matching.md
@@ -139,9 +139,7 @@ name = ...
 
 ### Handling line-based input
 
-Many simple configuration formats are a collection of key/value pairs
-delimited by newlines. For example, we would like to extract the
-`password` value from the following made-up input:
+This section explains how to use Semgrep's generic mode to match single lines of code using ellipsis metavariable. Many simple configuration formats are collections of key and value pairs delimited by newlines. For example, to extract the `password` value from the following made-up input:
 
 ```
 username = bob

--- a/docs/experiments/generic-pattern-matching.md
+++ b/docs/experiments/generic-pattern-matching.md
@@ -155,7 +155,7 @@ password = $PASSWORD
 
 This pattern matches the input file but does not assign the value `p` to `$PASSWORD` instead of the full value `p@$$w0rd`.
 
-To match an arbitrary sequence of items and capture their value in the this example:
+To match an arbitrary sequence of items and capture their value in the example:
 
 1. Use a named ellipsis, by changing the pattern to the following:
 


### PR DESCRIPTION
This was prompted by https://github.com/returntocorp/semgrep/issues/5665

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
