### PR TITLE
check version to confirm installation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -76,7 +76,7 @@ Semgrep CLI installation requires Python 3.7 or later.
 
 2. Confirm installation by running a simple search pattern. For example, run the following command:
     ```sh
-    semgrep --pattern '127.$A.$B.$C' --lang generic /etc/hosts
+    semgrep --version
     ```
 3. Run recommended Semgrep Registry rules:
     <pre class="language-bash"><code>semgrep --config=auto <span className="placeholder">PATH/TO/SRC</span></code></pre>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -74,7 +74,7 @@ Semgrep CLI installation requires Python 3.7 or later.
     </Tabs>
 
 
-2. Confirm installation by running a simple search pattern. For example, run the following command:
+2. Confirm installation by the following command:
     ```sh
     semgrep --version
     ```


### PR DESCRIPTION
From what I've seen, most tools do a version check to confirm installation instead of running a pattern. While it is nice to see a scan, I worry the syntax is a bit jarring on first impression. What do folks think?

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [] Redirects are added if the PR changes page URLs
