### PR TITLE
Change Swift to experimental

### DIFF
--- a/src/components/reference/_supported-languages-table.mdx
+++ b/src/components/reference/_supported-languages-table.mdx
@@ -15,8 +15,9 @@ Semgrep supports 20+ languages.
 | Ruby       |                            | R                          |
 | Scala      |                            | Rust                       |
 | Terraform  |                            | Solidity                   |
-| TSX        |                            | YAML                       |
-| TypeScript |                            | Generic (ERB, Jinja, etc.) |
+| TSX        |                            | Swift                      |
+| TypeScript |                            | YAML                       |
+|            |                            | Generic (ERB, Jinja, etc.) |
 
 </div>
 


### PR DESCRIPTION
As of https://github.com/returntocorp/semgrep/pull/5870, Swift meets the bar for experimental status!

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
