### PR TITLE
fixing small typo, install -> core-install

### DIFF
--- a/docs/contributing/semgrep-core-contributing.md
+++ b/docs/contributing/semgrep-core-contributing.md
@@ -118,7 +118,7 @@ make core-test
 Finally, to update the `semgrep-core` binary used by `semgrep`, run
 
 ```
-make install
+make core-install
 ```
 
 ### Testing `semgrep-core`


### PR DESCRIPTION
Updated the documentation with the correct command for making core install, (just changed make install to make core-install)
### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
