### PR TITLE
member roles can only read

### DIFF
--- a/docs/semgrep-cloud-platform/user-management.md
+++ b/docs/semgrep-cloud-platform/user-management.md
@@ -112,7 +112,7 @@ The following table displays features available to each role:
 | Projects              | no        | yes       | Only `admin` can manage projects.                                                  |
 | Rule Board (Policies) | no        | yes       | Only `admin` can manage policies and rules.                                        |
 | Findings              | yes       | yes       | Both `admin` and `member` roles can sort, filter, comment on, and triage findings. |
-| Editor                | yes       | yes       | `member` roles are able to write and modify rules within an organization.          |
+| Editor                | yes       | yes       | `member` access is read-only within their organization. Users with a `member` role can use their personal account to write a rule.  |
 | Settings              | no        | yes       |                                                                                    |
 | Community             | yes       | yes       |                                                                                    |
 | Registry              | yes       | yes       |                                                                                    |


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link

<img width="918" alt="rbac" src="https://github.com/returntocorp/semgrep-docs/assets/20766840/fa50797c-9603-43a8-b219-3779ab76fdbf">
