### PR TITLE
Update supported language extensions table

### DIFF
--- a/docs/writing-rules/rule-syntax.md
+++ b/docs/writing-rules/rule-syntax.md
@@ -22,7 +22,7 @@ This document describes Semgrep’s YAML rule syntax.
 
 <RequiredRuleFields />
 
-#### Language extensions and tags
+#### Language extensions and language key values
 
 <LanguageExtensionsTags />
 

--- a/docs/writing-rules/rule-syntax.md
+++ b/docs/writing-rules/rule-syntax.md
@@ -22,7 +22,7 @@ This document describes Semgrep’s YAML rule syntax.
 
 <RequiredRuleFields />
 
-#### Language extensions and language key values
+#### Language extensions and languages key values
 
 <LanguageExtensionsTags />
 

--- a/src/components/reference/_language-extensions-tags.mdx
+++ b/src/components/reference/_language-extensions-tags.mdx
@@ -5,42 +5,52 @@ or by default) uncomment the following two lines and closing tag below the table
 <!-- <details> -->
 <!-- <summary>Expand table of extensions and tags</summary> -->
 
-| Language   | Extensions             | Tags                                 |
-|:-----------|:-----------------------|:-------------------------------------|
-| Bash       | `.sh`                  | `bash`                               |
-| C          | `.c`                   | `c`                                  |
-| C++        | `.cpp`, `.h`           | `cpp`                                |
-| C#         | `.cs`                  | `csharp`, `cs`, `C#`                 |
-| Generic    |                        | `generic`                            |
-| Go         | `.go`                  | `go`, `golang`                       |
-| HTML       | `.htm`, `.html`        | `html`                               |
-| Java       | `.java`                | `java`                               |
-| JavaScript | `.js`, `.jsx`          | `js`, `jsx`, `javascript`            |
-| JSON       | `.json`                | `json`, `JSON`, `Json`               |
-| JSX        | `.js`, `.jsx`          | `js`, `jsx`, `javascript`            |
-| Kotlin     |  `.kt`, `.kts`, `.ktm` | `kotlin`                             |
-| Lua        | `.lua`                 | `lua`                                |
-| OCaml      | `.ml`, `.mli`          | `ocaml`, `ml`                        |
-| PHP        | `.php`                 | `php`                                |
-| Python     | `.py`, `.pyi`          | `python`, `python2`, `python3`, `py` |
-| R          | `.r`, `.rda`, `rds`    | `r`                                  |
-| Ruby       | `.rb`                  | `ruby`, `rb`                         |
-| Rust       | `.rs`                  | `rust`, `Rust`, `rs`                 |
-| Scala      | `.scala`, `.sc`        | `scala`                              |
-| Solidity   | `.sol`                 | `solidity`                           |
-| Terraform  | `.tf`                  | `hcl`                                |
-| TypeScript | `.ts`, `.tsx`          | `ts`, `tsx`, `typescript`            |
-| TSX        | `.ts`, `.tsx`          | `ts`, `tsx`, `typescript`            |
-| YAML       | `.yaml`                | `yaml`                               |
-| XML        |  `.xml`                |  TODO                                |
-| Clojure    | `.clj`, `.cljs`, `.cljc`, `.edn` | TODO                       |
-| Dart       | `.dart`                | TODO                                 |
-| Dockerfile | `.dockerfile`          | TODO                                 |
-| Elixir     | `.ex`, `exs`           | TODO                                 |
-| Jsonnet    | `.jsonnet`, `.libsonnet` | TODO                               |
-| Scheme     | `.scm`, `.ss`          | TODO                                 |
-| Swift      | `.swift`               | TODO                                 |
+The following table includes languages that Semgrep supports, their file extension, and valid values that Semgrep rules require in the `language` or `languages` key.
 
+| Language                            | Extensions                           | `language` and `languages` key values |
+|:------------------------------------|:-------------------------------------|:--------------------------------------|
+| Apex (only in Semgrep Pro Engine)   | `.cls`                               | `apex`                                | 
+| Bash                                | `.bash`, `.sh`                       | `bash`, `sh`                          |
+| C                                   | `.c`                                 | `c`                                   |
+| Clojure                             | `.clj`, `.cljs`, `.cljc`, `.edn`     | `clojure`                             |
+| C++                                 | `.cc`, `.cpp`                        | `cpp`, `c++`                          |
+| C#                                  | `.cs`                                | `csharp`, `c#`                        |
+| Dart                                | `.dart`                              | `dart`                                |
+| Dockerfile                          | `.dockerfile`, `.Dockerfile`         | `dockerfile`, `docker`                |
+| Elixir                              | `.ex`, `.exs`                        | `ex`, `elixir`                        |
+| Generic                             |                                      | `generic`                             |
+| Go                                  | `.go`                                | `go`, `golang`                        |
+| HTML                                | `.htm`, `.html`                      | `html`                                |
+| Java                                | `.java`                              | `java`                                |
+| JavaScript                          | `.js`, `.jsx`                        | `js`, `javascript`                    |
+| JSON                                | `.json`, `.ipynb`                    | `json`                                |
+| Jsonnet                             | `.jsonnet`, `.libsonnet`             | `jsonnet`                             |
+| JSX                                 | `.js`, `.jsx`                        | `js`, `javascript`                    |
+| Julia                               | `.jl`                                | `julia`                               |
+| Kotlin                              |  `.kt`, `.kts`, `.ktm`               | `kt`, `kotlin`                        |
+| Lisp                                | `.lisp`, `.cl`, `.el`                | `lisp`                                |
+| Lua                                 | `.lua`                               | `lua`                                 |
+| OCaml                               | `.ml`, `.mli`                        | `ocaml`                               |
+| PHP                                 | `.php`, `.tpl`                       | `php`                                 |
+| Python                              | `.py`, `.pyi`                        | `python`, `python2`, `python3`, `py`  |
+| R                                   | `.r`, `.R`                           | `r`                                   |
+| Ruby                                | `.rb`                                | `ruby`                                |
+| Rust                                | `.rs`                                | `rust`                                |
+| Scala                               | `.scala`                             | `scala`                               |
+| Scheme                              | `.scm`, `.ss`                        | `scheme`                              |
+| Solidity                            | `.sol`                               | `solidity`, `sol`                     |
+| Swift                               | `.swift`                             | `swift`                               |
+| Terraform                           | `.tf`, `.hcl`                        | `tf`, `hcl`, `terraform`              |
+| TypeScript                          | `.ts`, `.tsx`                        | `ts`, `typescript`                    |
+| TSX                                 | `.ts`, `.tsx`                        | `ts`, `typescript`                    |
+| YAML                                | `.yml`, `.yaml`                      | `yaml`                                |
+| XML                                 |  `.xml`                              | `xml`                                 |
+
+:::info
+To see maturity level of each supported language, see the following sections in [Supported languages](/supported-languages/) document:
+- [Semgrep OSS Engine](/supported-languages/#semgrep-oss-engine)
+- [Semgrep Pro Engine](/supported-languages/#semgrep-pro-engine)
+:::
 
 <!-- </details> -->
 

--- a/src/components/reference/_language-extensions-tags.mdx
+++ b/src/components/reference/_language-extensions-tags.mdx
@@ -5,9 +5,9 @@ or by default) uncomment the following two lines and closing tag below the table
 <!-- <details> -->
 <!-- <summary>Expand table of extensions and tags</summary> -->
 
-The following table includes languages supported by Semgrep, accepted file extensions for test files that accompany rules, and valid values that Semgrep rules require in the `language` or `languages` key.
+The following table includes languages supported by Semgrep, accepted file extensions for test files that accompany rules, and valid values that Semgrep rules require in the `languages` key.
 
-| Language                            | Extensions                           | `language` and `languages` key values |
+| Language                            | Extensions                           | `languages` key values                |
 |:------------------------------------|:-------------------------------------|:--------------------------------------|
 | Apex (only in Semgrep Pro Engine)   | `.cls`                               | `apex`                                | 
 | Bash                                | `.bash`, `.sh`                       | `bash`, `sh`                          |

--- a/src/components/reference/_language-extensions-tags.mdx
+++ b/src/components/reference/_language-extensions-tags.mdx
@@ -5,7 +5,7 @@ or by default) uncomment the following two lines and closing tag below the table
 <!-- <details> -->
 <!-- <summary>Expand table of extensions and tags</summary> -->
 
-The following table includes languages that Semgrep supports, their file extension, and valid values that Semgrep rules require in the `language` or `languages` key.
+The following table includes languages supported by Semgrep, accepted file extensions for test files that accompany rules, and valid values that Semgrep rules require in the `language` or `languages` key.
 
 | Language                            | Extensions                           | `language` and `languages` key values |
 |:------------------------------------|:-------------------------------------|:--------------------------------------|

--- a/src/components/reference/_language-extensions-tags.mdx
+++ b/src/components/reference/_language-extensions-tags.mdx
@@ -47,7 +47,7 @@ The following table includes languages supported by Semgrep, accepted file exten
 | XML                                 |  `.xml`                              | `xml`                                 |
 
 :::info
-To see maturity level of each supported language, see the following sections in [Supported languages](/supported-languages/) document:
+To see the maturity level of each supported language, see the following sections in [Supported languages](/supported-languages/) document:
 - [Semgrep OSS Engine](/supported-languages/#semgrep-oss-engine)
 - [Semgrep Pro Engine](/supported-languages/#semgrep-pro-engine)
 :::

--- a/src/components/reference/_language-extensions-tags.mdx
+++ b/src/components/reference/_language-extensions-tags.mdx
@@ -13,7 +13,6 @@ or by default) uncomment the following two lines and closing tag below the table
 | C#         | `.cs`                  | `csharp`, `cs`, `C#`                 |
 | Generic    |                        | `generic`                            |
 | Go         | `.go`                  | `go`, `golang`                       |
-| Hack       | `.h`, `.hack`          | `hack`                               |
 | HTML       | `.htm`, `.html`        | `html`                               |
 | Java       | `.java`                | `java`                               |
 | JavaScript | `.js`, `.jsx`          | `js`, `jsx`, `javascript`            |
@@ -33,6 +32,15 @@ or by default) uncomment the following two lines and closing tag below the table
 | TypeScript | `.ts`, `.tsx`          | `ts`, `tsx`, `typescript`            |
 | TSX        | `.ts`, `.tsx`          | `ts`, `tsx`, `typescript`            |
 | YAML       | `.yaml`                | `yaml`                               |
+| XML        |  `.xml`                |  TODO                                |
+| Clojure    | `.clj`, `.cljs`, `.cljc`, `.edn` | TODO                       |
+| Dart       | `.dart`                | TODO                                 |
+| Dockerfile | `.dockerfile`          | TODO                                 |
+| Elixir     | `.ex`, `exs`           | TODO                                 |
+| Jsonnet    | `.jsonnet`, `.libsonnet` | TODO                               |
+| Scheme     | `.scm`, `.ss`          | TODO                                 |
+| Swift      | `.swift`               | TODO                                 |
+
 
 <!-- </details> -->
 


### PR DESCRIPTION
- Update according to: https://github.com/returntocorp/semgrep-langs/blob/main/lang.json
- Remove Hack as the support level is only develop

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
