### PR TITLE
Fix sample-ci-configs.md's uploading findings file

### DIFF
--- a/docs/semgrep-ci/sample-ci-configs.md
+++ b/docs/semgrep-ci/sample-ci-configs.md
@@ -207,7 +207,7 @@ To add a Semgrep configuration file in your GitHub Actions pipeline:
         # Fetch project source with GitHub Actions Checkout.
         - uses: actions/checkout@v3
         # Run the "semgrep ci" command on the command line of the docker image.
-        - run: semgrep ci
+        - run: semgrep ci --sarif --output=semgrep.sarif
           env:
             # Connect to Semgrep App through your SEMGREP_APP_TOKEN.
             # Generate a token from Semgrep App > Settings
@@ -261,7 +261,7 @@ To add a Semgrep configuration file in your GitHub Actions pipeline:
         # Fetch project source with GitHub Actions Checkout.
         - uses: actions/checkout@v3
         # Run the "semgrep ci" command on the command line of the docker image.
-        - run: semgrep ci
+        - run: semgrep ci --sarif --output=semgrep.sarif
           env:
              # Add the rules that Semgrep uses by setting the SEMGREP_RULES environment variable. 
              SEMGREP_RULES: p/default # more at semgrep.dev/explore


### PR DESCRIPTION
Fixed the ["Alternate job that uploads findings to GitHub Advanced Security Dashboard"](https://semgrep.dev/docs/semgrep-ci/sample-ci-configs/#github-actions) sample CI files to actually upload the SARIF files to the dashboard. With the current command they do not upload any findings as a SARIF file is never created. This is to be more inline with: 

https://semgrep.dev/docs/semgrep-ci/running-semgrep-ci-with-semgrep-app/#setting-up-security-dashboards-for-github-and-gitlab 

GitHub file which does upload the findings.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
