### PR TITLE
trueup, license reconcilliation

### DIFF
--- a/docs/semgrep-cloud-platform/pricing-and-billing.mdx
+++ b/docs/semgrep-cloud-platform/pricing-and-billing.mdx
@@ -279,11 +279,28 @@ Notes:
 
 ### Number of developers
 
-Within your team or organization, assess the number of members that make commits. That determines the number of developers needed for the plan purchase.
+Within your team or organization, assess the number of members that make commits. That determines the number of **licenses** needed for the plan purchase.
 
-For example, if a project has 4 unique developers who create commits during the billing period while Semgrep is scanning their repositories, only 4 developers are required even if the organization has a total of 10 members. If these unique developers commit to many projects within the same organization, they are counted once, so no additional cost is charged.
+For example, if a project has 4 unique developers who create commits during the billing period while Semgrep is scanning their repositories, only 4 licenses are required even if the organization has a total of 10 members. If these unique developers commit to many projects within the same organization, they are counted once, so no additional cost is charged.
 
-All members of the organization, regardless of developer status, have access to paid features for the chosen tier. This means that project managers and other non-programming roles can still view the Semgrep Cloud Platform dashboard.
+All members of the organization, regardless of developer (license) status, have access to paid features for the chosen tier. This means that project managers and other non-programming roles can still view the Semgrep Cloud Platform dashboard.
+
+### Semgrep add-on reconciliation of licenses
+
+If the organization exceeds the number of purchased licenses, the organization will be charged based on the number of licenses that exceeded the amount purchased. The additional charge starts the month after the use of licenses exceeds the contracted amount.
+
+Check in with your Semgrep Account Executive every **60 days** if you need more licenses than initially purchased.
+
+#### Example of license reconcilliation
+
+On January 21st, you purchased an annual license for 50 developers of Semgrep Supply Chain’s Team tier ($40 per developer per month). The 21st of the month is the start date of the annual contract. In the following month, on February 28th, the number of used developer licenses exceeded the original purchased quantity by 20 users. This requires a contract adjustment.
+
+Contract adjustment:
+
+* Since the organization’s use exceeded the amount of purchased licenses on February 28th, the future date of March 21st is selected to align with the remaining months in the contract. There are 10 months remaining in the contract.
+* The additional amount charged, the add-on cost, is $8,000 ($40 per developer per month x 10 months x 20 users).
+* Resulting add-on cost: **$8,000**
+
 
 ### Plan limits
 

--- a/docs/semgrep-cloud-platform/pricing-and-billing.mdx
+++ b/docs/semgrep-cloud-platform/pricing-and-billing.mdx
@@ -293,7 +293,7 @@ Check in with your Semgrep Account Executive every **60 days** if you need more 
 
 #### Example of license reconcilliation
 
-On January 21st, you purchased an annual license for 50 developers of Semgrep Supply Chain’s Team tier ($40 per developer per month). The 21st of the month is the start date of the annual contract. In the following month, on February 28th, the number of used developer licenses exceeded the original purchased quantity by 20 users. This requires a contract adjustment.
+On January 21st, you purchased annual licenses for 50 developers of Semgrep Supply Chain’s Team tier ($40 per developer per month). The 21st of the month is the start date of the annual contract. In the following month, on February 28th, the number of used developer licenses exceeded the original purchased quantity by 20 users. This requires a contract adjustment.
 
 Contract adjustment:
 

--- a/docs/semgrep-cloud-platform/pricing-and-billing.mdx
+++ b/docs/semgrep-cloud-platform/pricing-and-billing.mdx
@@ -301,11 +301,6 @@ Contract adjustment:
 * The additional amount charged, the add-on cost, is $8,000 ($40 per developer per month x 10 months x 20 users).
 * Resulting add-on cost: **$8,000**
 
-
-### Plan limits
-
-Should your plan exceed the limit, we will reach out and come up with a new plan that fits your needs.
-
 ## Upgrading your plan
 
 To upgrade to the **Team tier** through a **credit card**:


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link

<img width="1015" alt="2023-04-20_17-52-51" src="https://user-images.githubusercontent.com/20766840/233332242-bfd18a7f-ff14-4f9a-9ae8-5eb2fe339f63.png">

**Changes from draft:**
* I noticed an inconsistency in the draft. We say "number of purchased license**s**" then say "purchase an annual license for 50 developers" in the example. This has been corrected to "purchase annual licenses for 50 developers".
* Created a header for the example and made it clear for the right-side TOC
* Replaced "Should the organization exceed the number..." with "If the organization exceeds the number..." for conciseness and clarity.
* Removed "we recommend" because :
    * If we use "we" we should state who we are referring to before hand (I can update if we choose to do this, something like "Semgrep Inc recommends...")
    * It's not actually a recommendation 😅 - if they plan to go over their plan limits, they will **have** to talk to us. (That being said, the previous alternative stated, "Semgrep Inc. recommends..." is also a viable phrasing and less harsh on a sensitive concern. 

**Given this addition, do we want to keep the "Plan limits" section? (See screenshot - it looks a little deprecated)**
