### PR TITLE
Update generic examples + how to ignore comments

### DIFF
--- a/docs/experiments/generic-pattern-matching.md
+++ b/docs/experiments/generic-pattern-matching.md
@@ -234,10 +234,10 @@ To match an arbitrary sequence of items and capture their value in the example:
 
 ### Ignoring comments
 
-By default, the generic mode doesn't know about comments or code that
-should be ignored. In the following example, for some reason we want
-to detect CSS code that sets text color to blue. Here's the target
-code:
+By default, the generic mode does **not** know about comments or code
+that can be ignored. In the following example, we are 
+scanning for CSS code that sets the text color to blue. The target code
+is the following:
 
 ```
 color: /* my fave color */ blue;

--- a/docs/experiments/generic-pattern-matching.md
+++ b/docs/experiments/generic-pattern-matching.md
@@ -28,7 +28,7 @@ rules:
     severity: WARNING
     message: >-
       The protocol scheme for this proxy is dynamically determined.
-      This can be dangerous if the scheme can be injected by an
+      This can be dangerous if the scheme is injected by an
       attacker because it may forcibly alter the connection scheme.
       Consider hardcoding a scheme for this proxy.
     metadata:

--- a/docs/experiments/generic-pattern-matching.md
+++ b/docs/experiments/generic-pattern-matching.md
@@ -91,11 +91,10 @@ Generic pattern matching has the following properties:
 Semgrep can reliably understand the syntax of natively [supported languages](/supported-languages/). The generic mode is useful for unsupported languages, consequently bringing specific limitations.
 
 :::caution
-- Generic mode is not good for detecting malicious code.
-- The quality of results in the generic mode can vary depending on the language you use it for.
+The quality of results in the generic mode can vary depending on the language you use it for.
 :::
 
-The generic mode works fine with any human-readable text, as long as it is primarily based on ASCII symbols. Since the generic mode does not understand the syntax of the language you are scanning, the quality of the result may differ from language to language or even depend on specific code. As a consequence, the generic mode works well for some languages, but it does not give consistent results always. Generally, it's possible or even easy to write code in weird ways that prevent generic mode from matching. Note generic mode is not good for detecting malicious code.
+The generic mode works fine with any human-readable text, as long as it is primarily based on ASCII symbols. Since the generic mode does not understand the syntax of the language you are scanning, the quality of the result may differ from language to language or even depend on specific code. As a consequence, the generic mode works well for some languages, but it does not give consistent results always. Generally, it's possible or even easy to write code in weird ways that prevent generic mode from matching.
 
 **Example**: In XML, one can write `&#x48;&#x65;&#x6C;&#x6C;&#x6F` instead of `Hello`. If a rule pattern in generic mode is `Hello`, Semgrep is unable to match the `&#x48;&#x65;&#x6C;&#x6C;&#x6F`, unlike if it had full XML support.
 

--- a/docs/experiments/generic-pattern-matching.md
+++ b/docs/experiments/generic-pattern-matching.md
@@ -243,9 +243,9 @@ is the following:
 color: /* my fave color */ blue;
 ```
 
-[`options.generic_comment_style`](https://semgrep.dev/docs/writing-rules/rule-syntax/#options)
-is an option that can be set to ignore
-C-style comments as is the case here. Our simple Semgrep rule is:
+Use the [`options.generic_comment_style`](/writing-rules/rule-syntax/#options)
+to ignore C-style comments as it is the case in our example.
+Our simple Semgrep rule is:
 
 ```yaml
 id: css-blue-is-ugly

--- a/docs/experiments/generic-pattern-matching.md
+++ b/docs/experiments/generic-pattern-matching.md
@@ -10,7 +10,7 @@ description: "Semgrep can match generic patterns in languages that it doesn’t 
      that makes sense. -->
 
 ## Introduction
-Semgrep can match matches generic patterns in languages that it doesn’t yet support. You can use generic pattern matching for languages that don’t yet have a parser, configuration files, and other structured data such as XML. Generic pattern matching is experimental.
+Semgrep can match generic patterns in languages that it does **not** yet support. Use generic pattern matching for languages that do not have a parser, configuration files, or other structured data such as XML. Generic pattern matching is experimental.
 
 As an example, consider this rule:
 ```yaml

--- a/docs/experiments/generic-pattern-matching.md
+++ b/docs/experiments/generic-pattern-matching.md
@@ -1,6 +1,6 @@
 ---
 append_help_link: true
-description: "Semgrep can match matches generic patterns in languages that it doesn’t yet support. You can use generic pattern matching for languages that don’t yet have a parser, configuration files, and other structured data such as XML. Generic pattern matching is experimental."
+description: "Semgrep can match generic patterns in languages that it doesn’t support yet. You can use generic pattern matching for languages that do **not** have a parser, configuration files, or other structured data such as XML. Generic pattern matching is experimental."
 ---
 
 # Generic pattern matching

--- a/docs/experiments/generic-pattern-matching.md
+++ b/docs/experiments/generic-pattern-matching.md
@@ -232,6 +232,35 @@ To match an arbitrary sequence of items and capture their value in the example:
     severity: WARNING
     ```
 
+### Ignoring comments
+
+By default, the generic mode doesn't know about comments or code that
+should be ignored. In the following example, for some reason we want
+to detect CSS code that sets text color to blue. Here's the target
+code:
+
+```
+color: /* my fave color */ blue;
+```
+
+[`options.generic_comment_style`](https://semgrep.dev/docs/writing-rules/rule-syntax/#options)
+is an option that can be set to ignore
+C-style comments as is the case here. Our simple Semgrep rule is:
+
+```yaml
+id: css-blue-is-ugly
+pattern: |
+  color: blue
+options:
+  # ignore comments of the form /* ... */
+  generic_comment_style: c
+message: |
+  Blue is ugly.
+languages:
+  - generic
+severity: WARNING
+```
+
 ## Command line example
 
 Sample pattern: `exec(...)`

--- a/docs/experiments/generic-pattern-matching.md
+++ b/docs/experiments/generic-pattern-matching.md
@@ -4,6 +4,11 @@ description: "Semgrep can match matches generic patterns in languages that it do
 ---
 
 # Generic pattern matching
+
+<!-- If you ever need to replace the examples below, a good way is to look
+     into the semgrep-rules repo under "generic" for an existing rule
+     that makes sense. -->
+
 ## Introduction
 Semgrep can match matches generic patterns in languages that it doesn’t yet support. You can use generic pattern matching for languages that don’t yet have a parser, configuration files, and other structured data such as XML. Generic pattern matching is experimental.
 

--- a/docs/experiments/generic-pattern-matching.md
+++ b/docs/experiments/generic-pattern-matching.md
@@ -86,7 +86,7 @@ Generic pattern matching has the following properties:
 * Common ASCII braces `()`, `[]`, and `{}` introduce secondary nesting but only within single lines. Therefore, misinterpreted or mismatched braces don't disturb the structure of the rest of document.
 * The document must be at least as indented as the pattern: any indentation specified in the pattern must be honored in the document.
 
-## Caveats and limitations
+## Caveats and limitations of generic mode
 
 Generic mode should work fine with any human-readable text, as long as it’s primarily based on ASCII symbols. In practice, it might work great with some languages and less well with others. In general, it’s possible or even easy to write code in weird ways that will prevent generic mode from matching. Note it’s not good for detecting malicious code. For example, in XML one can write `&#x48;&#x65;&#x6C;&#x6C;&#x6F`; instead of `Hello` and this is not something the generic mode would match if the pattern is `Hello`, unlike if it had full XML support.
 

--- a/docs/experiments/generic-pattern-matching.md
+++ b/docs/experiments/generic-pattern-matching.md
@@ -88,7 +88,16 @@ Generic pattern matching has the following properties:
 
 ## Caveats and limitations of generic mode
 
-Generic mode should work fine with any human-readable text, as long as it’s primarily based on ASCII symbols. In practice, it might work great with some languages and less well with others. In general, it’s possible or even easy to write code in weird ways that will prevent generic mode from matching. Note it’s not good for detecting malicious code. For example, in XML one can write `&#x48;&#x65;&#x6C;&#x6C;&#x6F`; instead of `Hello` and this is not something the generic mode would match if the pattern is `Hello`, unlike if it had full XML support.
+Semgrep can reliably understand the syntax of natively [supported languages](/supported-languages/). The generic mode is useful for unsupported languages, consequently bringing specific limitations.
+
+:::caution
+- Generic mode is not good for detecting malicious code.
+- The quality of results in the generic mode can vary depending on the language you use it for.
+:::
+
+The generic mode works fine with any human-readable text, as long as it is primarily based on ASCII symbols. Since the generic mode does not understand the syntax of the language you are scanning, the quality of the result may differ from language to language or even depend on specific code. As a consequence, the generic mode works well for some languages, but it does not give consistent results always. Generally, it's possible or even easy to write code in weird ways that prevent generic mode from matching. Note generic mode is not good for detecting malicious code.
+
+**Example**: In XML, one can write `&#x48;&#x65;&#x6C;&#x6C;&#x6F` instead of `Hello`. If a rule pattern in generic mode is `Hello`, Semgrep is unable to match the `&#x48;&#x65;&#x6C;&#x6C;&#x6F`, unlike if it had full XML support.
 
 With respect to Semgrep operators and features:
 

--- a/docs/experiments/generic-pattern-matching.md
+++ b/docs/experiments/generic-pattern-matching.md
@@ -79,7 +79,7 @@ server {
 Generic pattern matching has the following properties:
 
 * A document is interpreted as a nested sequence of ASCII words, ASCII punctuation, and other bytes.
-* `...` allows skipping non-matching elements, up to 10 lines down the last match.
+* `...` (ellipsis operator) allows skipping non-matching elements, up to 10 lines down the last match.
 * `$X` (metavariable) matches any word.
 * `$...X` (ellipsis metavariable) matches a sequence of words, up to 10 lines down the last match.
 * Indentation determines primary nesting in the document.


### PR DESCRIPTION
I wasn't sure about the internal link so I used the full URL https://semgrep.dev/docs/writing-rules/rule-syntax/#options. Maybe an internal link is better (= less likely to change when the server name changes).

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
