### PR TITLE
Remove reference to Slack on PR comment page

### DIFF
--- a/docs/semgrep-cloud-platform/github-pr-comments.md
+++ b/docs/semgrep-cloud-platform/github-pr-comments.md
@@ -24,7 +24,7 @@ Object.entries(frontMatter).filter(
 # Enabling GitHub pull request comments
 
 :::info Prerequisites
-* Pull request (PR) comments can only be enabled through Semgrep Cloud Platform (SCP). [Create an account](/semgrep-code/getting-started/#signing-in-to-semgrep-cloud-platform) to set up Slack notifications.
+* Pull request (PR) comments can only be enabled through Semgrep Cloud Platform (SCP). [Create an account](/semgrep-code/getting-started/#signing-in-to-semgrep-cloud-platform) to set up PR comments.
 * To receive alerts and notifications, you must [add or onboard a project](/semgrep-code/getting-started/#option-b-adding-a-repository-from-github-gitlab-or-bitbucket) (repository) to Semgrep Cloud Platform for scanning.
 :::
 


### PR DESCRIPTION
This looked like a copy-pasta issue - the note it should refer to the thing that the page focuses on configuring, not something else.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
