### PR TITLE
Reflect switch to `go.mod`

### DIFF
--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -174,9 +174,9 @@ This table provides information about fully supported (generally available or GA
 <tbody><tr>
    <td>Go</td>
    <td>Go modules (<code>go mod</code>)</td>
-   <td><code>go.sum</code></td>
+   <td><code>go.mod</code></td>
    <td style={{"text-align": "center"}}>✔️ Yes</td>
-   <td style={{"text-align": "center"}}>❌ No</td>
+   <td style={{"text-align": "center"}}>✔️ Yes</td>
    <td>May 2022</td>
   </tr>
   <tr>

--- a/docs/writing-rules/experiments/project-depends-on.md
+++ b/docs/writing-rules/experiments/project-depends-on.md
@@ -74,7 +74,7 @@ A finding is only considered reachable if the file containing the pattern match 
 | Python     | pypi       | `Pipfile.lock`                   |
 | JavaScript | npm        | `yarn.lock`, `package-lock.json` |
 | Java       | maven      | `pom.xml`                        |
-| Go         | gomod      | `go.sum`                         |
+| Go         | gomod      | `go.mod`                         |
 | Ruby       | gem        | `Gemfile.lock`                   |
 | Rust       | cargo      | `cargo.lock`                     |
 


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

We no longer us `go.sum` files to detect dependencies in go projects, we use `go.mod`. We can also identify transitive dependencies now.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
