### PR TITLE
renamed default_timeout to correct semgrep_timeout

### DIFF
--- a/docs/semgrep-ci/configuration-reference.md
+++ b/docs/semgrep-ci/configuration-reference.md
@@ -115,14 +115,14 @@ export SEMGREP_RULES="p/default no-exec.yml"
 Do not set `SEMGREP_APP_TOKEN` environment variable within the same CI job as `SEMGREP_RULES`.
 :::
 
-### `DEFAULT_TIMEOUT`
+### `SEMGREP_TIMEOUT`
 
-Set `DEFAULT_TIMEOUT` to define a custom timeout. The value must be in seconds. The default value is 30 seconds. This timeout refers to the maximum amount of time Semgrep spends scanning a single file. By default, it attempts to scan each file with this timeout three times; you can control this using `--timeout-threshold`.
+Set `SEMGREP_TIMEOUT` to define a custom timeout. The value must be in seconds. The default value is 30 seconds. This timeout refers to the maximum amount of time Semgrep spends scanning a single file. By default, it attempts to scan each file with this timeout three times; you can control this using `--timeout-threshold`.
 
 Example:
 
 ```bash
-export DEFAULT_TIMEOUT="20"
+export SEMGREP_TIMEOUT="20"
 ```
 
 ## Environment variables for creating hyperlinks in Semgrep App


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
