### PR TITLE
Update february 2023 release notes

### DIFF
--- a/docs/release-notes/february-2023.md
+++ b/docs/release-notes/february-2023.md
@@ -11,7 +11,7 @@ toc_max_heading_level: 3
 
 ## Important update
 
-- Semgrep CLI is now officially renamed to **Semgrep open-source (OSS) Engine**. As of now, this documentation reserves or uses the term Semgrep CLI for Semgrep command-line interface (CLI) which you can utilize for several products, such as Semgrep OSS, Semgrep Code, and Semgrep Supply Chain.
+- Semgrep CLI is now officially renamed to **Semgrep open-source (OSS) Engine**. As of now, this documentation uses the term Semgrep CLI for Semgrep command-line interface (CLI) which you can utilize for several products, such as Semgrep OSS, Semgrep Code, and Semgrep Supply Chain.
 - Team tier rules are now renamed to Pro Rules. **Pro rules** are created by r2c for security and software engineers who need accurate findings. These rules were previously called Team tier rules. As of this update, these rules are officially called the **[Pro rules](/semgrep-code/pro-rules/)** and are available with the [Team or higher tier](https://semgrep.dev/pricing).
 - DeepSemgrep has been bundled with other functionalities to offer you **Semgrep Pro Engine**. Semgrep Pro Engine is fully available for [Team or higher tier](https://semgrep.dev/pricing) users. See the [DeepSemgrep → Semgrep Pro Engine](#deepsemgrep--semgrep-pro-engine) update below for more details.
 

--- a/docs/release-notes/february-2023.md
+++ b/docs/release-notes/february-2023.md
@@ -11,7 +11,7 @@ toc_max_heading_level: 3
 
 ## Important update
 
-- Semgrep CLI is now officially renamed to **Semgrep OSS Engine**. You can use Semgrep CLI for several products, such as Semgrep OSS, Semgrep Code, and Semgrep Supply Chain.
+- Semgrep CLI is now officially renamed to **Semgrep open-source (OSS) Engine**. As of now, this documentation reserves term Semgrep CLI for Semgrep command-line interface (CLI) which you can utilize for several products, such as Semgrep OSS, Semgrep Code, and Semgrep Supply Chain.
 - Team tier rules are now renamed to Pro Rules. **Pro rules** are created by r2c for security and software engineers who need accurate findings. These rules were previously called Team tier rules. As of this update, these rules are officially called the **[Pro rules](/semgrep-code/pro-rules/)** and are available with the [Team or higher tier](https://semgrep.dev/pricing).
 - DeepSemgrep has been bundled with other functionalities to offer you **Semgrep Pro Engine**. Semgrep Pro Engine is fully available for [Team or higher tier](https://semgrep.dev/pricing) users. See the [DeepSemgrep → Semgrep Pro Engine](#deepsemgrep--semgrep-pro-engine) update below for more details.
 

--- a/docs/release-notes/february-2023.md
+++ b/docs/release-notes/february-2023.md
@@ -11,7 +11,7 @@ toc_max_heading_level: 3
 
 ## Important update
 
-- Semgrep CLI is now officially renamed to **Semgrep open-source (OSS) Engine**. As of now, this documentation reserves term Semgrep CLI for Semgrep command-line interface (CLI) which you can utilize for several products, such as Semgrep OSS, Semgrep Code, and Semgrep Supply Chain.
+- Semgrep CLI is now officially renamed to **Semgrep open-source (OSS) Engine**. As of now, this documentation reserves or uses the term Semgrep CLI for Semgrep command-line interface (CLI) which you can utilize for several products, such as Semgrep OSS, Semgrep Code, and Semgrep Supply Chain.
 - Team tier rules are now renamed to Pro Rules. **Pro rules** are created by r2c for security and software engineers who need accurate findings. These rules were previously called Team tier rules. As of this update, these rules are officially called the **[Pro rules](/semgrep-code/pro-rules/)** and are available with the [Team or higher tier](https://semgrep.dev/pricing).
 - DeepSemgrep has been bundled with other functionalities to offer you **Semgrep Pro Engine**. Semgrep Pro Engine is fully available for [Team or higher tier](https://semgrep.dev/pricing) users. See the [DeepSemgrep → Semgrep Pro Engine](#deepsemgrep--semgrep-pro-engine) update below for more details.
 


### PR DESCRIPTION
Please check this small update. I think that this is something I initially had in mind, but when reading this section of release notes again, I realized it does not really convey the meaning I wanted (without this fix, it might be even confusing for readers - 1. Semgrep CLI is renamed. 2. You can still use Semgrep CLI - it does not make logical sense without what we internally know here).

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
