### PR TITLE
[New KB article] Match the absence of something in a file

### DIFF
--- a/docs/kb/rules/match-absence.md
+++ b/docs/kb/rules/match-absence.md
@@ -1,0 +1,36 @@
+---
+description: How do I match the absence of something in a file?
+tags:
+  - Rules
+  - Semgrep Registry
+  - Semgrep Code
+---
+
+# How do I match the absence of something in a file?
+
+Currently, Semgrep does not have a clear way to match the absence of a pattern, rather than the presence of one. However, you can approximate this behavior by matching an entire file with `pattern-regex`, and excluding a file that contains the desired content with `pattern-not-regex` or other negative patterns.
+
+Here is a simple example:
+
+```yml
+rules:
+  - id: a
+    patterns:
+      - pattern-regex: |
+          (?s)(.*)
+      - pattern-not-regex: .*YOUR PATTERN TO BLOCK
+    message: match
+    languages:
+      - generic
+    severity: ERROR
+```
+
+:::note Example
+Try this pattern in the [Semgrep Playground](https://semgrep.dev/playground/s/vop8). 
+:::
+
+The regex pattern `(?s)(.*)` uses the `s` flag to put the match in "single-line" mode, so that the dot character matches a newline. This allows `(.*)` to match multiple lines, and therefore match an entire file.
+
+If the file contains `YOUR PATTERN TO BLOCK`, then the match is negated and the file does not appear as a finding. If the file does not contain `YOUR PATTERN TO BLOCK`, the file will be flagged as a finding. The finding will span the whole file, starting at line 1.
+
+

--- a/docs/kb/rules/match-absence.md
+++ b/docs/kb/rules/match-absence.md
@@ -1,12 +1,12 @@
 ---
-description: How do I match the absence of something in a file?
+description: You can approximate this behavior by matching an entire file, but excluding the desired content from the match.
 tags:
   - Rules
   - Semgrep Registry
   - Semgrep Code
 ---
 
-# How do I match the absence of something in a file?
+# Match the absence of something in a file
 
 Currently, Semgrep does not have a clear way to match the absence of a pattern, rather than the presence of one. However, you can approximate this behavior by matching an entire file with `pattern-regex`, and excluding a file that contains the desired content with `pattern-not-regex` or other negative patterns.
 

--- a/docs/kb/rules/match-absence.md
+++ b/docs/kb/rules/match-absence.md
@@ -29,8 +29,8 @@ rules:
 Try this pattern in the [Semgrep Playground](https://semgrep.dev/playground/s/vop8). 
 :::
 
-The regex pattern `(?s)(.*)` uses the `s` flag to put the match in "single-line" mode, so that the dot character matches a newline. This allows `(.*)` to match multiple lines, and therefore match an entire file.
+The regular expression pattern `(?s)(.*)` uses the `s` flag to put the match in "single-line" mode, so that the dot character matches a newline. This allows `(.*)` to match multiple lines, and therefore match an entire file.
 
-If the file contains `YOUR PATTERN TO BLOCK`, then the match is negated and the file does not appear as a finding. If the file does not contain `YOUR PATTERN TO BLOCK`, the file will be flagged as a finding. The finding will span the whole file, starting at line 1.
+If the file contains `YOUR PATTERN TO BLOCK`, then the match is negated and the file does not appear as a finding. If the file does not contain `YOUR PATTERN TO BLOCK`, the file is flagged as a finding. With this rule, the finding spans the whole file, starting at line 1.
 
 


### PR DESCRIPTION
One question we get is how to match the absence of a pattern, which is currently not supported natively as at least one positive pattern is required. This KB gives an option using pattern-regex.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team