### PR TITLE
Update sample-ci-configs.md

### DIFF
--- a/docs/semgrep-ci/sample-ci-configs.md
+++ b/docs/semgrep-ci/sample-ci-configs.md
@@ -607,7 +607,7 @@ These steps can also be performed through BitBucket's UI wizard. This UI wizard 
       - parallel:
         - step:
             name: 'Run Semgrep scan with current branch'
-            deployment: dev
+            deployment: dev # https://support.atlassian.com/bitbucket-cloud/docs/set-up-and-monitor-deployments/
             image: returntocorp/semgrep
             script:
               # The following variables are required to set up a Semgrep App-connected scan:
@@ -615,8 +615,9 @@ These steps can also be performed through BitBucket's UI wizard. This UI wizard 
 
               # Uncomment the following line to scan changed 
               # files in PRs or MRs (diff-aware scanning): 
-              # - export SEMGREP_BASELINE_REF = "main"
-
+              # - export SEMGREP_BASELINE_REF = "origin/main"
+              # - git fetch origin "+refs/heads/*:refs/remotes/origin/*"
+    
               # Optional:
               # Uncomment SEMGREP_TIMEOUT to set this job's timeout (in seconds).
               # Default timeout is 1800 seconds (30 minutes).


### PR DESCRIPTION
Bitbucket pipelines only clone the specific branch: https://stackoverflow.com/questions/42886031/how-can-i-diff-two-git-branches-in-bitbucket-pipeline

To perform a diff scan, the following `git` command needs to be added:
```console
$ git fetch origin "+refs/heads/*:refs/remotes/origin/*"
```

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
