### PR TITLE
Sara/mkt 440 update descriptions for docs displayed

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,8 +1,12 @@
 ---
 slug: getting-started
 append_help_link: true
-description: "This getting started guides you through the installation of Semgrep, shows you how to run Semgrep locally, and provides an overview of benefits which you may reap by using Semgrep CI."
+description: "Install Semgrep, run Semgrep locally, and learn about the benefits of running Semgrep in CI (continuous integration)."
+title: Getting started with Semgrep CLI
+hide_title: true
 ---
+
+import MoreHelp from "/src/components/MoreHelp"
 
 # Getting started with Semgrep CLI
 
@@ -97,3 +101,5 @@ Check out [Semgrep App](https://semgrep.dev/manage) to integrate CI with PR or M
 ## Upgrading
 
 We [release new Semgrep versions](https://github.com/returntocorp/semgrep/releases) often! See [upgrading](./upgrading.md) for more details.
+
+<MoreHelp />

--- a/docs/managing-findings.md
+++ b/docs/managing-findings.md
@@ -1,7 +1,9 @@
 ---
 slug: managing-findings
 append_help_link: true
-description: "A finding is the core result of Semgrep's analysis. Findings are generated when a Semgrep rule matches a piece of code. Learn how to interact with findings that come from running Semgrep in the command-line, in CI, and through Semgrep App."
+description: "Manage findings, the core results of Semgrep's analysis. Triage findings that come from Semgrep CLI, in CI, and through Semgrep App."
+title: Managing findings
+hide_title: true
 ---
 
 import MoreHelp from "/src/components/MoreHelp"

--- a/docs/running-rules.md
+++ b/docs/running-rules.md
@@ -1,6 +1,9 @@
 ---
 slug: running-rules
 append_help_link: true
+description: "Learn about Semgrep rules,how to add your custom rules and rules from Semgrep Registry, a community-contributed repository of rules to help enforce security."
+title: Running rules
+hide_title: true
 ---
 
 import MoreHelp from "/src/components/MoreHelp"

--- a/docs/running-rules.md
+++ b/docs/running-rules.md
@@ -1,7 +1,7 @@
 ---
 slug: running-rules
 append_help_link: true
-description: "Learn about Semgrep rules,how to add your custom rules and rules from Semgrep Registry, a community-contributed repository of rules to help enforce security."
+description: "Learn about Semgrep rules, how to add your custom rules and rules from Semgrep Registry, a community-contributed repository of rules to help enforce security."
 title: Running rules
 hide_title: true
 ---

--- a/docs/semgrep-ci/configuration-reference.md
+++ b/docs/semgrep-ci/configuration-reference.md
@@ -1,6 +1,6 @@
 ---
 slug: configuration-reference
-description: "Reference for running Semgrep CI in your CI job or on the command line. Learn how to select rules to scan with, enable diff-aware scanning, connect to Semgrep App, and more."
+description: "Configure Semgrep in CI by setting various environment variables. Enable diff-aware scanning, connect to Semgrep App, and more."
 tags:
     - Semgrep in CI
     - Community Tier

--- a/docs/semgrep-ci/overview.md
+++ b/docs/semgrep-ci/overview.md
@@ -1,7 +1,7 @@
 ---
 slug: overview
 append_help_link: true
-description: "Semgrep can run CI environments. It can either be used stand-alone or connected with Semgrep App for centralized rule and findings management."
+description: "Run Semgrep in CI environments. Learn about different features of Semgrep App-connected CI jobs and stand-alone Semgrep jobs."
 tags:
     - Semgrep in CI
     - Community Tier

--- a/docs/semgrep-ci/running-semgrep-ci-with-semgrep-app.md
+++ b/docs/semgrep-ci/running-semgrep-ci-with-semgrep-app.md
@@ -1,7 +1,7 @@
 ---
 slug: running-semgrep-ci-with-semgrep-app
 append_help_link: true
-description: "Run Semgrep CI with Semgrep App to manage findings and rules from a centralized dashboard as well as receive notifications in various channels."
+description: "Set up your CI pipeline with Semgrep App for centralized rule and findings management."
 tags:
     - Semgrep in CI
     - Community Tier

--- a/docs/semgrep-ci/running-semgrep-ci-without-semgrep-app.md
+++ b/docs/semgrep-ci/running-semgrep-ci-without-semgrep-app.md
@@ -2,7 +2,7 @@
 slug: running-semgrep-ci-without-semgrep-app
 append_help_link: true
 title: Running Semgrep in CI without Semgrep App 
-description: "This document guides you through setting up semgrep in continuous integration without connecting to Semgrep App."
+description: "Set up Semgrep in CI without connecting to Semgrep App."
 tags:
     - Semgrep in CI
     - Community Tier

--- a/docs/semgrep-ci/sample-ci-configs.md
+++ b/docs/semgrep-ci/sample-ci-configs.md
@@ -1,7 +1,7 @@
 ---
 slug: sample-ci-configs
 append_help_link: true
-description: "The sample configuration files below run Semgrep CI on continuous integration platforms such as GitHub, GitLab, Jenkins, Buildkite, CircleCI, and other providers."
+description: "View sample configuration files to run Semgrep with various CI/CD providers such as GitHub, GitLab, Jenkins, Buildkite, CircleCI, and more."
 title: Sample CI configurations
 hide_title: true
 tags:

--- a/docs/troubleshooting/gitlab-sast.md
+++ b/docs/troubleshooting/gitlab-sast.md
@@ -3,7 +3,7 @@ slug: gitlab-sast
 title: Troubleshooting GitLab SAST
 hide_title: true
 description: >-
-  Fix issues with GitLab SAST's Semgrep analyzer such as jobs running slowly,
+  Fix issues with GitLab SAST's Semgrep analyzer, such as jobs running slowly,
   not showing results, or returning errors.
 tags:
     - Semgrep in CI

--- a/docs/troubleshooting/gitlab-sast.md
+++ b/docs/troubleshooting/gitlab-sast.md
@@ -3,9 +3,8 @@ slug: gitlab-sast
 title: Troubleshooting GitLab SAST
 hide_title: true
 description: >-
-  GitLab SAST includes an analyzer that runs Semgrep.
-  Fix issues with semgrep-sast jobs running slowly,
-  not showing results, or erroring.
+  Fix issues with GitLab SAST's Semgrep analyzer such as jobs running slowly,
+  not showing results, or returning errors.
 tags:
     - Semgrep in CI
     - Community Tier

--- a/docs/troubleshooting/semgrep.md
+++ b/docs/troubleshooting/semgrep.md
@@ -1,6 +1,9 @@
 ---
 slug: semgrep
-description: "Ways you can get more information when semgrep CLI or CI hangs, crashes, or just takes too long."
+description: "Get more information when Semgrep CLI or CI hangs, crashes, times out, or is slow."
+title: Troubleshooting Semgrep
+hide_title: true
+append_help_link: true
 ---
 
 import MoreHelp from "/src/components/MoreHelp"

--- a/docs/troubleshooting/semgrep.md
+++ b/docs/troubleshooting/semgrep.md
@@ -1,6 +1,6 @@
 ---
 slug: semgrep
-description: "Get more information when Semgrep CLI or CI hangs, crashes, times out, or is slow."
+description: "Get more information when Semgrep hangs, crashes, times out, or is slow."
 title: Troubleshooting Semgrep
 hide_title: true
 append_help_link: true

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,8 +1,14 @@
 ---
+slug: upgrading
 append_help_link: true
+description: "Update Semgrep by running the correct commands for your environment or operating system."
+title: Upgrading Semgrep
+hide_title: true
 ---
 
-# Upgrading
+import MoreHelp from "/src/components/MoreHelp"
+
+# Upgrading Semgrep
 
 We [release new Semgrep versions](https://github.com/returntocorp/semgrep/releases) often, with many performance and bug improvements. 
 
@@ -22,3 +28,6 @@ Using Docker:
 ```sh
 docker pull returntocorp/semgrep:latest
 ```
+
+
+<MoreHelp />

--- a/sidebars.js
+++ b/sidebars.js
@@ -63,7 +63,7 @@ module.exports = {
                     type: 'generated-index',
                     title: 'Semgrep command-line interface (CLI)',
                     description:
-                      "Learn about Semgrep open source command line tool.",
+                      "Learn about the Semgrep open source command-line tool.",
                     keywords: ['CLI']
                   },
                 items: [

--- a/sidebars.js
+++ b/sidebars.js
@@ -83,7 +83,7 @@ module.exports = {
                     type: 'generated-index',
                     title: 'Semgrep in continuous integration (CI)',
                     description:
-                      "Find out about use of Semgrep in continuous integration (CI)",
+                      "Learn how to use Semgrep in continuous integration (CI).",
                     keywords: ['CI']
                   },
                 items: [


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

(n/a) A subject matter expert (SME) reviews the content

- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs

Requesting the whole cavalry for this: @pabloest and @adamkvitek 
### Approach

Refer to the [linear task](https://linear.app/r2c/issue/MKT-440/update-descriptions-for-docs-displayed-in-card-index) to understand the goal and approach behind this task.

### A note on the CLI docs:

I went through the CLI docs, which have not been update for a while. You can see in the changes that I added the following depending on what was missing:

* `slug`
* `hide_title: true` (this is so that the title in the sidebar can be different from the title in the document, which we do sometimes to expand acronyms in the document but not in the sidebar)
* `append_help_link`
* `description`
* `title`

**Just skimming some of them reveals potential regressions**. Not sure if we should prioritize it, it'll take time to piece out how to modularize, etc.

### Screenshots

### CLI:
<img width="570" alt="CLI" src="https://user-images.githubusercontent.com/20766840/202088627-7f1298f6-57c7-4098-831e-c1d2cfb4f5ac.png">

#### CI:
<img width="556" alt="CI" src="https://user-images.githubusercontent.com/20766840/202088784-feb944f2-0181-401c-a656-4daa1ae309a3.png">
