### PR TITLE
`focus-metavariable` can be a list

### DIFF
--- a/docs/writing-rules/rule-syntax.md
+++ b/docs/writing-rules/rule-syntax.md
@@ -159,8 +159,9 @@ Include more `focus-metavariable` keys with different metavariables under the `p
 ```yaml
     patterns:
       - pattern: foo($X, ..., $Y)
-      - focus-metavariable: $X
-      - focus-metavariable: $Y
+      - focus-metavariable:
+        - $X
+        - $Y
 ```
 
 :::note Example


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
