### PR TITLE
Sara/patch/ghsa

### DIFF
--- a/docs/semgrep-supply-chain/glossary.md
+++ b/docs/semgrep-supply-chain/glossary.md
@@ -87,4 +87,4 @@ An unreachable finding means that the dependency's version contains a known vuln
 
 ## Vulnerability
 
-A vulnerability is an unintentional flaw in a dependency that can be exploited. Vulnerabilities are assigned a CVE by the [MITRE corporation](https://cve.mitre.org/). Semgrep Supply Chain uses GitHub Security Advisory in categorizing the severity of a vulnerability.
+A vulnerability is an unintentional flaw in a dependency that can be exploited. Vulnerabilities are assigned a CVE by the [MITRE corporation](https://cve.mitre.org/). Semgrep Supply Chain uses GitHub Security Advisory (GHSA) in categorizing the severity of a vulnerability.

--- a/docs/semgrep-supply-chain/triage-remediation.md
+++ b/docs/semgrep-supply-chain/triage-remediation.md
@@ -11,6 +11,7 @@ hide_title: true
 
 import MoreHelp from "/src/components/MoreHelp"
 import AdmonitionSscLicense from "/src/components/reference/_admonition-ssc-license.md"
+import AdmonitionSotCves from "/src/components/reference/_admonition-sot-cves.md"
 
 <ul id="tag__badge-list">
 {
@@ -230,5 +231,7 @@ To ignore a vulnerability:
 ### Viewing the latest advisories
 
 The **Advisories** tab displays the newest CVEs that Semgrep Supply Chain can detect. Click the individual entry to see the code pattern that the Advisory detects. 
+
+<AdmonitionSotCves />
 
 <MoreHelp />

--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -168,7 +168,7 @@ This table provides information about fully supported (generally available or GA
     <th>Lockfile</th>
     <th>Scans transitive dependencies*</th>
     <th>Identifies transitive dependencies†</th>
-    <th>Rule coverage for CVEs/GHSAs‡</th>
+    <th>Rule coverage for GHSA CVEs‡</th>
 </tr></thead>
 <tbody><tr>
    <td>Go</td>
@@ -244,12 +244,14 @@ This table provides information about fully supported (generally available or GA
 
 _*****Semgrep Supply Chain scans transitive dependencies but does **not** perform reachability analysis on them._ <br />
 _**†**Refers to functionality in Semgrep Cloud Platform to indicate through a badge if a package is a transitive or direct dependency. This does not affect reachability analysis for any language._<br />
-_**‡**The month and year that Semgrep Supply Chain has begun writing rules to detect vulnerabilities listed in GHSA and the CVE program._<br />
+_**‡**The month and year that Semgrep Supply Chain has begun writing rules to detect vulnerabilities listed in GHSA._<br />
 _**††**Semgrep Supply Chain supports `requirements.txt` when it is used as a **lockfile**. This means that `requirements.txt` must be set to exact versions (pinned dependencies) and the file must be generated automatically._
 
+:::info
+Semgrep uses GitHub Security Advisory as the source of truth for advisories.
+:::
 
 :::info Transitivity support
-
 For more information on transitivity, see [Transitive dependencies and reachability analysis](/docs/semgrep-supply-chain/overview/#transitive-dependencies-and-reachability-analysis).
 :::
 

--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -16,6 +16,7 @@ import SupportedLanguagesTable from '/src/components/reference/_supported-langua
 import SscIntro from "/src/components/concept/_ssc-intro.md"
 import MoreHelp from "/src/components/MoreHelp"
 import DeepSemgrepIntroduction from "/src/components/concept/_semgrep-pro-engine-introduction.mdx"
+import AdmonitionSotCves from "/src/components/reference/_admonition-sot-cves.md"
 
 <ul id="tag__badge-list">
 {
@@ -247,9 +248,7 @@ _**†**Refers to functionality in Semgrep Cloud Platform to indicate through a 
 _**‡**The month and year that Semgrep Supply Chain has begun writing rules to detect vulnerabilities listed in GHSA._<br />
 _**††**Semgrep Supply Chain supports `requirements.txt` when it is used as a **lockfile**. This means that `requirements.txt` must be set to exact versions (pinned dependencies) and the file must be generated automatically._
 
-:::info
-Semgrep uses GitHub Security Advisory as the source of truth for advisories.
-:::
+<AdmonitionSotCves />
 
 :::info Transitivity support
 For more information on transitivity, see [Transitive dependencies and reachability analysis](/docs/semgrep-supply-chain/overview/#transitive-dependencies-and-reachability-analysis).

--- a/src/components/reference/_admonition-sot-cves.md
+++ b/src/components/reference/_admonition-sot-cves.md
@@ -1,0 +1,3 @@
+:::info
+Semgrep uses GitHub Security Advisory as the source of truth for advisories.
+:::

--- a/src/components/reference/_admonition-sot-cves.md
+++ b/src/components/reference/_admonition-sot-cves.md
@@ -1,3 +1,3 @@
 :::info
-Semgrep uses GitHub Security Advisory as the source of truth for advisories.
+Semgrep uses **[GitHub Security Advisory (GHSA)](https://github.com/advisories)** as the source of truth for advisories and rule coverage.
 :::


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
~~- [ ] A technical writer reviews the content or PR~~ quick patch
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link

Adds a callout box (admonition) into Supported Languages and Advisories. Renames CVEs/GHSAs into GHSA CVEs (using the GHSA noun as an adjective) to specify that the CVEs come from GHAs.
<img width="648" alt="Snag_2153680" src="https://github.com/returntocorp/semgrep-docs/assets/20766840/db599c2d-40c4-42ae-a28d-54eb60fb2567">

<img width="643" alt="2023-06-10_01-36-11" src="https://github.com/returntocorp/semgrep-docs/assets/20766840/2e8fc4b0-94c1-4ac2-9f9c-80aabbfda58d">


