### PR TITLE
add modules to ci guide and move admonition for diffaware scanning to…

### DIFF
--- a/docs/semgrep-ci/running-semgrep-ci-without-semgrep-app.md
+++ b/docs/semgrep-ci/running-semgrep-ci-without-semgrep-app.md
@@ -11,6 +11,9 @@ hide_title: true
 ---
 
 import MoreHelp from "/src/components/MoreHelp"
+import DiffAwareScanning from "/src/components/reference/_diff-aware-scanning.mdx"
+import CiScheduling from "/src/components/reference/_ci-scheduling.mdx"
+import CiIgnoringFiles from "/src/components/reference/_ci-ignoring-files.mdx"
 
 <ul id="tag__badge-list">
 {
@@ -392,31 +395,11 @@ Refer to [Semgrep exit codes](/docs/cli-reference/#exit-codes) to understand var
 
 ### Diff-aware scanning
 
-To enable diff-aware scanning, Semgrep provides a `SEMGREP_BASELINE_REF` environment variable that users can set with the **commit hash** or **branch name** as the baseline. For example, given a repository with 10 commits, setting `SEMGREP_BASELINE_REF` to the 8th commit will return results introduced by changes in the 9th and 10th commit.
-
-To only report findings newly added since branching off from your `main` branch, set the following:
-<pre class="language-bash"><code>SEMGREP_BASELINE_REF=<span className="placeholder">TOPIC-BRANCH-NAME</span></code></pre>
-
-To only report findings newly added after a specific commit, set the following:
-<pre class="language-bash"><code>SEMGREP_BASELINE_REF=<span className="placeholder">INSERT_GIT_COMMIT_HASH</span></code></pre>
-
-:::note
-* GitHub Actions and GitLab CI/CD diff-aware scanning works automatically, without the need to set `SEMGREP_BASELINE_REF`.
-* Depending on your CI provider, it may be necessary to create a separate job or script block for Semgrep to perform both full scans and diff-aware scans.
-:::
+<DiffAwareScanning />
 
 ### Setting a scan schedule
 
-The following table is a summary of methods and resources to set up schedules for different CI providers.
-
-| CI provider | Where to set schedule | Resource |
-| ----------- | --------------------  | -------  |
-| GitHub Actions | Within `semgrep.yml` file | [Sample code snippet](#github-actions-code-snippet) |
-| GitLab CI/CD | Within GitLab CI/CD interface |[Official documentation](https://docs.gitlab.com/ee/ci/pipelines/schedules.html) |
-| Jenkins | Within Jenkins interface |  [Official documentation](https://www.jenkins.io/doc/book/pipeline/running-pipelines/#scheduling-jobs-in-jenkins) |
-| BitBucket Pipelines | Within BitBucket Pipelines interface | [Official documentation](https://support.atlassian.com/bitbucket-cloud/docs/pipeline-triggers/) |
-| CircleCI | Within CircleCI interface | [Official documentation](https://circleci.com/docs/scheduled-pipelines#get-started-with-scheduled-pipelines-in-circleci) |
-| Buildkite | Within Buildkite interface | [Official documentation](https://buildkite.com/docs/pipelines/scheduled-builds) |
+<CiScheduling />
 
 ### Customizing rules and rulesets
 
@@ -464,17 +447,7 @@ See [Writing rules](https://semgrep.dev/docs/writing-rules/overview/) to learn h
 
 ### Ignoring files
 
-By default `semgrep ci` skips files and directories such as `tests/`, `node_modules/`, and `vendor/`. It uses the default `.semgrepignore` file which you can find in the [Semgrep GitHub repository](https://github.com/returntocorp/semgrep/blob/develop/.semgrepignore). This default is used when no explicit `.semgrepignore` file is found in the root of your repository.
-
-You can copy and commit the default `.semgrepignore` file to the **root of your repository** and extend it with your own entries or write one from scratch. If Semgrep detects a `.semgrepignore` file within your repository, it does not append entries from the default `.semgrepignore` file.
-
-For a complete example, see the [.semgrepignore file on Semgrep’s source code](https://github.com/returntocorp/semgrep/blob/develop/.semgrepignore).
-
-:::caution
-`.semgrepignore` is only used by Semgrep CI and the Semgrep command line tool. Integrations such as [GitLab's Semgrep SAST Analyzer](https://gitlab.com/gitlab-org/security-products/analyzers/semgrep) do not use it.
-:::
-
-For information on ignoring individual findings in code, see the [Ignoring findings page](https://semgrep.dev/docs/ignoring-findings/).
+<CiIgnoringFiles />
 
 ### Saving or exporting findings to a file
 

--- a/src/components/reference/_ci-scheduling.mdx
+++ b/src/components/reference/_ci-scheduling.mdx
@@ -8,4 +8,4 @@ The following table is a summary of methods and resources to set up schedules fo
 | BitBucket Pipelines | Within BitBucket Pipelines interface | [Official documentation](https://support.atlassian.com/bitbucket-cloud/docs/pipeline-triggers/) |
 | CircleCI | Within CircleCI interface | [Official documentation](https://circleci.com/docs/scheduled-pipelines#get-started-with-scheduled-pipelines-in-circleci) |
 | Buildkite | Within Buildkite interface | [Official documentation](https://buildkite.com/docs/pipelines/scheduled-builds) |
-| Azure Piplines | Within Pipelines interface (recommended) | [Official documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers?view=azure-devops&tabs=yaml) |
+| Azure Pipelines | Within Pipelines interface (recommended) | [Official documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers?view=azure-devops&tabs=yaml) |

--- a/src/components/reference/_diff-aware-scanning.mdx
+++ b/src/components/reference/_diff-aware-scanning.mdx
@@ -1,3 +1,10 @@
+:::info
+* Diff-aware scanning is automatically configured for GitHub Actions and GitLab CI/CD when the user runs Semgrep on PR or MR events. Do **not** set `SEMGREP_BASELINE_REF` for GitHub Actions or GitLab CI/DD.
+* For other CI providers, Semgrep App provides a full scan configuration by default. You can set up both diff-aware scanning and full scans through either of the following:
+    * Create separate jobs for diff-aware scans and full scans.
+    * If your CI provider supports conditional statements, use an if/then statement that detects the presence of `SEMGREP_BASELINE_REF`. 
+:::
+
 Semgrep scans can be classified by scope. The scope of a scan refers to what lines of code are scanned in a codebase. When classifying scans by scope, there are two types of scans:
 
 <dl>
@@ -11,12 +18,6 @@ Semgrep scans can be classified by scope. The scope of a scan refers to what lin
 ![Flow chart of Semgrep code scanning behavior based on environment variable](/img/diagram-semgrep_baseline_ref.png "Flow chart of Semgrep code scanning behavior based on environment variable")
 
 
-:::info
-* Diff-aware scanning is automatically configured for GitHub Actions and GitLab CI/CD through the snippets provided by Semgrep App. Do **not** set `SEMGREP_BASELINE_REF` for GitHub Actions or GitLab CI/DD.
-* For other CI providers, Semgrep App provides a full scan configuration by default. You can set up both diff-aware scanning and full scans through either of the following:
-    * Create separate jobs for diff-aware scans and full scans.
-    * If your CI provider supports conditional statements, use an if/then statement that detects the presence of `SEMGREP_BASELINE_REF`. 
-:::
 
 :::caution
 * Do **not** perform diff-aware scans on your `main` branch. Semgrep App keeps track of which findings have been fixed on a given branch. If you configure diff-aware scans on your main branch, and compare the last commit to the penultimate commit, Semgrep wrongly considers all findings from before the penultimate commit to be fixed.


### PR DESCRIPTION
… top

# Thanks for improving Semgrep Docs 😀

### Please ensure

n/a A subject matter expert (SME) reviews the content

- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team


* The "Semgrep CI with App" guide has modules, but I wasn't able to add them to "Semgrep CI without App". This Pull Request fixes that.
* Note from [slack channel](https://r2c-community.slack.com/archives/C0242656NQ2/p1663331634459449?thread_ts=1663269140.296079&cid=C0242656NQ2) informed me that people were missing the admonition/callout for diff-aware scans because it's at the end, so I bumped it to the beginning.