### PR TITLE
Remove autofix enablement info from Projects page, modularize enabling autofix and import it to more docs

### DIFF
--- a/docs/contributing/semgrep-core-contributing.md
+++ b/docs/contributing/semgrep-core-contributing.md
@@ -491,7 +491,7 @@ sc -f [your_pattern].sgrep [your_target].py -lang py
 
 ## Fixing an autofix error
 
-Autofix runs through both `semgrep-core` and `semgrep`, but the most common autofix error people encounter is some kind of incorrect range. This happens because `semgrep-core` determines the range of a match based on the locations of the tokens stored in the AST. When the range is incorrect, that usually means a token is missing. You can see token location information with
+Autofix runs through both `semgrep-core` and `semgrep`, but the most common autofix error you can encounter is a kind of incorrect range. This happens because `semgrep-core` determines the range of a match based on the locations of the tokens stored in the AST. When the range is incorrect, that usually means a token is missing. You can see token location information with
 
 ```
 sc -full_token_info -dump_ast [your_target].py -lang py

--- a/docs/release-notes/july-2022.md
+++ b/docs/release-notes/july-2022.md
@@ -14,7 +14,7 @@ toc_max_heading_level: 3
 ### Additions
 
 - Semgrep App now integrates with Slack through a Slack app. To create a new integration, go to **Settings** > **Integrations** > **Add Integration** > **Slack**. Previously, Semgrep App used Slack webhooks.
-- Enable autofix for all of your Projects (repositories connected to Semgrep App) by clicking on **Settings > Deployment > Autofix**.
+- Enable autofix for all of your Projects (repositories connected to Semgrep App) by clicking on **Settings** > **Deployment** > **Autofix**.
 
 ### Changes
 

--- a/docs/semgrep-app/getting-started-with-semgrep-app.md
+++ b/docs/semgrep-app/getting-started-with-semgrep-app.md
@@ -11,7 +11,7 @@ tags:
 ---
 
 import MoreHelp from "/src/components/MoreHelp"
-import EnableAutofix from "/src/components/_enable-autofix.mdx"
+import EnableAutofix from "/src/components/procedure/_enable-autofix.mdx"
 
 <ul id="tag__badge-list">
 {

--- a/docs/semgrep-app/getting-started-with-semgrep-app.md
+++ b/docs/semgrep-app/getting-started-with-semgrep-app.md
@@ -11,6 +11,7 @@ tags:
 ---
 
 import MoreHelp from "/src/components/MoreHelp"
+import EnableAutofix from "/src/components/_enable-autofix.mdx"
 
 <ul id="tag__badge-list">
 {
@@ -32,7 +33,6 @@ This guide walks you through scanning code in both types of environments.
 :::info
 Many improvements to the Semgrep App experience only work with up-to-date Semgrep CLI versions. For this reason, Semgrep App only supports the 10 most recent minor versions of the Semgrep open-source tool. For example, if the latest release was 0.114.0, all versions greater than 0.104.0 are supported while earlier versions, such as 0.103.0 can be deprecated or can result in failures. Use the **latest** tag for all Semgrep CI scans.
 :::
-
 
 Semgrep App enables you to run scans on multiple repositories by integrating with your GitHub or GitLab SaaS account. Semgrep uses **rules** to scan code. Matches found based on those rules are called **findings**. A Semgrep rule encapsulates pattern-matching logic and data-flow analysis used to find code violations, security issues, outdated libraries, and other issues.
 
@@ -105,7 +105,6 @@ The GitHub integration app is called `semgrep-app`. This app is used to integrat
 7. Optional: Fill out the survey and click Complete or click Skip to omit this step.
 
 You are now signed in to Semgrep App.
-
 
 #### Permissions for GitLab
 
@@ -270,27 +269,24 @@ By default, Semgrep scans are defined during a project's initial setup in Semgre
 * After every PR or MR.
 * Update to the `semgrep.yml` file (dependent on your CI provider).
 
-
 To change these scan parameters:
 
 * Manually edit the `semgrep.yml` file.
 * Remove the project and redo the steps described in [Scanning a new project](#scanning-a-new-project) section.
 
-Set up additional scan parameters in your organization's [Projects](https://semgrep.dev/orgs/-/projects/-/repo-to-scan) page.
+Set up additional scan parameters in your organization's [Settings](https://semgrep.dev/orgs/-/settings) page.
 
-To see additional scan parameters:
+You can also configure additional configuration options for a specific project. To configure project specific settings, follow these steps:
 
 1. Click **[Projects](https://semgrep.dev/orgs/-/projects)** on the left sidebar.
 2. Select the name of the project to modify, and then click the respective <i class="fa-solid fa-gear"></i> **gear** icon in the Settings column.
-3. Make edits as necessary.
-
-This page enables you to configure the following scan parameters:
+3. Make changes as necessary.
 
 <dl>
-    <dt>Autofix</dt>
-    <dd>Select this toggle to enable autofix, which creates suggestions in addition to PR or MR comments. For example, a rule may suggest using a function such as <code>logging.debug()</code> instead of <code>print()</code>.</dd>
     <dt>Path ignores</dt>
-	<dd>Paths and files specified here are not scanned by Semgrep App.</dd>
+    <dd>Specify which directories or files you want to exclude from Semgrep scans. See <a href="/ignoring-files-folders-code/#defining-ignored-files-and-folders-in-semgrep-app">Defining ignored files and folders in Semgrep App</a> for specific details.</dd>
+    <dt>Tags</dt>
+	<dd>Add or remove tags to specific projects. See <a href="/semgrep-app/tags/">Managing projects through tags</a> for more information.</dd>
 </dl>
 
 ### Adding rules and rulesets to scan with
@@ -327,9 +323,7 @@ To add rules and rulesets to your Rule Board:
 
 For more information on operations such as filtering and deleting as well as Rule board management, see [Rule board](../rule-board/).
 
-
 ## Viewing and managing findings
-
 
 ### Viewing findings of a scan
 
@@ -346,6 +340,8 @@ To see the rule specifics that triggered the finding, click on the rule entry.
 ![Screenshot of autofix in GitHub](/img/notifications-github-suggestions.png "Screenshot of autofix in GitHub")
 
 Include code suggestions that resolve findings in both GitHub and GitLab through Semgrep App's autofix feature. This improves the fix rate of findings by reducing the steps needed to resolve a finding. See the section above on Running a scan to enable autofix.
+
+<EnableAutofix />
 
 ## Going further with Semgrep App
 

--- a/docs/semgrep-app/notifications.md
+++ b/docs/semgrep-app/notifications.md
@@ -12,7 +12,7 @@ tags:
 
 import MoreHelp from "/src/components/MoreHelp"
 import ProcedureIntegrateSlack from "/src/components/procedure/_integrate-slack.mdx"
-import EnableAutofix from "/src/components/_enable-autofix.mdx"
+import EnableAutofix from "/src/components/procedure/_enable-autofix.mdx"
 
 <ul id="tag__badge-list">
 {

--- a/docs/semgrep-app/notifications.md
+++ b/docs/semgrep-app/notifications.md
@@ -12,6 +12,7 @@ tags:
 
 import MoreHelp from "/src/components/MoreHelp"
 import ProcedureIntegrateSlack from "/src/components/procedure/_integrate-slack.mdx"
+import EnableAutofix from "/src/components/_enable-autofix.mdx"
 
 <ul id="tag__badge-list">
 {
@@ -115,18 +116,11 @@ In the following screenshot, Semgrep detects the use of a native Python XML libr
 
 ![Screenshot of a sample autofix PR suggestion](/img/notifications-github-suggestions.png)
 
-
 #### Enabling autofix for your GitLab or GitHub code repository
 
 Autofix requires PR or MR comments to be enabled for your repository or organization. Follow the steps in [GitHub pull request comments](#github-pull-request-comments) or [GitLab merge request comments](#gitlab-merge-request-comments) to enable this feature.
 
-To enable autofix:
-
-1. Sign in to your [Semgrep App account](https://semgrep.dev/login).
-2. Click **[Projects](https://semgrep.dev/orgs/-/projects)** from the **App sidebar**.
-3. Click the name of the project for which to enable autofix.
-4. Click the <i class="fa-solid fa-toggle-large-on"></i> toggle for **Autofix**.
-![Screenshot of autofix toggle](/img/notifications-enable-autofix.png)
+<EnableAutofix />
 
 All scans performed after enabling autofix generate inline PR or MR comments with code suggestions for applicable rules.
 

--- a/docs/writing-rules/testing-rules.md
+++ b/docs/writing-rules/testing-rules.md
@@ -5,6 +5,7 @@ description: "Semgrep provides a convenient testing mechanism for your rules. Yo
 ---
 
 import MoreHelp from "/src/components/MoreHelp"
+import EnableAutofix from "/src/components/_enable-autofix.mdx"
 
 # Testing rules
 
@@ -209,5 +210,9 @@ You can run `semgrep --validate --config [filename]` to check the configuration.
 The semgrep rules are pulled from `p/semgrep-rule-lints`.
 
 This feature is still experimental and under active development. Your feedback is welcomed!
+
+## Enabling autofix in Semgrep App
+
+<EnableAutofix />
 
 <MoreHelp />

--- a/docs/writing-rules/testing-rules.md
+++ b/docs/writing-rules/testing-rules.md
@@ -5,7 +5,7 @@ description: "Semgrep provides a convenient testing mechanism for your rules. Yo
 ---
 
 import MoreHelp from "/src/components/MoreHelp"
-import EnableAutofix from "/src/components/_enable-autofix.mdx"
+import EnableAutofix from "/src/components/procedure/_enable-autofix.mdx"
 
 # Testing rules
 

--- a/src/components/procedure/_enable-autofix.mdx
+++ b/src/components/procedure/_enable-autofix.mdx
@@ -1,0 +1,4 @@
+To enable autofix for all projects in your Semgrep App organization, follow these steps:
+
+1. In Semgrep App, click **[Settings](https://semgrep.dev/orgs/-/settings)** on the left sidebar.
+2. Enable the **Autofix** <i class="fa-solid fa-toggle-large-on"></i> toggle.


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
