### PR TITLE
Updating Semgrep timeout docs

### DIFF
--- a/docs/semgrep-ci/configuration-reference.md
+++ b/docs/semgrep-ci/configuration-reference.md
@@ -115,14 +115,14 @@ export SEMGREP_RULES="p/default no-exec.yml"
 Do not set `SEMGREP_APP_TOKEN` environment variable within the same CI job as `SEMGREP_RULES`.
 :::
 
-### `SEMGREP_TIMEOUT`
+### `DEFAULT_TIMEOUT`
 
-Set `SEMGREP_TIMEOUT` to define a custom timeout. The value must be in seconds. The default value is 1800 seconds (30 minutes).
+Set `DEFAULT_TIMEOUT` to define a custom timeout. The value must be in seconds. The default value is 30 seconds. This timeout refers to the maximum amount of time Semgrep will spend scanning a single file. Dy default, it will attempt to scan each file with this timeout three times; you can control this using `--timeout-threshold`.
 
 Example:
 
 ```bash
-export SEMGREP_TIMEOUT="900"
+export DEFAULT_TIMEOUT="60"
 ```
 
 ## Environment variables for creating hyperlinks in Semgrep App

--- a/docs/semgrep-ci/configuration-reference.md
+++ b/docs/semgrep-ci/configuration-reference.md
@@ -122,7 +122,7 @@ Set `DEFAULT_TIMEOUT` to define a custom timeout. The value must be in seconds. 
 Example:
 
 ```bash
-export DEFAULT_TIMEOUT="60"
+export DEFAULT_TIMEOUT="20"
 ```
 
 ## Environment variables for creating hyperlinks in Semgrep App

--- a/docs/semgrep-ci/configuration-reference.md
+++ b/docs/semgrep-ci/configuration-reference.md
@@ -117,7 +117,7 @@ Do not set `SEMGREP_APP_TOKEN` environment variable within the same CI job as `S
 
 ### `DEFAULT_TIMEOUT`
 
-Set `DEFAULT_TIMEOUT` to define a custom timeout. The value must be in seconds. The default value is 30 seconds. This timeout refers to the maximum amount of time Semgrep will spend scanning a single file. Dy default, it will attempt to scan each file with this timeout three times; you can control this using `--timeout-threshold`.
+Set `DEFAULT_TIMEOUT` to define a custom timeout. The value must be in seconds. The default value is 30 seconds. This timeout refers to the maximum amount of time Semgrep spends scanning a single file. By default, it attempts to scan each file with this timeout three times; you can control this using `--timeout-threshold`.
 
 Example:
 

--- a/docs/semgrep-ci/sample-ci-configs.md
+++ b/docs/semgrep-ci/sample-ci-configs.md
@@ -107,11 +107,7 @@ To add a Semgrep configuration file in your GitHub Actions pipeline:
             # Generate a token from Semgrep App > Settings
             # and add it to your GitHub secrets.
             SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
-  
-            # Uncomment SEMGREP_TIMEOUT to set this job's timeout (in seconds):
-            # Default timeout is 1800 seconds (30 minutes).
-            # Set to 0 to disable the timeout.
-            # SEMGREP_TIMEOUT: 300
+
   ```
 
 </TabItem>
@@ -154,11 +150,6 @@ To add a Semgrep configuration file in your GitHub Actions pipeline:
           env:
              # Add the rules that Semgrep uses by setting the SEMGREP_RULES environment variable. 
              SEMGREP_RULES: p/default # more at semgrep.dev/explore
-
-             # Uncomment SEMGREP_TIMEOUT to set this job's timeout (in seconds):
-             # Default timeout is 1800 seconds (30 minutes).
-             # Set to 0 to disable the timeout.
-             # SEMGREP_TIMEOUT: 300
   ```
 </TabItem>
 </Tabs>
@@ -214,11 +205,6 @@ To add a Semgrep configuration file in your GitHub Actions pipeline:
             # and add it to your GitHub secrets.
             SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
   
-            # Uncomment SEMGREP_TIMEOUT to set this job's timeout (in seconds):
-            # Default timeout is 1800 seconds (30 minutes).
-            # Set to 0 to disable the timeout.
-            # SEMGREP_TIMEOUT: 300
-  
         - name: Upload SARIF file for GitHub Advanced Security Dashboard
           uses: github/codeql-action/upload-sarif@v2
           with:
@@ -266,10 +252,6 @@ To add a Semgrep configuration file in your GitHub Actions pipeline:
              # Add the rules that Semgrep uses by setting the SEMGREP_RULES environment variable. 
              SEMGREP_RULES: p/default # more at semgrep.dev/explore
 
-             # Uncomment SEMGREP_TIMEOUT to set this job's timeout (in seconds):
-             # Default timeout is 1800 seconds (30 minutes).
-             # Set to 0 to disable the timeout.
-             # SEMGREP_TIMEOUT: 300
         - name: Upload SARIF file for GitHub Advanced Security Dashboard
           uses: github/codeql-action/upload-sarif@v2
           with:
@@ -326,9 +308,6 @@ To add a Semgrep configuration snippet in your GitLab CI/CD pipeline:
     # Never fail the build due to findings on pushes.
     # Instead, just collect findings for semgrep.dev/manage/findings
     #   SEMGREP_AUDIT_ON: push
-
-    # Change job timeout (default is 1800 seconds; set to 0 to disable)
-    #   SEMGREP_TIMEOUT: 300
   
     # Receive inline MR comments (requires Semgrep App account)
     # Setup instructions: 
@@ -363,9 +342,6 @@ To add a Semgrep configuration snippet in your GitLab CI/CD pipeline:
     # Never fail the build due to findings on pushes.
     # Instead, just collect findings for semgrep.dev/manage/findings
     #   SEMGREP_AUDIT_ON: push
-
-    # Change job timeout (default is 1800 seconds; set to 0 to disable)
-    #   SEMGREP_TIMEOUT: 300
   ```
 
 </TabItem>
@@ -409,9 +385,6 @@ To add a Semgrep configuration snippet in your GitLab CI/CD pipeline:
     # Never fail the build due to findings on pushes.
     # Instead, just collect findings for semgrep.dev/manage/findings
     #   SEMGREP_AUDIT_ON: push
-
-    # Change job timeout (default is 1800 seconds; set to 0 to disable)
-    #   SEMGREP_TIMEOUT: 300
   
     # Receive inline MR comments (requires Semgrep App account)
     # Setup instructions: 
@@ -455,9 +428,6 @@ To add a Semgrep configuration snippet in your GitLab CI/CD pipeline:
     # Never fail the build due to findings on pushes.
     # Instead, just collect findings for semgrep.dev/manage/findings
     #   SEMGREP_AUDIT_ON: push
-
-    # Change job timeout (default is 1800 seconds; set to 0 to disable)
-    #   SEMGREP_TIMEOUT: 300
   
     # Run the "semgrep ci" command on the command line of the docker image and send findings
     # to GitLab SAST.
@@ -504,12 +474,6 @@ This code snippet uses Jenkins declarative syntax.
         // Uncomment the following line to scan changed 
         // files in PRs or MRs (diff-aware scanning): 
         // SEMGREP_BASELINE_REF = "main"
-  
-        // Optional:
-        // Uncomment SEMGREP_TIMEOUT to set this job's timeout (in seconds).
-        // Default timeout is 1800 seconds (30 minutes).
-        // Set to 0 to disable the timeout.
-        // SEMGREP_TIMEOUT = "300"
 
         // Troubleshooting:
 
@@ -553,12 +517,6 @@ This code snippet uses Jenkins declarative syntax.
         // Uncomment the following line to scan changed 
         // files in PRs or MRs (diff-aware scanning): 
         // SEMGREP_BASELINE_REF = "main"
-  
-        // Optional:
-        // Uncomment SEMGREP_TIMEOUT to set this job's timeout (in seconds).
-        // Default timeout is 1800 seconds (30 minutes).
-        // Set to 0 to disable the timeout.
-        // SEMGREP_TIMEOUT = "300"
       }
       stages {
         stage('Semgrep-Scan') {
@@ -617,12 +575,6 @@ These steps can also be performed through BitBucket's UI wizard. This UI wizard 
               # files in PRs or MRs (diff-aware scanning): 
               # - export SEMGREP_BASELINE_REF = "origin/main"
               # - git fetch origin "+refs/heads/*:refs/remotes/origin/*"
-    
-              # Optional:
-              # Uncomment SEMGREP_TIMEOUT to set this job's timeout (in seconds).
-              # Default timeout is 1800 seconds (30 minutes).
-              # Set to 0 to disable the timeout.
-              # - export SEMGREP_TIMEOUT = "300"
 
               # Troubleshooting:
 
@@ -664,12 +616,6 @@ These steps can also be performed through BitBucket's UI wizard. This UI wizard 
               # Uncomment the following line to scan changed 
               # files in PRs or MRs (diff-aware scanning): 
               # - export SEMGREP_BASELINE_REF = "main"
-
-              # Optional:
-              # Uncomment SEMGREP_TIMEOUT to set this job's timeout (in seconds).
-              # Default timeout is 1800 seconds (30 minutes).
-              # Set to 0 to disable the timeout.
-              # - export SEMGREP_TIMEOUT = "300"
 
               - semgrep ci
   ```
@@ -725,10 +671,6 @@ jobs:
       SEMGREP_REPO_NAME: '$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME'
       SEMGREP_REPO_URL: << pipeline.project.git_url >>
       SEMGREP_BRANCH: << pipeline.git.branch >>
-
-
-    # Change job timeout (default is 1800 seconds; set to 0 to disable)
-    #   SEMGREP_TIMEOUT: 300
 
     docker:
       - image: returntocorp/semgrep


### PR DESCRIPTION
Change to the SEMGREP_TIMEOUT variable, as it was slightly out-of-date in the docs. Update the CI reference to reflect its actual behavior, and removed SEMGREP_TIMEOUT from the sample snippets as it is no longer a flag.
I did add DEFAULT_TIMEOUT into the snippets by default, as since it is not a general timeout for the entire semgrep job, rather a timeout per-file, it seems like less of a general customization and more of a niche tweak one would use if one or a few files happen to be taking too long to scan. Will defer to Emma on if this should be added in the default snippets.

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/50721067/200076800-aef1f63e-704f-4e8e-8bcf-1c9d5348f475.png">





# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x ] This change has no security implications or else you have pinged the security team
- [x ] Redirects are added if the PR changes page URLs

