### PR TITLE
Changed path of Sample CI configs doc due to broken link

### DIFF
--- a/docs/semgrep-ci/overview.md
+++ b/docs/semgrep-ci/overview.md
@@ -113,7 +113,7 @@ For more information on the features supported by CI providers and source code p
 This section describes a high-level view of steps to run Semgrep continuously with Semgrep Cloud Platform. 
 
 :::info
-Semgrep Cloud Platform creates a SAST (Static Application Security Testing) job by default. To run dependency scans exclusively, refer to [Sample CI configurations](semgrep-ci/sample-ci-configs).
+Semgrep Cloud Platform creates a SAST (Static Application Security Testing) job by default. To run dependency scans exclusively, refer to [Sample CI configurations](/docs/semgrep-ci/sample-ci-configs).
 :::
 
 ![High level view of steps to integrate and refine Semgrep in your CI environment with Semgrep Cloud Platform](/img/semgrep-ci-overview-app.png "High level view of steps to integrate and refine Semgrep in your CI environment with Semgrep Cloud Platform")

--- a/docs/semgrep-ci/overview.md
+++ b/docs/semgrep-ci/overview.md
@@ -113,7 +113,7 @@ For more information on the features supported by CI providers and source code p
 This section describes a high-level view of steps to run Semgrep continuously with Semgrep Cloud Platform. 
 
 :::info
-Semgrep Cloud Platform creates a SAST (Static Application Security Testing) job by default. To run dependency scans exclusively, refer to [Sample CI configurations](/docs/semgrep-ci/sample-ci-configs).
+Semgrep Cloud Platform creates a SAST (Static Application Security Testing) job by default. To run dependency scans exclusively, refer to [Sample CI configurations](/semgrep-ci/sample-ci-configs/).
 :::
 
 ![High level view of steps to integrate and refine Semgrep in your CI environment with Semgrep Cloud Platform](/img/semgrep-ci-overview-app.png "High level view of steps to integrate and refine Semgrep in your CI environment with Semgrep Cloud Platform")


### PR DESCRIPTION
Changed the path of the link to the following info box:

Semgrep Cloud Platform creates a SAST (Static Application Security Testing) job by default. To run dependency scans exclusively, refer to Sample CI configurations. 

As the link to the Sample CI configurations was broken. The link currently leads to [https://semgrep.dev/docs/semgrep-ci/overview/semgrep-ci/sample-ci-configs/](https://semgrep.dev/docs/semgrep-ci/overview/semgrep-ci/sample-ci-configs/) which does not exist.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
