### PR TITLE
Split overview of Experiments category to Autofix and Deprecated experiments, add introduction

### DIFF
--- a/docs/experiments/autofix.md
+++ b/docs/experiments/autofix.md
@@ -2,11 +2,7 @@
 append_help_link: true
 ---
 
-# Experiments
-
-This document describes experimental features and how to try them. Have fun, [file bugs](https://github.com/returntocorp/semgrep/issues/new/choose), tweak the code, and most importantly share your thoughts! 
-
-## Autofix
+# Autofix
 
 Hands down the best way to enforce a code standard is to just automatically fix it. Semgrep's rule format supports a `fix:` key that supports metavariable replacement, much like message fields. This allows for value capture and rewriting.
 
@@ -28,7 +24,7 @@ rules:
   severity: WARNING
 ```
 
-### Autofix with regular expression replacement
+## Autofix with regular expression replacement
 
 A variant on the experimental `fix` key is `fix-regex`, which applies regular expression replacements (think `sed`) to matches found by Semgrep.
 
@@ -72,21 +68,3 @@ rules:
 <p align="center">
   <img src="https://web-assets.r2c.dev/inline-autofix-regex.gif" width="100%" alt="Apply Semgrep autofix direclty to a file"/>
 </p>
-
-## Generic pattern matching
-
-See [generic pattern matching](./generic-pattern-matching.md).
-
-## Deprecated experiments
-
-### Equivalences
-
-:::note
-This feature was deprecated in Semgrep v0.61.0.
-:::
-
-Equivalences enable defining equivalent code patterns (i.e. a commutative property: `$X + $Y <==> $Y + $X`). Equivalence rules use the `equivalences` top-level key and one `equivalence` key for each equivalence.
-
-For example:
-
-<iframe src="https://semgrep.dev/embed/editor?snippet=jNnn" border="0" frameBorder="0" width="100%" height="432"></iframe>

--- a/docs/experiments/deprecated-experiments.md
+++ b/docs/experiments/deprecated-experiments.md
@@ -1,0 +1,13 @@
+# Deprecated experiments
+
+## Equivalences
+
+:::note
+This feature was deprecated in Semgrep v0.61.0.
+:::
+
+Equivalences enable defining equivalent code patterns (i.e. a commutative property: `$X + $Y <==> $Y + $X`). Equivalence rules use the `equivalences` top-level key and one `equivalence` key for each equivalence.
+
+For example:
+
+<iframe src="https://semgrep.dev/embed/editor?snippet=jNnn" border="0" frameBorder="0" width="100%" height="432"></iframe>

--- a/docs/experiments/introduction.md
+++ b/docs/experiments/introduction.md
@@ -1,6 +1,6 @@
 ---
-id: introduction-experiments
-slug: introduction-experiments
+id: introduction
+slug: introduction
 title: Introduction
 hide_title: true
 append_help_link: true

--- a/docs/experiments/introduction.md
+++ b/docs/experiments/introduction.md
@@ -7,7 +7,7 @@ append_help_link: true
 description: "Introduction of Semgrep experiments that also documents that some experiments can sunset or become GA, which means that particular documents can change their position in docs also."
 ---
 
-# Introduction to Semgrep Experiments
+# Introduction to Semgrep experiments
 
 The experiments category documents experimental features and the way you can use them. In the future, as it is the nature of experiments, some of these experiments can become deprecated, and others can become generally available (GA), meaning that GA features are fully supported parts of Semgrep. If a feature is deprecated, its documentation is moved to the [Deprecated experiments](/experiments/deprecated-experiments/) document. If a feature becomes GA, its docs are moved to a relevant category outside of the experiments section.
 

--- a/docs/experiments/introduction.md
+++ b/docs/experiments/introduction.md
@@ -1,0 +1,13 @@
+---
+slug: introduction-experiments
+title: Introduction
+hide_title: true
+append_help_link: true
+description: "Introduction of Semgrep experiments that also documents that some experiments can sunset or become GA, which means that particular documents can change their position in docs also."
+---
+
+# Introduction to Semgrep Experiments
+
+The experiments category documents experimental features and the way you can use them. In the future, as it is the nature of experiments, some of these experiments can become deprecated, and others can become generally available (GA), meaning that GA features are fully supported parts of Semgrep. If a feature is deprecated, its documentation is moved to the [Deprecated experiments](/experiments/deprecated-experiments/) document. If a feature becomes GA, its docs are moved to a relevant category outside of the experiments section.
+
+Enjoy the experiments, tweak the code, and most importantly share your thoughts! If you see any issues with the experimental features, please [file a bug](https://github.com/returntocorp/semgrep/issues/new/choose). 

--- a/docs/experiments/introduction.md
+++ b/docs/experiments/introduction.md
@@ -1,4 +1,5 @@
 ---
+id: introduction-experiments
 slug: introduction-experiments
 title: Introduction
 hide_title: true

--- a/docs/semgrep-app/notifications.md
+++ b/docs/semgrep-app/notifications.md
@@ -107,7 +107,7 @@ GitLab MR comments are only available to logged-in Semgrep users, as they requir
 
 ### Automatically fix your findings through pull or merge requests
 
-[Autofix](../experiments/overview.md/#autofix) is a Semgrep feature in which rules contain suggested fixes to resolve findings. Either metavariables or regex matches are replaced with a potential fix. Due to their complexity, not all rules make use of autofix, but for rules that use this feature, autofix allows you to quickly resolve findings as part of your code review workflow. Semgrep App can suggest these fixes through PR or MR comments within GitHub or GitLab, thus integrating seamlessly with your review environment.
+[Autofix](/experiments/autofix) is a Semgrep feature in which rules contain suggested fixes to resolve findings. Either metavariables or regex matches are replaced with a potential fix. Due to their complexity, not all rules make use of autofix, but for rules that use this feature, autofix allows you to quickly resolve findings as part of your code review workflow. Semgrep App can suggest these fixes through PR or MR comments within GitHub or GitLab, thus integrating seamlessly with your review environment.
 
 Autofix is free to use for all tiers.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -188,7 +188,7 @@ module.exports = {
           { from: "/integrations", to: "/semgrep-app/notifications/" },
           { from: "/notifications", to: "/semgrep-app/notifications/" },
           { from: "/sso", to: "/semgrep-app/sso/" },
-          { from: "/experiments", to: "/experiments/overview/" },
+          { from: "/experiments", to: "/experiments/introduction/" },
           { from: "/upgrade", to: "/upgrading/" },
           { from: "/semgrep-ci", to: "/semgrep-ci/overview/" },
           { from: "/sample-ci-configs", to: "/semgrep-ci/sample-ci-configs/" },

--- a/sidebars.js
+++ b/sidebars.js
@@ -49,8 +49,8 @@ module.exports = {
         {
           type: 'category',
           label: 'Experiments 🧪',
-          items: [
-            'experiments/introduction',
+          link: {type: 'doc', id: 'experiments/introduction-experiments'},
+          items: [,
             'experiments/autofix',
             'experiments/generic-pattern-matching',
             { type: 'category',

--- a/sidebars.js
+++ b/sidebars.js
@@ -50,7 +50,7 @@ module.exports = {
           type: 'category',
           label: 'Experiments 🧪',
           items: [
-            'experiments/overview',
+            'experiments/autofix',
             'experiments/generic-pattern-matching',
             { type: 'category',
                 label: 'Join mode',
@@ -70,7 +70,8 @@ module.exports = {
             'experiments/taint-labels',
             'experiments/metavariable-analysis',
             'experiments/multiple-focus-metavariables',
-            'experiments/display-propagated-metavariable'
+            'experiments/display-propagated-metavariable',
+            'experiments/deprecated-experiments'
           ]
         },
         'deepsemgrep',

--- a/sidebars.js
+++ b/sidebars.js
@@ -49,7 +49,7 @@ module.exports = {
         {
           type: 'category',
           label: 'Experiments 🧪',
-          link: {type: 'doc', id: 'experiments/introduction-experiments'},
+          link: {type: 'doc', id: 'experiments/introduction'},
           items: [,
             'experiments/autofix',
             'experiments/generic-pattern-matching',

--- a/sidebars.js
+++ b/sidebars.js
@@ -50,6 +50,7 @@ module.exports = {
           type: 'category',
           label: 'Experiments 🧪',
           items: [
+            'experiments/introduction',
             'experiments/autofix',
             'experiments/generic-pattern-matching',
             { type: 'category',


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
