### PR TITLE
Update "Alerts and notifications" link

### DIFF
--- a/docs/semgrep-ci/running-semgrep-ci-with-semgrep-cloud-platform.md
+++ b/docs/semgrep-ci/running-semgrep-ci-with-semgrep-cloud-platform.md
@@ -329,7 +329,7 @@ SEMGREP_PR_ID="44"
 
 ### Receiving PR or MR comments
 
-To receive PR or MR comments in your repository, follow the steps to enable hyperlinks. Verify that comments are sent by adding rules to your Rule Board's **Comment** or **Block** columns that can match code to generate a finding. To configure PR or MR comments, review [Alerts and notifications](/semgrep-code/notifications/) documentation.
+To receive PR or MR comments in your repository, follow the steps to enable hyperlinks. Verify that comments are sent by adding rules to your Rule Board's **Comment** or **Block** columns that can match code to generate a finding. To configure PR or MR comments, review [Alerts and notifications](/semgrep-cloud-platform/notifications/) documentation.
 
 :::info
 Only rules in the **Comment** and **Block** columns of your [Rule board](https://semgrep.dev/orgs/-/board) create the PR or MR comments. Rules from the **Block** column also block the PR or MR pipeline. To unblock the pipeline, the detected code needs to be fixed.


### PR DESCRIPTION
Updates the path in the link within "Receiving PR or MR comments" section. There is a redirect for the current path to the one I'm updating to, but it seems not to be working consistently.

### Thanks for improving Semgrep Docs 😀
My pleasure. 😁 

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs