### PR TITLE
Fix title rendering for "Removing rules or rulesets"

### DIFF
--- a/docs/semgrep-app/rule-board.md
+++ b/docs/semgrep-app/rule-board.md
@@ -81,6 +81,7 @@ Semgrep Code detects the framework and language when scanning a project and only
 ## Disabling rules
 
 <DisableRule />
+
 ## Removing rules or rulesets
 
 <RemoveRule />


### PR DESCRIPTION
The "Removing rules or rulesets" heading was showing as raw Markdown with ## instead of a rendered H2, due to a missing line break; that should be fixed now.

### Please ensure

- [x] A subject matter expert (SME) reviews the content (no content changes)
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
