### PR TITLE
Update admonition to reflect Policies as default

### DIFF
--- a/docs/semgrep-code/policies.md
+++ b/docs/semgrep-code/policies.md
@@ -23,9 +23,9 @@ Object.entries(frontMatter).filter(
 # Policies
 
 :::tip
-The Policies page is a new version of the [Rule board](https://semgrep.dev/orgs/-/board).
+The Policies page is a new version of the [Rule board](https://semgrep.dev/orgs/-/board) that is now the default representation for rule management.
 
-To access the Policies page: Go to [Rule board](https://semgrep.dev/orgs/-/board), and then click **Try new version**. You can go back to the old Rule board by clicking the **Back to old version** button.
+You can go back to the old Rule board by clicking the **Back to old version** button.
 :::
 
 The Policies page displays a visual representation of the rules that Semgrep Code uses for scanning. Rules can be categorized into various groups. The Policies page uses the following categorization criteria:

--- a/docs/semgrep-code/rule-board.md
+++ b/docs/semgrep-code/rule-board.md
@@ -25,7 +25,11 @@ Object.entries(frontMatter).filter(
 # Rule board
 
 :::tip
-🎉 There is a new version of the Rule board called **Policies**. 🎉 To access the Policies page, go to [Rule board](https://semgrep.dev/orgs/-/board), and then click **Try new version**. You can always go back to the old Rule board by clicking the **Back to old version** button. For more information, see [Policies](/semgrep-code/policies/) documentation.
+🎉 There is a new version of the Rule board called **Policies** that is now the default representation for rule management. 🎉 
+
+If you've previously opted out of Policies, to access it again, go to [Rule board](https://semgrep.dev/orgs/-/board), and then click **Try new version**.
+
+You can go back to the Rule board by clicking the **Back to old version** button. For more information, see [Policies](/semgrep-code/policies/) documentation.
 
 The new Policies page:
 - Autosaves any changes you make on the page.

--- a/docs/semgrep-code/rule-board.md
+++ b/docs/semgrep-code/rule-board.md
@@ -27,9 +27,9 @@ Object.entries(frontMatter).filter(
 :::tip
 🎉 There is a new version of the Rule board called **Policies** that is now the default representation for rule management. 🎉 
 
-If you've previously opted out of Policies, to access it again, go to [Rule board](https://semgrep.dev/orgs/-/board), and then click **Try new version**.
-
 You can go back to the Rule board by clicking the **Back to old version** button. For more information, see [Policies](/semgrep-code/policies/) documentation.
+
+If you've previously opted out of Policies, to access it again, go to [Rule board](https://semgrep.dev/orgs/-/board), and then click **Try new version**.
 
 The new Policies page:
 - Autosaves any changes you make on the page.


### PR DESCRIPTION
On June 14 we shifted from beta-testing the new Policies (Rule management) to making it the default. This update reflects that in the tips at the top of each relevant page.

[Linear issue](https://linear.app/semgrep/issue/MKT-680/update-rule-board-and-policies-docs-to-reflect-new-policies-as-default)

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs