### PR TITLE
Remove link to Semgrep repository

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -23,7 +23,7 @@ Object.entries(frontMatter).filter(
 
 # CLI reference
 
-This documentation provides the `--help` option outputs for `semgrep --help` and `semgrep scan --help` for the [Semgrep command-line interface (CLI)](https://github.com/returntocorp/semgrep), as well as Semgrep exit codes overview.
+This documentation provides the `--help` option outputs for `semgrep --help` and `semgrep scan --help` for the Semgrep command-line interface (CLI), as well as Semgrep exit codes overview.
 
 ## Semgrep commands
 


### PR DESCRIPTION
As Semgrep CLI is only an interface accessible to more of our products, I am removing the link to the Semgrep OSS repository from Semgrep command-line interface (CLI) term.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
