### PR TITLE
Update .semgrepignore link

### DIFF
--- a/src/components/reference/_ci-ignoring-files.mdx
+++ b/src/components/reference/_ci-ignoring-files.mdx
@@ -1,4 +1,4 @@
-By default `semgrep ci` skips files and directories such as `tests/`, `node_modules/`, and `vendor/`. It uses the default `.semgrepignore` file which you can find in the [Semgrep GitHub repository](https://github.com/returntocorp/semgrep/blob/develop/.semgrepignore). This default is used when no explicit `.semgrepignore` file is found in the root of your repository.
+By default `semgrep ci` skips files and directories such as `tests/`, `node_modules/`, and `vendor/`. It uses the default `.semgrepignore` file which you can find in the [Semgrep GitHub repository](https://github.com/returntocorp/semgrep/blob/develop/cli/src/semgrep/templates/.semgrepignore). This default is used when no explicit `.semgrepignore` file is found in the root of your repository.
 
 Optional: Copy and commit the default `.semgrepignore` file to the **root of your repository** and extend it with your own entries or write your `.semgrepignore` file from scratch. If Semgrep detects a `.semgrepignore` file within your repository, it does not append entries from the default `.semgrepignore` file.
 


### PR DESCRIPTION
This previously linked to `.semgrepignore` file that is used when Semgrep scans the Semgrep repository, so it has things specific to scanning Semgrep in there. I've updated it to link to the default `.semgrepignore` that Semgrep uses when scanning anything if there is no `.semgrepignore` file provided by the user.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
