### PR TITLE
Fix redirects in experimental category and release notes

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -200,7 +200,21 @@ module.exports = {
           { from: "/semgrep-app/role-based-access-control", to: "/semgrep-app/user-management/" },
           { from: "/cli-usage/", to: "/cli-reference/" },
           { from: "/writing-rules/data-flow", to: "/writing-rules/data-flow/data-flow-overview/" },
-          { from: "/writing-rules/data-flow/overview/", to: "/writing-rules/data-flow/data-flow-overview/" }
+          { from: "/release-notes/", to: "/release-notes/introduction/" },
+          { from: "/rule-updates/", to: "/release-notes/rule-updates/" },
+          { from: "/experiments/overview/", to: "/writing-rules/experiments/introduction/" },
+          { from: "/experiments/generic-pattern-matching/", to: "/writing-rules/experiments/generic-pattern-matching/" },
+          { from: "/experiments/join-mode/overview/", to: "/writing-rules/experiments/join-mode/overview/" },
+          { from: "/experiments/join-mode/recursive-joins/", to: "/writing-rules/experiments/join-mode/recursive-joins/" },
+          { from: "/experiments/extract-mode/", to: "/writing-rules/experiments/extract-mode/" },
+          { from: "/experiments/r2c-internal-project-depends-on/", to: "/writing-rules/experiments/r2c-internal-project-depends-on/" },
+          { from: "/experiments/symbolic-propagation/", to: "/writing-rules/experiments/symbolic-propagation/" },
+          { from: "/experiments/taint-propagators/", to: "/writing-rules/experiments/taint-propagators/" },
+          { from: "/experiments/taint-labels/", to: "/writing-rules/experiments/taint-labels/" },
+          { from: "/experiments/metavariable-analysis/", to: "/writing-rules/experiments/metavariable-analysis/" },
+          { from: "/experiments/multiple-focus-metavariables/", to: "/writing-rules/experiments/multiple-focus-metavariables/" },
+          { from: "/experiments/display-propagated-metavariable/", to: "/writing-rules/experiments/display-propagated-metavariable/" },
+          { from: "/experiments/deprecated-experiments/", to: "/writing-rules/experiments/deprecated-experiments/" }
         ]
       }
     ],


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
