### PR TITLE
Remove the 'Integrating Semgrep with webhooks link

### DIFF
--- a/docs/semgrep-app/integrations.md
+++ b/docs/semgrep-app/integrations.md
@@ -139,7 +139,6 @@ Here is a sample of a webhook sent from Semgrep with findings:
 ## See also
 
 * [Notifications -> Webhooks](notifications.md/#webhooks)
-* [Integrating Semgrep with webhooks](https://support.semgrep.dev/hc/en-us/articles/4415975269275-Integrating-Semgrep-with-Webhooks)
 
 <!---
 ### Amazon S3


### PR DESCRIPTION
With the deprecation of Zendesk on our side this link should also be removed from the docs as it is also deprecated. 

* [Integrating Semgrep with webhooks](https://support.semgrep.dev/hc/en-us/articles/4415975269275-Integrating-Semgrep-with-Webhooks)

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
