### PR TITLE
Common Clause -> Commons Clause

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -26,7 +26,7 @@ Our paid product, [Semgrep Code](https://semgrep.dev/products/semgrep-code), inc
 
 #### Semgrep Registry
 
-The [Semgrep Registry](https://semgrep.dev/explore) contains rules from different contributors. Semgrep Registry rules written by the Semgrep team are licensed under the [Common Clause](https://github.com/returntocorp/semgrep-rules/blob/develop/LICENSE). The source for these Registry rules is available at [returntocorp/semgrep-rules](https://github.com/returntocorp/semgrep-rules/). Those rules licensed under the Common Clause license cannot be resold without Semgrep, Inc. (“Semgrep”)’s permission. Since Semgrep offers a paid, hosted application, it’s important to have this restriction so other companies, like major cloud providers, cannot resell Semgrep’s rules as a competing service.
+The [Semgrep Registry](https://semgrep.dev/explore) contains rules from different contributors. Semgrep Registry rules written by the Semgrep team are licensed under the [Commons Clause](https://github.com/returntocorp/semgrep-rules/blob/develop/LICENSE). The source for these Registry rules is available at [returntocorp/semgrep-rules](https://github.com/returntocorp/semgrep-rules/). Those rules licensed under the Commons Clause license cannot be resold without Semgrep, Inc. (“Semgrep”)’s permission. Since Semgrep offers a paid, hosted application, it’s important to have this restriction so other companies, like major cloud providers, cannot resell Semgrep’s rules as a competing service.
 
 [Semgrep Code](https://semgrep.dev/products/semgrep-code)’s Team tier includes Pro rules which are proprietary and only available to paying customers.
 

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -20,7 +20,7 @@ This document provides an overview of the licenses of important products created
     <dd>
     <a href="https://semgrep.dev/explore">Semgrep Registry</a> is a collection of rules and rulesets:
     <ul>
-    <li>Rules in the <a href="https://github.com/returntocorp/semgrep-rules">semgrep-rules</a> repository are licensed LGPL 2.1 under Common Clause v1.0. Review the <a href="https://github.com/returntocorp/semgrep-rules/blob/develop/LICENSE#L10">semgrep-rules license</a>.</li>
+    <li>Rules in the <a href="https://github.com/returntocorp/semgrep-rules">semgrep-rules</a> repository are licensed LGPL 2.1 under Commons Clause v1.0. Review the <a href="https://github.com/returntocorp/semgrep-rules/blob/develop/LICENSE#L10">semgrep-rules license</a>.</li>
     <li>Rules from third-party repositories in the <a href="https://semgrep.dev/explore">Semgrep Registry</a> inherit the licenses of their source repositories. These licenses are displayed within the rule definition in the editor. For example: <a href="https://semgrep.dev/p/trailofbits">Rules written by Trail of Bits</a> security experts licensed under CC-BY-NC-SA-4.0.</li>
     <li>Premium rules are proprietary.</li>
     </ul>


### PR DESCRIPTION
This should be "Commons Clause":

- https://github.com/returntocorp/semgrep-rules/blob/develop/LICENSE
- https://commonsclause.com/

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
