### PR TITLE
removed vpc from line, specified all github plans, unified messaging …

### DIFF
--- a/docs/semgrep-app/pricing-and-billing.mdx
+++ b/docs/semgrep-app/pricing-and-billing.mdx
@@ -42,9 +42,9 @@ Semgrep App has three tiers:
 
 | Tier | Price | Description |
 | ---- | ------- | -------- |
-| **Community** | Free | For general-purpose security scanning.  |
-| **Team** | US$40 monthly per developer per product | For the enforcement of company-specific coding standards, private rules, and the analysis of findings.  |
-| **Enterprise** | Custom pricing | For custom solutions, including deployment into virtual private clouds (VPCs) with dedicated technical support.  |
+| **Community** | Free | For individuals and small teams that need the essentials to secure their code. |
+| **Team** | US$40 monthly per developer per product | For bigger teams that want to scale their usage and access all features.  |
+| **Enterprise** | Custom pricing | For organizations needing custom features, control, and support. |
 
 Semgrep App integrates with a GitHub or GitLab account at either the organizational or individual level. There is no limit to the number of members in an organization for all tiers.
 
@@ -79,11 +79,13 @@ Notes:
 
 | Feature  | Community | Team | Enterprise |
 | -------  | --------- | ------- | -------- |
-| **GitHub**  | ✔️ yes | ✔️ yes | ✔️  yes |
+| **GitHub Free**  | ✔️ yes | ✔️ yes | ✔️  yes |
+| **GitHub Team** | ✔️ yes | ✔️ yes | ✔️  yes |
+| **GitHub Enterprise Cloud** |  ❌ no  | ✔️ yes | ✔️  yes |
+| **GitHub Enterprise Server** |  ❌ no | ✔️ yes | ✔️  yes |
 | **GitLab SaaS**  | ✔️ yes | ✔️ yes | ✔️  yes |
 | **GitHub Enterprise**  | ❌ no | ✔️  yes | ✔️  yes |
 | **GitLab Self Managed**  | ❌ no | ✔️  yes | ✔️  yes |
-| **VPC deployment** | ❌ no | ❌ no | ✔️  yes |
 
 #### Findings, language support, and rules
 

--- a/docs/semgrep-app/scm.md
+++ b/docs/semgrep-app/scm.md
@@ -6,7 +6,7 @@ description: "Integrate Semgrep into self-hosted and custom SCM tools such as Gi
 hide_title: true
 tags:
     - Semgrep App
-    - Enterprise Tier
+    - Team & Enterprise Tier
 ---
 
 import MoreHelp from "/src/components/MoreHelp"


### PR DESCRIPTION
…from semgrep.dev pricing page into docs

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs

* Correctly tag SCM as a team and enterprise feature
* For pricing and billing:
    * Edit descriptions to fully match semgrep.dev/pricing
    * Remove VPC mentions ([see this thread](https://returntocorp.slack.com/archives/C0370TA46PL/p1667933146656379))
    * Include GHE Cloud and GHE server with explicit support for Team and Enterprise tier only (**not** Community tier).

As this was primarily to align with marketing's positioning, I'm asking for a marketing reviewer @pabloest :) 