### PR TITLE
Fix typo in Nginx location sample

### DIFF
--- a/docs/experiments/generic-pattern-matching.md
+++ b/docs/experiments/generic-pattern-matching.md
@@ -66,7 +66,7 @@ server {
 
   location ~ /proxy/(.*)/(.*)/(.*)$ {
     # ok: dynamic-proxy-scheme
-    proxy_pass http://$2/$3/$1;
+    proxy_pass http://$1/$2/$3;
   }
 
   location ~ /proxy/(.*)/(.*)/(.*)$ {


### PR DESCRIPTION
This PR fixes a minor typo in the Nginx doc.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [X] A subject matter expert (SME) reviews the content
- [N/A] A technical writer reviews the content or PR
- [X] This change has no security implications or else you have pinged the security team
- [N/A] Redirects are added if the PR changes page URLs
