### PR TITLE
Sara/mkt 480 update algolia scraper and config

### DIFF
--- a/.github/workflows/algolia-scrape.yml
+++ b/.github/workflows/algolia-scrape.yml
@@ -1,8 +1,15 @@
 name: Algolia scrape
 
 on:
+  workflow_dispatch:
+    inputs:
+      parameter:
+        description: Run from dispatch
   push:
-    branches: main
+    branches:
+      - main
+      - sara/mkt-480-update-algolia-scraper-and-config
+
 
 jobs:
   scrape:
@@ -25,4 +32,4 @@ jobs:
           docker run \
           -e APPLICATION_ID -e API_KEY \
           -e CONFIG="$(cat algolia-config.json)" \
-          algolia/docsearch-scraper:v1.15.0
+          algolia/docsearch-scraper:latest

--- a/.github/workflows/algolia-scrape.yml
+++ b/.github/workflows/algolia-scrape.yml
@@ -14,7 +14,6 @@ jobs:
   scrape:
     runs-on: ubuntu-latest
     steps:
-    comment out to test quickly
      - name: Wait for 4 minutes
        run: sleep 240s
        shell: bash

--- a/.github/workflows/algolia-scrape.yml
+++ b/.github/workflows/algolia-scrape.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-      - sara/mkt-480-update-algolia-scraper-and-config
 
 
 jobs:

--- a/.github/workflows/algolia-scrape.yml
+++ b/.github/workflows/algolia-scrape.yml
@@ -15,10 +15,10 @@ jobs:
   scrape:
     runs-on: ubuntu-latest
     steps:
-    # comment out to test quickly
-    #  - name: Wait for 4 minutes
-    #    run: sleep 240s
-    #    shell: bash
+    comment out to test quickly
+     - name: Wait for 4 minutes
+       run: sleep 240s
+       shell: bash
       - name: check out code 🛎
         uses: actions/checkout@v2
       # when scraping the site, inject secrets as environment variables

--- a/.github/workflows/algolia-scrape.yml
+++ b/.github/workflows/algolia-scrape.yml
@@ -18,7 +18,7 @@ jobs:
     # comment out to test quickly
     #  - name: Wait for 4 minutes
     #    run: sleep 240s
-        shell: bash
+    #    shell: bash
       - name: check out code 🛎
         uses: actions/checkout@v2
       # when scraping the site, inject secrets as environment variables

--- a/.github/workflows/algolia-scrape.yml
+++ b/.github/workflows/algolia-scrape.yml
@@ -15,8 +15,9 @@ jobs:
   scrape:
     runs-on: ubuntu-latest
     steps:
-      - name: Wait for 4 minutes
-        run: sleep 240s
+    # comment out to test quickly
+    #  - name: Wait for 4 minutes
+    #    run: sleep 240s
         shell: bash
       - name: check out code 🛎
         uses: actions/checkout@v2

--- a/algolia-config.json
+++ b/algolia-config.json
@@ -1,5 +1,5 @@
 {
-  "index_name": "docs",
+  "index_name": "mkt480_docs",
   "start_urls": [
     {
       "url": "https://semgrep.dev/docs/release-notes",
@@ -29,7 +29,7 @@
         "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
         "type": "xpath",
         "global": true,
-        "default_value": "Documentation"
+        "default_value": "Semgrep documentation"
       },
       "lvl1": "header h1",
       "lvl2": "article h2",

--- a/algolia-config.json
+++ b/algolia-config.json
@@ -26,7 +26,7 @@
   "selectors": {
     "default": {
       "lvl0": {
-        "selector": ".breadcrumbs__item span.breadcrumbs__link",
+        "selector": ".breadcrumbs > li:nth-child(2) span.breadcrumbs__link",
         "global": true,
         "default_value": "Semgrep documentation"
       },

--- a/algolia-config.json
+++ b/algolia-config.json
@@ -26,7 +26,7 @@
   "selectors": {
     "default": {
       "lvl0": {
-        "selector": "(//ul[contains(@class,'menu__list')]//li[contains(@class,'theme-doc-sidebar-item-category-level-1')]//a[contains(@class, 'menu__link')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
+        "selector": "(/html[@class='docs-wrapper docs-doc-page docs-version-current plugin-docs plugin-id-default docs-doc-id-semgrep-ci/overview']/body/div[@id='__docusaurus']/div[@id='docusaurus_skipToContent_fallback']/div[@class='docPage__5DB']/main[@class='docMainContainer_gTbr']/div[@class='container padding-top--md padding-bottom--lg']/div[@class='row']/div[@class='col docItemCol_VOVn']/div[@class='docItemContainer_Djhp']/article/nav[@class='theme-doc-breadcrumbs breadcrumbsContainer_Z_bl']/ul[@class='breadcrumbs']/li[@class='breadcrumbs__item'][2]/span[@class='breadcrumbs__link'])",
         "type": "xpath",
         "global": true,
         "default_value": "Semgrep documentation"

--- a/algolia-config.json
+++ b/algolia-config.json
@@ -1,5 +1,5 @@
 {
-  "index_name": "mkt480_docs",
+  "index_name": "docs",
   "start_urls": [
     {
       "url": "https://semgrep.dev/docs/release-notes",

--- a/algolia-config.json
+++ b/algolia-config.json
@@ -26,8 +26,7 @@
   "selectors": {
     "default": {
       "lvl0": {
-        "selector": "(/html[@class='docs-wrapper docs-doc-page docs-version-current plugin-docs plugin-id-default docs-doc-id-semgrep-ci/overview']/body/div[@id='__docusaurus']/div[@id='docusaurus_skipToContent_fallback']/div[@class='docPage__5DB']/main[@class='docMainContainer_gTbr']/div[@class='container padding-top--md padding-bottom--lg']/div[@class='row']/div[@class='col docItemCol_VOVn']/div[@class='docItemContainer_Djhp']/article/nav[@class='theme-doc-breadcrumbs breadcrumbsContainer_Z_bl']/ul[@class='breadcrumbs']/li[@class='breadcrumbs__item'][2]/span[@class='breadcrumbs__link'])",
-        "type": "xpath",
+        "selector": ".breadcrumbs__item span.breadcrumbs__link",
         "global": true,
         "default_value": "Semgrep documentation"
       },

--- a/algolia-config.json
+++ b/algolia-config.json
@@ -26,7 +26,7 @@
   "selectors": {
     "default": {
       "lvl0": {
-        "selector": "(//ul[contains(@class,'menu__list')]//li[contains(@class,'theme-doc-sidebar-item-category-level-1')] //a[contains(@class, 'menu__link')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
+        "selector": "(//ul[contains(@class,'menu__list')]//li[contains(@class,'theme-doc-sidebar-item-category-level-1')]//a[contains(@class, 'menu__link')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
         "type": "xpath",
         "global": true,
         "default_value": "Semgrep documentation"

--- a/algolia-config.json
+++ b/algolia-config.json
@@ -26,7 +26,7 @@
   "selectors": {
     "default": {
       "lvl0": {
-        "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
+        "selector": "(//ul[contains(@class,'menu__list')]//li[contains(@class,'theme-doc-sidebar-item-category-level-1')] //a[contains(@class, 'menu__link')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
         "type": "xpath",
         "global": true,
         "default_value": "Semgrep documentation"


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs


Previously, we only had general headings appear in Algolia's search results modal: Continuous Integration, CLI, Release Notes, + some others, but we **never** had a working "Semgrep App" or "Semgrep Supply Chain" heading. 

This PR fixes that. The fix is done by fixing what element the scraper picks up.

See before and after:
<img width="1108" alt="before-after" src="https://user-images.githubusercontent.com/20766840/210435980-76299de0-c7be-42f9-bd93-43989cc65c2e.png">

