### PR TITLE
fixed bug in title regression for tagging projects

### DIFF
--- a/docs/semgrep-app/tags.md
+++ b/docs/semgrep-app/tags.md
@@ -2,7 +2,7 @@
 slug: tags
 append_help_link: true
 description: "Guidelines on how to add or remove tags through Semgrep Cloud Platform and semgrepconfig.yml file."
-title: Managing projects through tags
+title: Tagging projects 
 hide_title: true
 tags:
     - Semgrep Cloud Platform
@@ -20,7 +20,7 @@ Object.entries(frontMatter).filter(
 
 import MoreHelp from "/src/components/MoreHelp"
 
-# Managing projects through tags
+# Tagging projects 
 
 Add tags for specific projects in the Semgrep Cloud Platform through the following methods:
 


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs

Currently in the docs we have an article "Managing projects through tags" - however this was discussed ([Slack thread, see screenshot](https://returntocorp.slack.com/archives/C02JT6YA5S7/p1675714264449269)) previously to be changed to "Tagging projects". I think something may have gotten overwritten post-launch. This PR just fixes the title to what was discussed most recently.
