### PR TITLE
Remove additional space that causes break in the description list

### DIFF
--- a/docs/semgrep-code/semgrep-pro-engine-intro.md
+++ b/docs/semgrep-code/semgrep-pro-engine-intro.md
@@ -82,8 +82,6 @@ To test Semgrep Pro Engine on a purposefully vulnerable repository, fork the [ju
 <dl>
     <dt>Interfile analysis</dt>
     <dd>The interfile analysis gathers context across multiple files to help security engineers deeply understand their organization's security issues. Semgrep Pro Engine reduces noise and detects new vulnerabilities that Semgrep OSS Engine can't find. Interfile analysis runs on nightly scans. These scans may take longer to complete and can use more memory than Semgrep OSS Engine scans. See the available languages for interfile analysis in <a href="/docs/supported-languages/#semgrep-pro-engine">Semgrep Pro Engine supported languages</a>.</dd>
-
- <dl>  
     <dt>Interprocedural analysis</dt>
     <dd>Keeps the fast scan times of Semgrep OSS Engine while also finding new vulnerabilities that cross functions within a single file. Interprocedural analysis improves results in pull requests (PRs) or merge requests (MRs) through CI scans. The interprocedural analysis is available for all languages listed as GA on the <a href="/docs/supported-languages/">Supported languages</a> page</dd>
 </dl>

--- a/docs/semgrep-code/semgrep-pro-engine-intro.md
+++ b/docs/semgrep-code/semgrep-pro-engine-intro.md
@@ -83,7 +83,7 @@ To test Semgrep Pro Engine on a purposefully vulnerable repository, fork the [ju
     <dt>Interfile analysis</dt>
     <dd>The interfile analysis gathers context across multiple files to help security engineers deeply understand their organization's security issues. Semgrep Pro Engine reduces noise and detects new vulnerabilities that Semgrep OSS Engine can't find. Interfile analysis runs on nightly scans. These scans may take longer to complete and can use more memory than Semgrep OSS Engine scans. See the available languages for interfile analysis in <a href="/docs/supported-languages/#semgrep-pro-engine">Semgrep Pro Engine supported languages</a>.</dd>
     <dt>Interprocedural analysis</dt>
-    <dd>Keeps the fast scan times of Semgrep OSS Engine while also finding new vulnerabilities that cross functions within a single file. Interprocedural analysis improves results in pull requests (PRs) or merge requests (MRs) through CI scans. The interprocedural analysis is available for all languages listed as GA on the <a href="/docs/supported-languages/">Supported languages</a> page</dd>
+    <dd>Interprocedural analysis keeps the fast scan times of Semgrep OSS Engine while also finding new vulnerabilities that cross functions within a single file. Interprocedural analysis improves results in pull requests (PRs) or merge requests (MRs) through CI scans. The interprocedural analysis is available for all languages listed as GA on the <a href="/docs/supported-languages/">Supported languages</a> page</dd>
 </dl>
 
 

--- a/docs/semgrep-code/semgrep-pro-engine-intro.md
+++ b/docs/semgrep-code/semgrep-pro-engine-intro.md
@@ -83,6 +83,7 @@ To test Semgrep Pro Engine on a purposefully vulnerable repository, fork the [ju
     <dt>Interfile analysis</dt>
     <dd>The interfile analysis gathers context across multiple files to help security engineers deeply understand their organization's security issues. Semgrep Pro Engine reduces noise and detects new vulnerabilities that Semgrep OSS Engine can't find. Interfile analysis runs on nightly scans. These scans may take longer to complete and can use more memory than Semgrep OSS Engine scans. See the available languages for interfile analysis in <a href="/docs/supported-languages/#semgrep-pro-engine">Semgrep Pro Engine supported languages</a>.</dd>
 
+ <dl>  
     <dt>Interprocedural analysis</dt>
     <dd>Keeps the fast scan times of Semgrep OSS Engine while also finding new vulnerabilities that cross functions within a single file. Interprocedural analysis improves results in pull requests (PRs) or merge requests (MRs) through CI scans. The interprocedural analysis is available for all languages listed as GA on the <a href="/docs/supported-languages/">Supported languages</a> page</dd>
 </dl>


### PR DESCRIPTION
*missing a <dl> tag caused this section to show up as a code snippet

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
