### PR TITLE
Sara/mkt 416 fill docs with tags

### DIFF
--- a/docs/semgrep-app/dashboard.md
+++ b/docs/semgrep-app/dashboard.md
@@ -6,6 +6,7 @@ description: "The Dashboard is a summary view within Semgrep App to help securit
 tags:
     - Semgrep App
     - Community Tier
+    - Team & Enterprise Tier
 hide_title: true
 ---
 

--- a/docs/semgrep-app/editor.md
+++ b/docs/semgrep-app/editor.md
@@ -1,14 +1,27 @@
 ---
 slug: editor 
 append_help_link: true
-title: Editor 
+title: Editor
+hide_title: true
+tags:
+    - Semgrep App
+    - Community Tier
+    - Team & Enterprise Tier
 description: "Semgrep Editor is a powerful tool within Semgrep App to author rules and quickly apply these rules across an organization to enforce coding standards across an organization."
 ---
 
+<ul id="tag__badge-list">
+{
+Object.entries(frontMatter).filter(
+    frontmatter => frontmatter[0] === 'tags')[0].pop().map(
+    (value) => <li class='tag__badge-item'>{value}</li> )
+}
+</ul>
+
 import MoreHelp from "/src/components/MoreHelp"
 
-# Writing rules using Semgrep Editor
 
+# Writing rules using Semgrep Editor
 
 ![Screenshot of the Editor's splash screen](/img/editor-splashscreen.png)
 

--- a/docs/semgrep-app/findings.md
+++ b/docs/semgrep-app/findings.md
@@ -3,9 +3,22 @@ slug: findings
 append_help_link: true
 title: Findings
 description: "The Findings page allows users to view, manage, and triage Findings."
+hide_title: true
+tags:
+    - Semgrep App
+    - Community Tier
+    - Team & Enterprise Tier
 ---
 
 import MoreHelp from "/src/components/MoreHelp"
+
+<ul id="tag__badge-list">
+{
+Object.entries(frontMatter).filter(
+    frontmatter => frontmatter[0] === 'tags')[0].pop().map(
+    (value) => <li class='tag__badge-item'>{value}</li> )
+}
+</ul>
 
 # Managing findings in Semgrep App
 

--- a/docs/semgrep-app/getting-started-with-semgrep-app.md
+++ b/docs/semgrep-app/getting-started-with-semgrep-app.md
@@ -2,10 +2,25 @@
 slug: getting-started-with-semgrep-app
 append_help_link: true
 title: Getting started with Semgrep App
+hide_title: true
 description: "Get started with Semgrep App to scan for security vulnerabilities on both local and remote repositories hosted on GitHub and GitLab."
+tags:
+    - Semgrep App
+    - Community Tier
+    - Team & Enterprise Tier
 ---
 
 import MoreHelp from "/src/components/MoreHelp"
+
+<ul id="tag__badge-list">
+{
+Object.entries(frontMatter).filter(
+    frontmatter => frontmatter[0] === 'tags')[0].pop().map(
+    (value) => <li class='tag__badge-item'>{value}</li> )
+}
+</ul>
+
+# Getting started with Semgrep App
 
 Semgrep App supports code scanning from:
 

--- a/docs/semgrep-app/integrations.md
+++ b/docs/semgrep-app/integrations.md
@@ -2,11 +2,24 @@
 slug: integrations
 append_help_link: true
 title: Integrations
+hide_title: true
 description: "Semgrep App contains 3rd party integrations to allow users to add data from Semgrep to other tools that are part of their workflows."
+tags:
+    - Semgrep App
+    - Community Tier
+    - Team & Enterprise Tier
 ---
 
 import MoreHelp from "/src/components/MoreHelp"
 import ProcedureIntegrateSlack from "/src/components/procedure/_integrate-slack.mdx"
+
+<ul id="tag__badge-list">
+{
+Object.entries(frontMatter).filter(
+    frontmatter => frontmatter[0] === 'tags')[0].pop().map(
+    (value) => <li class='tag__badge-item'>{value}</li> )
+}
+</ul>
 
 # Integrating Semgrep App with third-party tools
 

--- a/docs/semgrep-app/notifications.md
+++ b/docs/semgrep-app/notifications.md
@@ -1,11 +1,25 @@
 ---
 slug: notifications
 append_help_link: true
+title: Notifications
+hide_title: true
 description: "Semgrep CI integrates with 3rd party services when connected to Semgrep App. Learn how to get Slack or email alerts about findings and failures, how to get merge or pull request comments in your CI/CD pipeline, or how to integrate using webhooks."
+tags:
+    - Semgrep App
+    - Community Tier
+    - Team & Enterprise Tier
 ---
 
 import MoreHelp from "/src/components/MoreHelp"
 import ProcedureIntegrateSlack from "/src/components/procedure/_integrate-slack.mdx"
+
+<ul id="tag__badge-list">
+{
+Object.entries(frontMatter).filter(
+    frontmatter => frontmatter[0] === 'tags')[0].pop().map(
+    (value) => <li class='tag__badge-item'>{value}</li> )
+}
+</ul>
 
 # Notifications
 

--- a/docs/semgrep-app/pricing-and-billing.mdx
+++ b/docs/semgrep-app/pricing-and-billing.mdx
@@ -3,10 +3,21 @@ slug: pricing-and-billing
 append_help_link: true
 title: Pricing and billing
 description: "Semgrep CLI and CI are free to use. Semgrep App has both free and paid tiers, each with their own features and levels of support."
+tags:
+    - Semgrep App
+    - Community Tier
+    - Team & Enterprise Tier
 ---
 
 import MoreHelp from "/src/components/MoreHelp"
 
+<ul id="tag__badge-list">
+{
+Object.entries(frontMatter).filter(
+    frontmatter => frontmatter[0] === 'tags')[0].pop().map(
+    (value) => <li class='tag__badge-item'>{value}</li> )
+}
+</ul>
 
 # Pricing and billing
 

--- a/docs/semgrep-app/rule-board.md
+++ b/docs/semgrep-app/rule-board.md
@@ -1,10 +1,24 @@
 ---
 slug: rule-board
 append_help_link: true
+title: Rule board
+hide_title: true
 description: "The Rule Board is a visual representation of the rules that Semgrep App uses to scan code. Rules are cards, and are grouped into columns representing the actions undertaken (whether to block, comment, or silently monitor) when a finding surfaces."
+tags:
+    - Semgrep App
+    - Community Tier
+    - Team & Enterprise Tier
 ---
 
 import MoreHelp from "/src/components/MoreHelp"
+
+<ul id="tag__badge-list">
+{
+Object.entries(frontMatter).filter(
+    frontmatter => frontmatter[0] === 'tags')[0].pop().map(
+    (value) => <li class='tag__badge-item'>{value}</li> )
+}
+</ul>
 
 # Rule board
 

--- a/docs/semgrep-app/scm.md
+++ b/docs/semgrep-app/scm.md
@@ -4,9 +4,20 @@ append_help_link: true
 title: Integrating Semgrep into source code management (SCM) tools
 description: "Integrate Semgrep into self-hosted and custom SCM tools such as GitHub Enterprise and GitLab Self Hosted."
 hide_title: true
+tags:
+    - Semgrep App
+    - Enterprise Tier
 ---
 
 import MoreHelp from "/src/components/MoreHelp"
+
+<ul id="tag__badge-list">
+{
+Object.entries(frontMatter).filter(
+    frontmatter => frontmatter[0] === 'tags')[0].pop().map(
+    (value) => <li class='tag__badge-item'>{value}</li> )
+}
+</ul>
 
 # Integrating Semgrep into source code management (SCM) tools
 
@@ -14,7 +25,6 @@ Semgrep App's Team and Enterprise tiers support repositories hosted on **GitHub 
 
 :::note
 This document covers the enablement of features for GitHub Enterprise **Server** plans. For users of GitHub Enterprise **Cloud** plans, see [Getting started with Semgrep App](/docs/semgrep-app/getting-started-with-semgrep-app).
-
 :::
 
 ## Prerequisites
@@ -30,7 +40,6 @@ You need the following permissions to integrate Semgrep into GHE Server or GLSM 
 Semgrep App requires PATs with assigned scopes. These scopes grant necessary permissions to the PAT and vary depending on the user's SCM.
 
 | GitHub Enterprise Server          | GitLab Self-Managed        |
-
 |:---------------------------|:---------------------------|
 | <ul><li>`public_repo`</li> <li>`repo:status`</li> <li>`user:email`</li> <li>`write:discussion`</li></ul> | `api` |
 

--- a/docs/semgrep-app/semgrep-api.md
+++ b/docs/semgrep-app/semgrep-api.md
@@ -7,7 +7,7 @@ description: >-
   This document links to Semgrep API documentation.
 tags:
     - Semgrep App
-    - Team & Enterprise Tier
+    - Enterprise Tier
 ---
 
 <ul id="tag__badge-list">

--- a/docs/semgrep-app/semgrep-api.md
+++ b/docs/semgrep-app/semgrep-api.md
@@ -7,7 +7,7 @@ description: >-
   This document links to Semgrep API documentation.
 tags:
     - Semgrep App
-    - Enterprise Tier
+    - Team & Enterprise Tier 
 ---
 
 <ul id="tag__badge-list">

--- a/docs/semgrep-app/semgrep-api.md
+++ b/docs/semgrep-app/semgrep-api.md
@@ -1,9 +1,22 @@
 ---
 slug: semgrep-api
 append_help_link: true
+title: Semgrep API
+hide_title: true
 description: >-
   This document links to Semgrep API documentation.
+tags:
+    - Semgrep App
+    - Team & Enterprise Tier
 ---
+
+<ul id="tag__badge-list">
+{
+Object.entries(frontMatter).filter(
+    frontmatter => frontmatter[0] === 'tags')[0].pop().map(
+    (value) => <li class='tag__badge-item'>{value}</li> )
+}
+</ul>
 
 # Semgrep API
 

--- a/docs/semgrep-app/sso.md
+++ b/docs/semgrep-app/sso.md
@@ -2,11 +2,24 @@
 slug: sso
 append_help_link: true
 description: "SSO Configuration instruction"
+title: Single-sign on (SSO) configuration
+hide_title: true
+tags:
+    - Semgrep App
+    - Team & Enterprise Tier
 ---
+
+<ul id="tag__badge-list">
+{
+Object.entries(frontMatter).filter(
+    frontmatter => frontmatter[0] === 'tags')[0].pop().map(
+    (value) => <li class='tag__badge-item'>{value}</li> )
+}
+</ul>
 
 import MoreHelp from "/src/components/MoreHelp"
 
-# SSO Configuration
+#  Single-sign on (SSO) configuration
 
 **SSO (single sign-on)** is a **Team/Enterprise tier feature**. Semgrep supports [OAuth2/OIDC](#oauth2oidc) and [SAML 2.0](#saml-20).
 

--- a/docs/semgrep-app/user-management.md
+++ b/docs/semgrep-app/user-management.md
@@ -2,8 +2,21 @@
 slug: user-management 
 append_help_link: true
 title: Managing users and roles 
+hide_title: true
 description: "Learn about roles, user management, and how to implement role-based access control in Semgrep App."
+tags:
+    - Semgrep App
+    - Community Tier
+    - Team & Enterprise Tier
 ---
+
+<ul id="tag__badge-list">
+{
+Object.entries(frontMatter).filter(
+    frontmatter => frontmatter[0] === 'tags')[0].pop().map(
+    (value) => <li class='tag__badge-item'>{value}</li> )
+}
+</ul>
 
 import MoreHelp from "/src/components/MoreHelp"
 

--- a/docs/semgrep-ci/configuration-reference.md
+++ b/docs/semgrep-ci/configuration-reference.md
@@ -1,12 +1,23 @@
 ---
 slug: configuration-reference
 description: "Reference for running Semgrep CI in your CI job or on the command line. Learn how to select rules to scan with, enable diff-aware scanning, connect to Semgrep App, and more."
+tags:
+    - Semgrep in CI
+    - Community Tier
 title: CI configuration reference
 hide_title: true
 ---
 
 import MoreHelp from "/src/components/MoreHelp"
 import BlockFindingsErrorsConfigs from '/src/components/reference/_block-findings-errors-configs.mdx'
+
+<ul id="tag__badge-list">
+{
+Object.entries(frontMatter).filter(
+    frontmatter => frontmatter[0] === 'tags')[0].pop().map(
+    (value) => <li class='tag__badge-item'>{value}</li> )
+}
+</ul>
 
 # Continuous Integration (CI) configuration reference
 

--- a/docs/semgrep-ci/overview.md
+++ b/docs/semgrep-ci/overview.md
@@ -2,11 +2,22 @@
 slug: overview
 append_help_link: true
 description: "Semgrep can run CI environments. It can either be used stand-alone or connected with Semgrep App for centralized rule and findings management."
-hide_title: true
+tags:
+    - Semgrep in CI
+    - Community Tier
 title: Getting started with Semgrep in CI 
+hide_title: true
 ---
 
 import MoreHelp from "/src/components/MoreHelp"
+
+<ul id="tag__badge-list">
+{
+Object.entries(frontMatter).filter(
+    frontmatter => frontmatter[0] === 'tags')[0].pop().map(
+    (value) => <li class='tag__badge-item'>{value}</li> )
+}
+</ul>
 
 # Getting started with Semgrep in continuous integration (CI)
 

--- a/docs/semgrep-ci/running-semgrep-ci-with-semgrep-app.md
+++ b/docs/semgrep-ci/running-semgrep-ci-with-semgrep-app.md
@@ -2,6 +2,9 @@
 slug: running-semgrep-ci-with-semgrep-app
 append_help_link: true
 description: "Run Semgrep CI with Semgrep App to manage findings and rules from a centralized dashboard as well as receive notifications in various channels."
+tags:
+    - Semgrep in CI
+    - Community Tier
 title: Running Semgrep in CI with Semgrep App
 hide_title: true
 ---
@@ -11,6 +14,14 @@ import CiScheduling from "/src/components/reference/_ci-scheduling.mdx"
 import CiIgnoringFiles from "/src/components/reference/_ci-ignoring-files.mdx"
 import DiffAwareScanning from "/src/components/reference/_diff-aware-scanning.mdx"
 import RuleBoard from "/src/components/reference/_rule-board.md"
+
+<ul id="tag__badge-list">
+{
+Object.entries(frontMatter).filter(
+    frontmatter => frontmatter[0] === 'tags')[0].pop().map(
+    (value) => <li class='tag__badge-item'>{value}</li> )
+}
+</ul>
 
 # Running Semgrep in continuous integration (CI) with Semgrep App
 

--- a/docs/semgrep-ci/running-semgrep-ci-without-semgrep-app.md
+++ b/docs/semgrep-ci/running-semgrep-ci-without-semgrep-app.md
@@ -3,10 +3,21 @@ slug: running-semgrep-ci-without-semgrep-app
 append_help_link: true
 title: Running Semgrep in CI without Semgrep App 
 description: "This document guides you through setting up semgrep in continuous integration without connecting to Semgrep App."
+tags:
+    - Semgrep in CI
+    - Community Tier
 hide_title: true
 ---
 
 import MoreHelp from "/src/components/MoreHelp"
+
+<ul id="tag__badge-list">
+{
+Object.entries(frontMatter).filter(
+    frontmatter => frontmatter[0] === 'tags')[0].pop().map(
+    (value) => <li class='tag__badge-item'>{value}</li> )
+}
+</ul>
 
 # Running Semgrep in continuous integration (CI) without Semgrep App
 

--- a/docs/semgrep-ci/sample-ci-configs.md
+++ b/docs/semgrep-ci/sample-ci-configs.md
@@ -2,7 +2,20 @@
 slug: sample-ci-configs
 append_help_link: true
 description: "The sample configuration files below run Semgrep CI on continuous integration platforms such as GitHub, GitLab, Jenkins, Buildkite, CircleCI, and other providers."
+title: Sample CI configurations
+hide_title: true
+tags:
+    - Semgrep in CI
+    - Community Tier
 ---
+
+<ul id="tag__badge-list">
+{
+Object.entries(frontMatter).filter(
+    frontmatter => frontmatter[0] === 'tags')[0].pop().map(
+    (value) => <li class='tag__badge-item'>{value}</li> )
+}
+</ul>
 
 import MoreHelp from "/src/components/MoreHelp"
 

--- a/docs/troubleshooting/gitlab-sast.md
+++ b/docs/troubleshooting/gitlab-sast.md
@@ -1,12 +1,25 @@
 ---
 slug: gitlab-sast
+title: Troubleshooting GitLab SAST
+hide_title: true
 description: >-
   GitLab SAST includes an analyzer that runs Semgrep.
   Fix issues with semgrep-sast jobs running slowly,
   not showing results, or erroring.
+tags:
+    - Semgrep in CI
+    - Community Tier
 ---
 
 import MoreHelp from "/src/components/MoreHelp"
+
+<ul id="tag__badge-list">
+{
+Object.entries(frontMatter).filter(
+    frontmatter => frontmatter[0] === 'tags')[0].pop().map(
+    (value) => <li class='tag__badge-item'>{value}</li> )
+}
+</ul>
 
 # Troubleshooting GitLab SAST
 

--- a/docs/troubleshooting/semgrep-app.md
+++ b/docs/troubleshooting/semgrep-app.md
@@ -1,9 +1,25 @@
 ---
 slug: semgrep-app
 description: "Not seeing what you expect in Semgrep App? Follow these troubleshooting steps or find out how to get one-on-one help."
+title: Troubleshooting Semgrep App
+hide_title: true
+tags:
+    - Semgrep App
+    - Community Tier
+    - Team & Enterprise Tier
+
 ---
 
 import MoreHelp from "/src/components/MoreHelp"
+
+<ul id="tag__badge-list">
+{
+Object.entries(frontMatter).filter(
+    frontmatter => frontmatter[0] === 'tags')[0].pop().map(
+    (value) => <li class='tag__badge-item'>{value}</li> )
+}
+</ul>
+
 
 # Troubleshooting Semgrep App
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -304,6 +304,7 @@ a.navbar__item.navbar__link:hover {
   margin-top: 0 !important;
   text-transform: uppercase;
   font-weight: 600;
+  font-size: 0.8rem;
 }
 
 .tag__badge-item:not(:last-child):after {


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs


This change adds tags to CI and App sections in docs, the two most affected by paid/free tiers. Will continue our incremental rollout of tags in the coming weeks.

![2022-09-09 03_15](https://user-images.githubusercontent.com/20766840/189207179-4c2efd23-f198-4e16-b292-2e69b8ea4ccc.png)
