### PR TITLE
Added import of secure_eval in detect-eval.py

### DIFF
--- a/docs/writing-rules/testing-rules.md
+++ b/docs/writing-rules/testing-rules.md
@@ -69,7 +69,7 @@ rules:
 Given the above is named `rules/detect-eval.yaml`, you can create `rules/detect-eval.py`:
 
 ```python
-from lib import get_user_input, safe_get_user_input
+from lib import get_user_input, safe_get_user_input, secure_eval
 
 user_input = get_user_input()
 # ruleid: insecure-eval-use


### PR DESCRIPTION
If we do not import secure_eval in detect-eval.py, then there will be a difference between detect-eval.py and detect-eval.fixed.py. This would result in the following out of the command `semgrep --test --config tests/rules/ tests/targets/`:

```
1/1: ✓ All tests passed
0/1: 1 fix tests did not pass:
--------------------------------------------------------------------------------
	✖ tests/targets/python/detect-eval.fixed.py <> autofix applied to tests/targets/python/detect-eval.py

	---
	+++
	@@ -1 +1 @@
	-from lib import get_user_input, safe_get_user_input, secure_eval
	+from lib import get_user_input, safe_get_user_input
```

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
