### PR TITLE
Fix rule_schema.yaml link in rule-syntax.md

### DIFF
--- a/docs/writing-rules/rule-syntax.md
+++ b/docs/writing-rules/rule-syntax.md
@@ -512,7 +512,7 @@ The above rule makes use of many operators. It uses `pattern-either`, `patterns`
 
 ## Full specification
 
-The [full configuration-file format](https://github.com/returntocorp/semgrep/blob/develop/cli/src/semgrep/rule_schema.yaml) is defined as
+The [full configuration-file format](https://github.com/returntocorp/semgrep-interfaces/blob/main/rule_schema.yaml) is defined as
 a [jsonschema](http://json-schema.org/specification.html) object.
 
 <MoreHelp />


### PR DESCRIPTION
Fix rule_schema.yaml link in rule-syntax.md to reflect the file move in https://github.com/returntocorp/semgrep/commit/ba08b088afb6aa7ad5ca975803f4da95fd590201

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
