### PR TITLE
[NEW KB] How to run all available rules within the registry.

### DIFF
--- a/docs/kb/rules/run-all-available-rules.md
+++ b/docs/kb/rules/run-all-available-rules.md
@@ -6,15 +6,21 @@ tags:
   - Semgrep Code
 ---
 
-# How to run all available rules on a repository.
+# Running all available rules on a repository
 
-If you would like to run all rules that are available within the [Semgrep Registry](https://semgrep.dev/explore) and are not willing to add all available rules/rulesets to the Rule Board or add a variety of `--config` entries, what you can do is run the following command:
+To run all rules that are available within the [Semgrep Registry](https://semgrep.dev/explore) without using the Rule board, enter the following command:
 
 ```
 semgrep --config=r/all
 ```
 
-This command will pull out all available public, org private, and pro tiered rules if you have access to them. Below is an example output:
+This command runs the following rules from the Semgrep Registry:
+
+* All public or community-written rules
+* Your organization's private rules, if you are logged in 
+* Semgrep Pro rules, if you have access to them
+
+Refer to the following snippet for a sample output of `config=r/all` while logged in through `semgrep ci`:
 
 ```
 ┌─────────────┐
@@ -34,19 +40,24 @@ This command will pull out all available public, org private, and pro tiered rul
                                                                                                                         
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:02:31   
 ```
-The above example output is when you are running `--config=r/all` while logged in via `semgrep ci`. If you are not logged in you will just use the public rules within `r/all`.
 
-However there is one error that you should be wary about which is the following:
+If you are not logged in, `config=r/all` runs public rules only.
+
+## Troubleshooting invalid configuration file
+
+The following error may occur:
 
 ```
 [ERROR] invalid configuration file found (1 configs were invalid)
 ```
 
-This error may come up when running `r/all` if there is a current error within any of your custom/private rules.
+This error appears if there is a syntax or other error within any of your custom rules.
 
-To get around this you can use the following two commands as a workaround:
+Enter the following commands as a workaround:
 
 ```
 semgrep --config r/all . -d
 semgrep --config ~/.semgrep/semgrep_rules.json .
 ```
+
+The first command creates a cache of rules and creates a `semgrep_rules.json`. The second command then runs the rules.

--- a/run-all-available-rules.md
+++ b/run-all-available-rules.md
@@ -1,0 +1,51 @@
+---
+description: How do I run all available rules on my repository?
+tags:
+  - Rules
+  - Semgrep Registry
+  - Semgrep Code
+---
+
+# How to run all available rules on a repository.
+
+If you would like to run all rules that are available within the [Semgrep Registry](https://semgrep.dev/explore) and are not willing to add all available rules/rulesets to the Rule Board or add a variety of `--config` entries, what you can do is run the following command:
+
+```
+semgrep --config=r/all
+```
+
+This command will pull out all avaialable public, private, and pro tiered rules if you have access to them. Below is an example output:
+
+```
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 8453 files tracked by git with 3248 Code rules, 451 Pro rules:
+                                                                                                                        
+  Language      Rules   Files          Origin      Rules                                                                
+ ─────────────────────────────        ───────────────────                                                               
+  <multilang>     289   16870          Community    2432                                                                
+  html              4    2783          Pro rules     451                                                                
+  java            437    2763          Custom        365                                                                
+  bash              8      29                                                                                           
+  yaml             89       5                                                                                           
+  js              550       4                                                                                           
+  dockerfile       40       1                                                                                           
+                                                                                                                        
+  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:02:31   
+```
+
+However there is one error that you should be wary about which is the following:
+
+```
+[ERROR] invalid configuration file found (1 configs were invalid)
+```
+
+This error may come up when running `r/all` if there is a current error within any of your custom/private rules.
+
+To get around this you can use the following two commands as a workaround:
+
+```
+semgrep --config r/all . -d
+semgrep --config ~/.semgrep/semgrep_rules.json .
+```

--- a/run-all-available-rules.md
+++ b/run-all-available-rules.md
@@ -14,7 +14,7 @@ If you would like to run all rules that are available within the [Semgrep Regist
 semgrep --config=r/all
 ```
 
-This command will pull out all available public, private, and pro tiered rules if you have access to them. Below is an example output:
+This command will pull out all available public, org private, and pro tiered rules if you have access to them. Below is an example output:
 
 ```
 ┌─────────────┐
@@ -34,6 +34,7 @@ This command will pull out all available public, private, and pro tiered rules i
                                                                                                                         
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:02:31   
 ```
+The above example output is when you are running `--config=r/all` while logged in via `semgrep ci`. If you are not logged in you will just use the public rules within `r/all`.
 
 However there is one error that you should be wary about which is the following:
 

--- a/run-all-available-rules.md
+++ b/run-all-available-rules.md
@@ -14,7 +14,7 @@ If you would like to run all rules that are available within the [Semgrep Regist
 semgrep --config=r/all
 ```
 
-This command will pull out all avaialable public, private, and pro tiered rules if you have access to them. Below is an example output:
+This command will pull out all available public, private, and pro tiered rules if you have access to them. Below is an example output:
 
 ```
 ┌─────────────┐


### PR DESCRIPTION
How to run all available rules within the registry.

This kb talks about the use of `--config=r/all` when wanting to run all available rules within the registry on a repository.
  
### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
