### PR TITLE
Post-launch cleanup, better separation for SCP and Semgrep Code

### DIFF
--- a/docs/semgrep-ci/configuration-reference.md
+++ b/docs/semgrep-ci/configuration-reference.md
@@ -24,8 +24,8 @@ Object.entries(frontMatter).filter(
 
 Use this reference to configure Semgrep's behavior in CI environments by setting environment variables. You can set these variables within a CI configuration file or your CI provider's interface. Refer to your CI provider's documentation for the correct syntax. Examples are written for a Bash environment unless otherwise stated.  
 
-:::tip
-You can also set many of these environment variables within your local development environment for testing or experimental purposes. Set these variables in your command line then run `semgrep ci --config p/default` to test these environment variables locally.
+:::tip Testing environment variables locally
+You can also set many of these environment variables within your local development environment. Set these variables in your command line then run `semgrep ci --config p/default` while logged out of Semgrep CLI to test these environment variables locally. 
 :::
 
 ## Environment variables for configuring scan behavior

--- a/docs/semgrep-ci/configuration-reference.md
+++ b/docs/semgrep-ci/configuration-reference.md
@@ -25,7 +25,7 @@ Object.entries(frontMatter).filter(
 Use this reference to configure Semgrep's behavior in CI environments by setting environment variables. You can set these variables within a CI configuration file or your CI provider's interface. Refer to your CI provider's documentation for the correct syntax. Examples are written for a Bash environment unless otherwise stated.  
 
 :::tip
-You can also set many of these environment variables within your local development environment for testing or experimental purposes. Set these variables in your command line then run `semgrep ci` to test these environment variables locally.
+You can also set many of these environment variables within your local development environment for testing or experimental purposes. Set these variables in your command line then run `semgrep ci --config p/default` to test these environment variables locally.
 :::
 
 ## Environment variables for configuring scan behavior

--- a/docs/semgrep-ci/overview.md
+++ b/docs/semgrep-ci/overview.md
@@ -66,7 +66,7 @@ The following table displays what features are available for manual (without Sem
 | Trigger scans when a Pull request (PR) or merge request (MR) is created | ✔️ | ✔️ |
 | Prevent vulnerable code from merging into mainline branches | ✔️ | ✔️ |
 | Generate CI configuration files for [many providers](/semgrep-ci/running-semgrep-ci-with-semgrep-cloud-platform/#ci-providers-listed-in-semgrep-cloud-platform) | ✔️ | ❌ |
-| Receive PR or MR review comments in GitHub or GitLab | ✔️ | ❌ |
+| Receive PR or MR review comments in GitHub, GitLab, or BitBucket | ✔️ | ❌ |
 | Manage false positives in bulk through triage | ✔️ | ❌ |
 | Receive notifications in Slack and email | ✔️ | ❌ |
 | Pricing | Free for up to 20 developers* | Free |
@@ -101,12 +101,12 @@ In addition to the features mentioned previously, Semgrep Cloud Platform has the
     <dt>Receiving results (findings) as PR or MR comments</dt>
     <dd>This feature enables you to receive <a href="/docs/semgrep-code/notifications/#enabling-github-pull-request-comments">PR or MR comments</a> from Semgrep Cloud Platform on the lines of code that generated a finding.</dd>
     <dt>Hyperlinks to code</dt>
-    <dd>Semgrep Cloud Platform collects findings in a Findings page. In this page, you can click on a finding to return to your GitHub or GitLab repository to view the lines of code in your repository that generated the finding.</dd>
+    <dd>Semgrep Cloud Platform collects findings in a Findings page. In this page, you can click on a finding to return to your GitHub, GitLab, or BitBucket repository to view the lines of code in your repository that generated the finding.</dd>
     <dt>GitHub or GitLab security dashboard</dt>
     <dd>Send Semgrep findings to GitHub or GitLab's security dashboard.</dd>
 </dl>
 
-For more information on the features supported by CI providers and source code providers such as GitHub or GitLab, see [Semgrep Cloud Platform feature support](/docs/semgrep-ci/running-semgrep-ci-with-semgrep-cloud-platform/#semgrep-cloud-platform-feature-support).
+For more information on the features supported by CI providers and source code providers such as GitHub, GitLab, or BitBucket see [Semgrep Cloud Platform feature support](/docs/semgrep-ci/running-semgrep-ci-with-semgrep-cloud-platform/#semgrep-cloud-platform-feature-support).
 
 ### General steps to run Semgrep in CI with Semgrep Cloud Platform
 

--- a/docs/semgrep-cloud-platform/getting-started.md
+++ b/docs/semgrep-cloud-platform/getting-started.md
@@ -33,7 +33,7 @@ Object.entries(frontMatter).filter(
 
 # Getting started with Semgrep Cloud Platform
 
-Semgrep Cloud Platform (SCP) enables you to run scans on multiple repositories by integrating with your GitHub or GitLab SaaS account.
+Semgrep Cloud Platform (SCP) enables you to run scans continuously on multiple repositories by integrating with your GitHub, GitLab, or BitBucket SaaS repositories.
 
 <SemgrepScan />
 
@@ -50,9 +50,7 @@ For Docker users: Use the [**latest** tag](https://hub.docker.com/r/returntocorp
 Semgrep Cloud Platform supports code scanning from:
 
 * Local command-line interfaces (CLI).
-* GitHub and GitLab, through continuous integration (CI).
-
-This guide walks you through scanning code in both types of environments.
+* GitHub, GitLab, and BitBucket through continuous integration (CI).
 
 ![Diagram of Semgrep Cloud Platform flow](/img/semgrep-app-diagram.png "Diagram of Semgrep Cloud Platform flow")
 
@@ -60,7 +58,7 @@ This guide walks you through scanning code in both types of environments.
 
 ### Semgrep Cloud Platform with Semgrep Code
 
-Semgrep Code, a SAST (Static Application Security Testing) tool, enables you to scan your first-party code through the use of rules. Many rules are available from [Semgrep Registry](https://semgrep.dev/explore), an open-source, community-driven repository of rules. You can also write your own rules to customize Semgrep for your team's specific practices, or publish rules for the community. You can use Semgrep Code from your CLI or with Semgrep Cloud Platform.
+Semgrep Code, a SAST tool, enables you to scan your first-party code through the use of rules. Many rules are available from [Semgrep Registry](https://semgrep.dev/explore), an open-source, community-driven repository of rules. You can also write your own rules to customize Semgrep for your team's specific practices, or publish rules for the community. You can use Semgrep Code from your CLI or with Semgrep Cloud Platform.
 
 Using Semgrep Code with Semgrep Cloud Platform provides you with the Rule Board, where you can determine which rules Semgrep uses and what action Semgrep undertakes when it generates a finding. The Rule Board can block pull requests (PRs) or merge requests (MRs) from merging until findings are resolved. This behavior helps to prevent vulnerable code from shipping to widely-accessible environments, such as production or staging servers.
 

--- a/docs/semgrep-cloud-platform/scm.md
+++ b/docs/semgrep-cloud-platform/scm.md
@@ -57,7 +57,7 @@ Integrate Semgrep into these custom source code management (SCM) tools by follow
 
 </div>
 
-3. Select your source code provider.
+3. Select your source code manager.
 4. For **GitHub Enterprise Server**, follow these steps:
 
     1. Create a PAT by following the steps outlined in this [guide to creating a PAT](https://docs.github.com/en/enterprise-server@3.1/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). Ensure that the PAT is **[created with the required scopes](../scm/#table-of-required-scopes-for-pats)**.

--- a/docs/semgrep-cloud-platform/user-management.md
+++ b/docs/semgrep-cloud-platform/user-management.md
@@ -31,10 +31,8 @@ Semgrep Cloud Platform has two types of accounts:
     <dt>Personal account</dt>
     <dd>Every person who signs into Semgrep Cloud Platform is first signed in to a <strong>personal account</strong>. In a personal account, your findings, projects, private rules, and scans are visible only to you.</dd>
     <dt>Organization (Org) account</dt>
-    <dd>To collaborate with others, create an <strong>organization account</strong>. An organization account in Semgrep Cloud Platform requires an existing organization from GitHub or GitLab. Creating this type of account integrates Semgrep Cloud Platform with your organization. A user can be part of many Semgrep Cloud Platform organization accounts, provided that they are a member of that organization in their SCM (source code management) tool, such as GitHub or GitLab.</dd>
+    <dd>To collaborate with others, create an <strong>organization account</strong>. An organization account in Semgrep Cloud Platform requires an existing organization from GitHub or GitLab. Creating this type of account integrates Semgrep Cloud Platform with your organization. A user can be part of many Semgrep Cloud Platform organization accounts, provided that they are a member of that organization in their SCM (source code management) tool, such as GitHub or GitLab. Semgrep Cloud Platform can also detect the organization's repositories available for scanning.</dd>
 </dl>
-
-Users from the same organization can sign in to Semgrep Cloud Platform with their SCM's credentials and are automatically added to the organization account. Semgrep Cloud Platform can also detect the organization's repositories available for scanning.
 
 In organization accounts, collaborators can collectively manage Semgrep Cloud Platform. By default, users can:
 
@@ -51,6 +49,10 @@ Semgrep Cloud Platform can restrict features based on user roles. See [Controlli
 By setting up an organization account, teams can collaborate on rule writing and the management of repositories. Teams with organization accounts can enforce organization-wide standards and secure their repositories at scale. Perform the steps outlined in the following subsections to set up an organization account.
 
 ### Creating a Semgrep organization account
+
+:::note
+- Semgrep supports the creation of organization accounts from GitHub or GitLab only.
+:::
 
 To create an organization account:
 

--- a/docs/semgrep-code/findings.md
+++ b/docs/semgrep-code/findings.md
@@ -41,7 +41,7 @@ A finding can be categorized in two ways:
     - Business or logic bugs
     - Matches based on your own custom rules (such as organization-specific authentication logic)
 
-    Semgrep rules provide a metadata schema to identify common categories such as the above. Semgrep findings include a `message` field that describes the security issue or bug found in matching code. Additionally, findings can provide a `fix` field that fixes the issue by creating a suggestion within your source code management (SCM) tool, such as GitHub or GitLab.
+    Semgrep rules provide a metadata schema to identify common categories such as the above. Semgrep findings include a `message` field that describes the security issue or bug found in matching code. Additionally, findings can provide a `fix` field that fixes the issue by creating a suggestion within your source code management (SCM) tool, such as GitHub, GitLab, and BitBucket.
 2. **Finding categorization based on the validity of the match**:
     <dl>
         <dt>True positive</dt>

--- a/docs/semgrep-code/getting-started.md
+++ b/docs/semgrep-code/getting-started.md
@@ -333,7 +333,7 @@ Semgrep Cloud Platform supports various phases of the development cycle through 
 
 * Alerts and notifications keep teams informed without having to leave their working environments, such as Slack or email.
 * Forking Registry rules to easily write custom rules, enabling teams to enforce their own standards.
-* Developer feedback enables teams to collaborate and improve on scan quality.
+* User management and collaboration features for security teams to work as a team in for rule-writing, triage, and remediation.
 
 ### Tracking findings and receiving notifications
 
@@ -353,6 +353,10 @@ Semgrep provides the following environments to learn, experiment, and write Semg
     <dt><a href= "https://semgrep.dev/login?return_path=/orgs/-/editor">Editor</a></dt>
     <dd>Fork existing security rules to customize them for your own organization or team's use in this advanced editor. Refer to <a href="/semgrep-code/editor/#jumpstart-rule-writing-using-existing-rules">Writing rules using Semgrep Editor</a>.</dd>
 </dl>
+
+### User management
+
+You can onboard (add) your entire organization's users and repositories by creating an organization account. Additionally, Semgrep Cloud Platform provides role-based access control (RBAC) for Team or Enterprise tiers. See [User management, accounts, and roles](/semgrep-cloud-platform/user-management) to learn more.
 
 ### Getting support
 

--- a/docs/semgrep-code/getting-started.md
+++ b/docs/semgrep-code/getting-started.md
@@ -37,10 +37,9 @@ Secure your code quickly and continuously by scanning with Semgrep Code, a fast 
 
 <!-- TODO Add no code ever leaves your computer admonition. -->
 
-Semgrep Code is transparent: you can fully configure what rules are run and how the presence of a finding is communicated to different channels. The content of a rule can be customized to improve the true positive rate of a rule or its message to fellow developers.
+Semgrep Code is transparent: you can fully configure what rules are run and inspect the Semgrep syntax to understand how the finding was detected. The content of a rule can be customized to improve the true positive rate of a rule or its message to fellow developers.
 
 This document provides steps to get started with Semgrep Code for all tiers except where indicated.
-
 
 ## Semgrep Code with Semgrep Cloud Platform
 
@@ -51,8 +50,9 @@ Semgrep Code includes Semgrep Cloud Platform (SCP), a web application that helps
 * Preventing insecure code from reaching production or staging servers by blocking pull or merge requests, based on how you configure your rules.
 * Notifying security teams of findings (results) as well as communicating with other developers by leaving pull or merge request comments in GitHub or GitLab.
 
-:::tip
-* Scanning with Semgrep Cloud Platform is the recommended method to scan with Semgrep Code.
+:::tip SUGGESTED WORKFLOWS
+* You can use SCP to scan remote repositories (GitHub, GitLab, and BitBucket) and consolidate the findings.
+* You can also use Semgrep Cloud Platform to consolidate findings from a Semgrep CLI scan performed on a **local** machine.
 * Semgrep Code can be integrated into your custom infrastructure without SCP. See [API](/semgrep-cloud-platform/semgrep-api) for details.
 :::
 
@@ -98,7 +98,7 @@ Semgrep Cloud Platform enables users to choose what findings prevent a pull or m
 
 A **project** is a repository from either:
 
-* Your GitHub or GitLab account that you add to Semgrep Cloud Platform for scanning. Projects from GitHub or GitLab are integrated through Semgrep Cloud Platform.
+* Your GitHub, GitLab, or BitBucket account that you add to Semgrep Cloud Platform for scanning.
 * A local Git repository in your machine. Projects from your local machine are integrated through Semgrep CLI.
 
 Semgrep Cloud Platform can run scans on many projects with rules set in the Rule Board. First-time Semgrep Cloud Platform users scan projects with pre-selected rules chosen based on the repository's language and framework. To view these pre-selected rules, see the [Registry default ruleset](https://semgrep.dev/p/default).
@@ -209,7 +209,7 @@ $> export SEMGREP_COMMIT=fa4e36b9369e5b039bh2220b5h9R61a38b077f29
 
 *Figure 3.* Partial screenshot of findings page with hyperlinks.
 
-#### Option B: Adding a repository from GitHub or GitLab
+#### Option B: Adding a repository from GitHub, GitLab, or BitBucket
 
 <PlatformAddRepo />
 

--- a/docs/semgrep-code/getting-started.md
+++ b/docs/semgrep-code/getting-started.md
@@ -35,8 +35,6 @@ Secure your code quickly and continuously by scanning with Semgrep Code, a fast 
 
 <SemgrepScan />
 
-<!-- TODO Add no code ever leaves your computer admonition. -->
-
 Semgrep Code is transparent: you can fully configure what rules are run and inspect the Semgrep syntax to understand how the finding was detected. The content of a rule can be customized to improve the true positive rate of a rule or its message to fellow developers.
 
 This document provides steps to get started with Semgrep Code for all tiers except where indicated.
@@ -87,6 +85,10 @@ See [Permissions in GitLab](/semgrep-cloud-platform/getting-started/#requested-p
 </TabItem>
 
 </Tabs>
+
+:::tip
+To use Semgrep with your team, [create an organization account](/semgrep-cloud-platform/user-management/). An organization account enables users to share rules and perform triage or remediation as a team.
+:::
 
 ## Performing a scan
 

--- a/docs/semgrep-code/getting-started.md
+++ b/docs/semgrep-code/getting-started.md
@@ -31,7 +31,7 @@ import PlatformSigninGitlab from "/src/components/procedure/_platform-signin-git
 
 # Getting started with Semgrep Code
 
-Secure your code quickly and continuously by scanning with Semgrep Code, a fast and lightweight SAST (Static Analysis Security Testing) engine that leverages Semgrep OSS.
+Secure your code quickly and continuously by scanning with Semgrep Code, a fast and lightweight SAST (Static Application Security Testing) engine that leverages Semgrep OSS.
 
 <SemgrepScan />
 
@@ -39,30 +39,8 @@ Secure your code quickly and continuously by scanning with Semgrep Code, a fast 
 
 Semgrep Code is transparent: you can fully configure what rules are run and how the presence of a finding is communicated to different channels. The content of a rule can be customized to improve the true positive rate of a rule or its message to fellow developers.
 
-This document provides steps to get started with Semgrep Code and its Team and Enterprise tier features.
+This document provides steps to get started with Semgrep Code for all tiers except where indicated.
 
-:::note
-To get started with Semgrep Code and its Community (free) tier, see [Getting Started with Semgrep Cloud Platform](/semgrep-cloud-platform/getting-started).
-:::
-
-## Semgrep Code and Semgrep OSS Engine
-
-The following table shows differences between Semgrep Code and Semgrep OSS Engine:
-
-| Feature                | Description | Semgrep OSS Engine | Semgrep Code |
-| -------                | ---   | -----------------  | ------------ |
-| Semgrep CLI            | Run local scans. | ✔️  | ✔️  |
-| Semgrep CI             | Run scans on remote repositories. | ✔️  | ✔️  | 
-| Custom rules           | Write your own rules tailored to your organization's needs. | ✔️  | ✔️  |
-| Community rules        | Make use of community-contributed rules. | ✔️  | ✔️  |
-| Semgrep Cloud Platform | Manage findings, rules, and alerts in a centralized location. | ❌ | ✔️  |
-| Semgrep Pro Engine     | Run Semgrep with interprocedural and interfile analysis. | ❌ | ✔️ * |
-| Semgrep Pro rules      | Rules leveraging Semgrep Pro Engine to detect hardcoded secrets, XXE injections, deserialization issues, and more. | ❌ | ✔️ * |
-| Findings retention     | Keep track of when a finding is created and resolved. | ❌ | ✔️  |
-| Alerts & notifications | Receive alerts to catch issues before they reach live servers. | ❌ | ✔️  |
-| Findings management    | Filter and sort findings in bulk. | ❌ | ✔️  |
-| API and webhooks       | Query and receive scan data for your custom infrastructure. |❌ | ✔️  |
-_*These features require a Team-tier license or above*._
 
 ## Semgrep Code with Semgrep Cloud Platform
 
@@ -112,7 +90,7 @@ See [Permissions in GitLab](/semgrep-cloud-platform/getting-started/#requested-p
 
 ## Performing a scan
 
-Scanning is Semgrep's primary operation. When you first sign into Semgrep Cloud Platform, it uses a default SAST (Static Application Security Testing) ruleset selected to enforce best practices for a repository's framework and programming language. You can customize future scans to address your organization's specific practices.
+Scanning is Semgrep's primary operation. When you first sign into Semgrep Cloud Platform, it uses a default SAST ruleset selected to enforce best practices for a repository's framework and programming language. You can customize future scans to address your organization's specific practices.
 
 Semgrep Cloud Platform enables users to choose what findings prevent a pull or merge request (PR or MR) from merging into the repository. Setting these blocking and non-blocking rules is achieved through the Rule Board.
 
@@ -328,6 +306,25 @@ Include code suggestions that resolve findings in both GitHub and GitLab through
 
 <EnableAutofix />
 
+## Semgrep Code and Semgrep OSS Engine
+
+The following table shows differences between Semgrep Code and Semgrep OSS Engine:
+
+| Feature                | Description | Semgrep OSS Engine | Semgrep Code |
+| -------                | ---   | -----------------  | ------------ |
+| Semgrep CLI            | Run local scans. | ✔️  | ✔️  |
+| Semgrep CI             | Run scans on remote repositories. | ✔️  | ✔️  | 
+| Custom rules           | Write your own rules tailored to your organization's needs. | ✔️  | ✔️  |
+| Community rules        | Make use of community-contributed rules. | ✔️  | ✔️  |
+| Semgrep Cloud Platform | Manage findings, rules, and alerts in a centralized location. | ❌ | ✔️  |
+| Semgrep Pro Engine     | Run Semgrep with interprocedural and interfile analysis. | ❌ | ✔️ * |
+| Semgrep Pro rules      | Rules leveraging Semgrep Pro Engine to detect hardcoded secrets, XXE injections, deserialization issues, and more. | ❌ | ✔️ * |
+| Findings retention     | Keep track of when a finding is created and resolved. | ❌ | ✔️  |
+| Alerts & notifications | Receive alerts to catch issues before they reach live servers. | ❌ | ✔️  |
+| Findings management    | Filter and sort findings in bulk. | ❌ | ✔️  |
+| API and webhooks       | Query and receive scan data for your custom infrastructure. |❌ | ✔️  |
+_*These features require a Team-tier license or above*._
+
 ## Going further with Semgrep Cloud Platform
 
 Semgrep Cloud Platform supports various phases of the development cycle through the following features:
@@ -354,15 +351,6 @@ Semgrep provides the following environments to learn, experiment, and write Semg
     <dt><a href= "https://semgrep.dev/login?return_path=/orgs/-/editor">Editor</a></dt>
     <dd>Fork existing security rules to customize them for your own organization or team's use in this advanced editor. Refer to <a href="/semgrep-code/editor/#jumpstart-rule-writing-using-existing-rules">Writing rules using Semgrep Editor</a>.</dd>
 </dl>
-
-### Receiving feedback about a rule
-
-[Developer feedback](/semgrep-cloud-platform/dashboard/#rule-performance-through-developer-feedback) is a Team/Enterprise tier feature in which developers can submit feedback about a rule or finding. This is used to evaluate a rule's performance:
-
-* Is the rule's message clear?
-* Does the rule have too many false positives?
-* Should the rule be ignored for a certain file or block of code?
-* Are there additional improvements to the rule, such as possible autofix values?
 
 ### Getting support
 

--- a/docs/semgrep-code/getting-started.md
+++ b/docs/semgrep-code/getting-started.md
@@ -48,15 +48,15 @@ Semgrep Code includes Semgrep Cloud Platform (SCP), a web application that helps
 * Sorting, filtering, triaging, and remediating security issues.
 * Enforcing coding standards through the creation of custom rules.
 * Preventing insecure code from reaching production or staging servers by blocking pull or merge requests, based on how you configure your rules.
-* Notifying security teams of findings (results) as well as communicating with other developers by leaving pull or merge request comments in GitHub or GitLab.
+* Notifying security teams of findings (results) as well as communicating with other developers by leaving pull or merge request comments in GitHub, GitLab, or BitBucket.
 
 :::tip SUGGESTED WORKFLOWS
-* You can use SCP to scan remote repositories (GitHub, GitLab, and BitBucket) and consolidate the findings.
+* You can use SCP to scan remote repositories (GitHub, GitLab, or BitBucket) and consolidate the findings.
 * You can also use Semgrep Cloud Platform to consolidate findings from a Semgrep CLI scan performed on a **local** machine.
 * Semgrep Code can be integrated into your custom infrastructure without SCP. See [API](/semgrep-cloud-platform/semgrep-api) for details.
 :::
 
-### Scanning a repository from GitHub or GitLab
+### Scanning a repository
 
 #### Signing in to Semgrep Cloud Platform
 

--- a/docs/semgrep-code/semgrep-pro-engine-intro.md
+++ b/docs/semgrep-code/semgrep-pro-engine-intro.md
@@ -69,7 +69,7 @@ To enable Semgrep Pro Engine in the Semgrep Cloud Platform, follow these steps:
 1. Select **[Settings](https://semgrep.dev/orgs/-/settings)**.
 1. Enable the <i class="fa-solid fa-toggle-large-on"></i> **Semgrep Pro Engine beta** toggle.
 1. Ensure that you have the **default ruleset** added in your **[Rule Board](https://semgrep.dev/orgs/-/board)**. In the Rule Board, the **default ruleset** is in the **Monitor column**. If this ruleset is **not** added, go to [https://semgrep.dev/p/default](https://semgrep.dev/p/default), and then click **Add to Rule Board**.
-1. Optional: If you don't have any projects added to your organization, follow the procedures described in [Scanning a repository from GitHub or GitLab](/semgrep-code/getting-started/#semgrep-code-with-semgrep-cloud-platform) to scan a new project with Semgrep Pro Engine. Ensure that your project's language is supported by Semgrep Pro Engine.
+1. Optional: If you don't have any projects added to your organization, follow the procedures described in [Scanning a repository](/semgrep-code/getting-started/#semgrep-code-with-semgrep-cloud-platform) to scan a new project with Semgrep Pro Engine. Ensure that your project's language is supported by Semgrep Pro Engine.
 
 :::info Testing Semgrep Pro Engine
 To test Semgrep Pro Engine on a purposefully vulnerable repository, fork the [juice-shop](https://github.com/juice-shop/juice-shop) repository, and then add it to SCP by following the steps described in [Adding a repository](/semgrep-code/getting-started/#option-b-adding-a-repository-from-github-or-gitlab).

--- a/src/components/procedure/_platform-add-repo.md
+++ b/src/components/procedure/_platform-add-repo.md
@@ -1,10 +1,11 @@
-Adding a repository from GitHub or GitLab enables Semgrep Cloud Platform to perform many of its core features, such as the ability to record, triage, and manage findings.
+Adding a repository from GitHub, GitLab, or BitBucket enables Semgrep Cloud Platform to perform many of its core features, such as the ability to record, triage, and manage findings.
 
 :::info Prerequisite
-A GitHub or GitLab SaaS repository associated with your account.
+* **For GitHub or GitLab SaaS users:** A GitHub or GitLab SaaS repository associated with your account.
+* **For BitBucket SaaS users:** A BitBucket repository and sufficient permissions to edit a BitBucket Pipeline and add repository variables.
 :::
 
-To add a repository from GitHub or GitLab, follow these steps:
+To add a repository from GitHub, GitLab, or BitBucket, follow these steps:
 
 1. Ensure you are signed in to Semgrep Cloud Platform.
 2. Click **[Projects](https://semgrep.dev/orgs/-/projects)** on the left sidebar.
@@ -13,4 +14,4 @@ To add a repository from GitHub or GitLab, follow these steps:
 5. Select which CI provider for Semgrep to integrate with.
 6. Follow the instructions displayed on Semgrep Cloud Platform page for your particular CI provider.
 
-You have now added a repository to Semgrep Cloud Platform.
+You have now added a repository to Semgrep Cloud Platform. A scan begins automatically after adding a new repository.

--- a/src/components/reference/_triage-states.mdx
+++ b/src/components/reference/_triage-states.mdx
@@ -8,4 +8,4 @@ Findings can also be **removed**. A removed finding does not count towards the f
 
 * The rule isn't enabled on the repository anymore.
 * The file path where the finding appeared is no longer found (it was deleted, renamed, added to a `.semgrepignore`, added to a `.gitignore` or added to the list of ignored paths in Semgrep Cloud Platform).
-* The PR or MR where the finding was detected has been closed without merging.
+* For GitHub organization accounts: the PR or MR where the finding was detected has been closed without merging.


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs

See the ff tables for the changes:

`docs/semgrep-ci/configuration-reference`
* Corrected from `semgrep ci` to `semgrep ci --config p/default` to bypass login for the specific use case of testing environment (CI) variables. (It's tested folks.)

`docs/semgrep-code/getting-started`
|  OLD | NEW  |
| ------ | ------ |
| SAST (Static Analysis...) | Fixed as "SAST (Static **Application**...)" |
| Previously stated this getting started doc is only for paid tiers. This is not accurate | The Semgrep Code doc actually covers features for both free and paid, and it's a tofu doc, so it should be more welcoming with some intro to the value add of paid tiers |
| OSS and Code table comparison is above the fold | Moved the comparison table of OSS and Code after scanning, so that users focus on scanning right away |
|  Includes developer feedback  |  Dev feedback is removed as it has been deprecated from the product.  |
| No mention of BitBucket | Added BitBucket as repository mention |

Important reminder: You cannot sign in as a BitBucket user into SCP. BitBucket as auth vs BitBucket as SCM are 2 different things.

