### PR TITLE
A word about ellipses matching non-sequences

### DIFF
--- a/docs/writing-rules/pattern-syntax.mdx
+++ b/docs/writing-rules/pattern-syntax.mdx
@@ -42,6 +42,9 @@ def foo(x):
 The `...` ellipsis operator abstracts away a sequence of zero or more
 arguments, statements, parameters, fields, characters, etc.
 
+An ellipsis can also match anything that's a not a sequence
+when it's unambiguous. Use cases are shown below.
+
 ### Function calls
 
 Use the ellipsis operator to search for function calls or
@@ -265,6 +268,31 @@ if can_make_request:
 :::tip
 Half or partial statements can't be matches; both of the examples above must specify the contents of the condition’s body (e.g., `$BODY` or `...`), otherwise they are not valid patterns.
 :::
+
+### Matching single items with an ellipsis
+
+While ellipses generally stand for sequences of like elements, they
+are also supported in other contexts where they would match
+any single item. The following pattern is valid in languages with a C-like
+syntax even though `...` matches a single boolean value rather than a
+sequence:
+
+```java
+if (...)
+  return 42;
+```
+
+Another example where a single expression is matched by an ellipsis is
+the right-hand side of assignments:
+
+```java
+foo = ...;
+```
+
+However, matching a sequence of items remains the default meaning of an
+ellipsis. For example, the pattern `bar(...)` would match `bar(a)`,
+but also `bar(a, b)` and `bar()`. To force a match on a single item,
+use a metavariable as in `bar($X)`.
 
 ## Metavariables
 

--- a/docs/writing-rules/pattern-syntax.mdx
+++ b/docs/writing-rules/pattern-syntax.mdx
@@ -42,9 +42,10 @@ def foo(x):
 The `...` ellipsis operator abstracts away a sequence of zero or more
 arguments, statements, parameters, fields, characters, etc.
 
-An ellipsis can also match anything that's **not** a sequence
-when it's unambiguous. Use cases and examples are displayed
-below in the [Function calls](#function-calls) section.
+`...` can also match any single item that's a not part of a sequence
+when the context allows it.
+
+Use cases are shown below.
 
 ### Function calls
 
@@ -270,10 +271,10 @@ if can_make_request:
 Half or partial statements can't be matches; both of the examples above must specify the contents of the condition’s body (e.g., `$BODY` or `...`), otherwise they are not valid patterns.
 :::
 
-### Matching single items with an ellipsis operator
+### Matching single items with an ellipsis
 
-While ellipses generally stand for sequences of like elements, they
-are also supported in other contexts where they would match
+While `...` generally stands for sequences of like elements, it's
+are also supported in other contexts where it can match
 any single item. The following pattern is valid in languages with a C-like
 syntax even though `...` matches a single boolean value rather than a
 sequence:

--- a/docs/writing-rules/pattern-syntax.mdx
+++ b/docs/writing-rules/pattern-syntax.mdx
@@ -270,7 +270,7 @@ if can_make_request:
 Half or partial statements can't be matches; both of the examples above must specify the contents of the condition’s body (e.g., `$BODY` or `...`), otherwise they are not valid patterns.
 :::
 
-### Matching single items with an ellipsis
+### Matching single items with an ellipsis operator
 
 While ellipses generally stand for sequences of like elements, they
 are also supported in other contexts where they would match

--- a/docs/writing-rules/pattern-syntax.mdx
+++ b/docs/writing-rules/pattern-syntax.mdx
@@ -42,8 +42,9 @@ def foo(x):
 The `...` ellipsis operator abstracts away a sequence of zero or more
 arguments, statements, parameters, fields, characters, etc.
 
-An ellipsis can also match anything that's a not a sequence
-when it's unambiguous. Use cases are shown below.
+An ellipsis can also match anything that's **not** a sequence
+when it's unambiguous. Use cases and examples are displayed
+below in the [Function calls](#function-calls) section.
 
 ### Function calls
 


### PR DESCRIPTION
This feature is implemented for some languages but not all of them. It's a natural expectation from users, so we try to support it when it doesn't cause problems, even if it's redundant with metavariables.

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
