### PR TITLE
updated timeout

### DIFF
--- a/.github/workflows/algolia-scrape.yml
+++ b/.github/workflows/algolia-scrape.yml
@@ -14,8 +14,8 @@ jobs:
   scrape:
     runs-on: ubuntu-latest
     steps:
-      - name: Wait for 4 minutes
-        run: sleep 240s
+      - name: Wait for 8 minutes
+        run: sleep 480s
         shell: bash
       - name: check out code 🛎
         uses: actions/checkout@v2


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A technical writer reviews the content or PR

Doubles the sleep to make sure our docs build when the scraper runs (i.e. race condition "prevention")