### PR TITLE
chore: fix urls to broken snippets

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -55,7 +55,7 @@ You **cannot** ship the Semgrep Community rules in a commercial product without 
 
 The Semgrep Pro Rules are proprietary and cannot be redistributed without explicit license from Semgrep, Inc. For more information, please contact partners@semgrep.com.
 
-### Contacting Semgrep, Inc support 
+### Contacting Semgrep, Inc support
 
 All users can contact Semgrep, Inc support. Regardless if you are a free tier or paid tier user, reach our support through the [Semgrep, Inc Community Slack](https://go.semgrep.dev/slack). Paying Semgrep Team tier customers receive 8\*5 email/phone/Slack support with committed SLAs. See [Support](../support/) for more details.
 
@@ -64,10 +64,7 @@ All users can contact Semgrep, Inc support. Regardless if you are a free tier or
 Embed a special version of Semgrep Playground with an `iframe`. The source is `https://semgrep.dev/embed/editor?snippet=<snippet-id>` where the `snippet-id` is either the short identifier generated when you share a Playground link (this usually looks like `DzKv`) or the named identifier from a saved rule (this usually looks like `username:rule-name`).
 
 ```html
-<iframe title="Semgrep example no prints" src="https://semgrep.dev/embed/editor?snippet=DzKv" width="100%" height="432" frameborder="0"></iframe>
-
-
-<iframe title="Semgrep example no prints" src="https://semgrep.dev/embed/editor?snippet=ievans:print-to-logger" width="100%" height="432" frameborder="0"></iframe>
+<iframe title="Semgrep example no prints" src="https://semgrep.dev/embed/editor?snippet=3qUzQD" width="100%" height="432" frameborder="0"></iframe>
 ```
 
 ## Comparisons
@@ -90,7 +87,7 @@ If you are shipping code daily a code analysis tool that takes a week to run is 
 
 Semgrep automatically handles the nuance of “there’s more than one way to do it”: you write your query and all equivalent variations of that code are automatically matched.
 
-As Semgrep evolves, queries similar to `foo("password")` become smarter. In the original version of Semgrep, this query would only match the code `foo("password")`. But a few months after release Semgrep would match `const x = "password"; foo(x)`. Today Semgrep can [do even more with intraprocedural dataflow](https://semgrep.dev/s/ievans:c-dataflow) analysis, and we’re working on adding more of these semantic features with every release.
+As Semgrep evolves, queries similar to `foo("password")` become smarter. In the original version of Semgrep, this query would only match the code `foo("password")`. But a few months after release Semgrep would match `const x = "password"; foo(x)`. Today Semgrep can [do even more with intraprocedural dataflow](https://semgrep.dev/s/AbUGbp) analysis, and we’re working on adding more of these semantic features with every release.
 
 **3. Integrated: Semgrep understands git and other version-control systems**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,14 +33,12 @@ The code is kept here for easy maintenance.
 
 Semgrep is a fast, open source, static analysis engine for finding bugs, detecting dependency vulnerabilities, and enforcing code standards. [Get started →](getting-started/)
 
-Semgrep analyzes code locally on your computer or in your build environment: **code is never uploaded**. 
+Semgrep analyzes code locally on your computer or in your build environment: **code is never uploaded**.
 
 Its rules look like the code you already write; no abstract syntax trees, regex wrestling, or painful DSLs. Here's a quick rule for finding Python `print()` statements. Run it by clicking the [▸] button:
 
-<iframe title="Semgrep example no prints" src="https://semgrep.dev/embed/editor?snippet=ievans:print-to-logger" width="100%" height="432px" frameBorder="0"></iframe>
+<iframe title="Semgrep example no prints" src="https://semgrep.dev/embed/editor?snippet=3qUzQD" width="100%" height="432px" frameBorder="0"></iframe>
 <br />
-
-<!-- <EditorWidget snippetId={"ievans:print-to-logger2"} /> -->
 
 The Semgrep ecosystem includes the following products:
 
@@ -77,7 +75,7 @@ The following table lists environments in which you can run various Semgrep prod
 | Semgrep Code         |  ✅  Log in to access [Pro Engine](semgrep-code/semgrep-pro-engine-intro) and [Pro rules](semgrep-code/pro-rules) (Team and Enterprise tier) |   ✅  Best used with [Semgrep Cloud Platform](semgrep-cloud-platform/getting-started) |
 | Semgrep Supply Chain |  ✅  Log in to access [Supply Chain](semgrep-supply-chain/overview) rules (Team and Enterprise tier)  |   ✅  Best used with [Semgrep Cloud Platform](semgrep-cloud-platform/getting-started) |
 
-:::info 
+:::info
 Semgrep Cloud Platform is a hosted web application (SaaS) and as such is excluded from the table.
 :::
 

--- a/docs/playground.md
+++ b/docs/playground.md
@@ -99,7 +99,7 @@ To create a rule in advanced mode:
 
 1. Ensure that you are in the **Advanced mode**.
 ![Screenshot of the advanced view](/img/pleditor-advanced.png "Playground advanced mode")
-2. Enter the keys and values needed to finish your rule. 
+2. Enter the keys and values needed to finish your rule.
 3. Click **Run** or press <kbd>Ctrl</kbd>+<kbd>Enter</kbd> (<kbd>⌘</kbd>+<kbd>Enter</kbd> on Mac).
 
 ## Running and testing a rule for precision
@@ -134,7 +134,7 @@ File a [bug](https://github.com/returntocorp/semgrep/issues/new?title=semgrep.de
 
 ## Exploring rules through Semgrep Registry
 
-[Semgrep Registry](https://semgrep.dev/explore/) is an open-source, community-driven repository of rules. These rules can detect OWASP vulnerabilities, best practice violations, and security issues for a wide variety of languages and frameworks. These rules can be used as a starting point for writing your own custom rules by creating a forked rule. 
+[Semgrep Registry](https://semgrep.dev/explore/) is an open-source, community-driven repository of rules. These rules can detect OWASP vulnerabilities, best practice violations, and security issues for a wide variety of languages and frameworks. These rules can be used as a starting point for writing your own custom rules by creating a forked rule.
 
 [Signing in to Semgrep Cloud Platform](https://semgrep.dev/login?return_path=/playground/) enables you to access the Registry directly from the Playground's Library pane.
 
@@ -152,7 +152,7 @@ Another method of creating rules is by **forking** or **copying** from existing 
 6. Click **Run** to validate your rule.
 7. Click **Save** to save your rule. The following rule displays the end result.
 
-<iframe title="Prevent use of MD2" src="https://semgrep.dev/embed/editor?snippet=s-santillan:use-of-md2" width="100%" height="432px" frameBorder="0"></iframe>
+<iframe title="Prevent use of MD2" src="https://semgrep.dev/embed/editor?snippet=KxU5pW" width="100%" height="432px" frameBorder="0"></iframe>
 
 ## Setting code standards by adding a rule to the Rule Board
 

--- a/docs/semgrep-code/editor.md
+++ b/docs/semgrep-code/editor.md
@@ -1,5 +1,5 @@
 ---
-slug: editor 
+slug: editor
 append_help_link: true
 title: Editor
 hide_title: true
@@ -105,7 +105,7 @@ Another method of creating rules is by **forking/copying** from existing rules f
 6. Click **Run** to validate your rule.
 7. Click **Save** to save your rule. The following rule displays the end result.
 
-<iframe title="Prevent use of MD2" src="https://semgrep.dev/embed/editor?snippet=s-santillan:use-of-md2" width="100%" height="432px" frameBorder="0"></iframe>
+<iframe title="Prevent use of MD2" src="https://semgrep.dev/embed/editor?snippet=KxU5pW" width="100%" height="432px" frameBorder="0"></iframe>
 
 ### Debugging syntax issues
 

--- a/docs/writing-rules/experiments/display-propagated-metavariable.md
+++ b/docs/writing-rules/experiments/display-propagated-metavariable.md
@@ -6,7 +6,7 @@ description: "This document provides information about experimental syntax addit
 
 # Displaying propagated value of metavariables
 
-This document provides information about experimental syntax supplement to [Displaying matched metavariables in rule messages](/writing-rules/pattern-syntax/#displaying-matched-metavariables-in-rule-messages). Semgrep enables you to display values of matched metavariables in rule messages. However, in some cases, the matched value of the metavariable is not the real value you were looking for. 
+This document provides information about experimental syntax supplement to [Displaying matched metavariables in rule messages](/writing-rules/pattern-syntax/#displaying-matched-metavariables-in-rule-messages). Semgrep enables you to display values of matched metavariables in rule messages. However, in some cases, the matched value of the metavariable is not the real value you were looking for.
 
 See the following rule message and part of a Semgrep rule (formula):
 
@@ -45,4 +45,4 @@ Regular Semgrep syntax for displaying matched metavariables in rule messages is 
 
 Run the following example in Semgrep Playground to see the message (click **Open in Editor**, and then **Run**, unroll the **1 Match** to see the message):
 
-<iframe title="Metavariable value in message example" src="https://semgrep.dev/embed/editor?snippet=returntocorp:value-in-message-example" width="100%" height="432" frameborder="0"></iframe>
+<iframe title="Metavariable value in message example" src="https://semgrep.dev/embed/editor?snippet=3qU28g" width="100%" height="432" frameborder="0"></iframe>

--- a/docs/writing-rules/generic-pattern-matching.md
+++ b/docs/writing-rules/generic-pattern-matching.md
@@ -104,7 +104,7 @@ With respect to Semgrep operators and features:
 * metavariable support is limited to capturing a single “word”, which is a token of the form [A-Za-z0-9_]+. They can’t capture sequences of tokens such as hello, world (in this case there are 3 tokens: `hello`, `,`, and `world`).
 * the ellipsis operator is supported and spans at most 10 lines
 * pattern operators like either/not/inside are supported
-* inline regular expressions for strings (`"=~/word.*/"`) is not supported 
+* inline regular expressions for strings (`"=~/word.*/"`) is not supported
 
 ## Troubleshooting
 
@@ -219,13 +219,13 @@ To match an arbitrary sequence of items and capture their value in the example:
     `server = example.com`. In generic mode, an ellipsis extends until the end of the current block or up to 10 lines below, whichever comes first. To prevent this behavior, continue with the next step.
 
 2. In the Semgrep rule, specify the following key:
-   
+
     ```yaml
     generic_ellipsis_max_span: 0
     ```
 
     This option forces the ellipsis operator to match patterns within a single line.
-    Example of the [resulting rule](https://semgrep.dev/playground/s/returntocorp:password-in-config-file):
+    Example of the [resulting rule](https://semgrep.dev/playground/r/L1UkAg/returntocorp.password-in-config-file):
 
     ```yaml
     id: password-in-config-file
@@ -244,7 +244,7 @@ To match an arbitrary sequence of items and capture their value in the example:
 ### Ignoring comments
 
 By default, the generic mode does **not** know about comments or code
-that can be ignored. In the following example, we are 
+that can be ignored. In the following example, we are
 scanning for CSS code that sets the text color to blue. The target code
 is the following:
 

--- a/docs/writing-rules/pattern-syntax.mdx
+++ b/docs/writing-rules/pattern-syntax.mdx
@@ -124,7 +124,7 @@ The YAML `|` operator allows for [multiline strings](https://yaml-multiline.info
 :::
 
 The ellipsis operator can match the function name.
-Match any function definition: 
+Match any function definition:
 Regular functions, methods, and also anonymous functions (such as lambdas).
 To match named or anonymous functions use an ellipsis `...` in place of the name of the function.
 For example, in JavaScript the pattern `function ...($X) { ... }` matches
@@ -470,7 +470,7 @@ class Test {
 
     public static void run_test(String input, int num) {
         logger.log("Running a test with " + input);
-        
+
         test(input, Math.log(num));
     }
 }
@@ -484,7 +484,7 @@ If you searched for `$X.log(...)`, you would also match `Math.log(num)`. Instead
 
 which will only give you the call to `logger`.
 
-See the rule [here](https://semgrep.dev/s/emjin:logger_search)
+See the rule [here](https://semgrep.dev/r/ReUyBA/emjin.logger_search)
 
 
 :::caution
@@ -530,7 +530,7 @@ Setting a password on user
 
 Run the following example in Semgrep Playground to see the message (click **Open in Editor**, and then **Run**, unroll the **1 Match** to see the message):
 
-<iframe title="Metavariable value in message example" src="https://semgrep.dev/embed/editor?snippet=returntocorp:metavariable-message-example" width="100%" height="432" frameborder="0"></iframe>
+<iframe title="Metavariable value in message example" src="https://semgrep.dev/embed/editor?snippet=KxU84Y" width="100%" height="432" frameborder="0"></iframe>
 
 :::info
 If you're using Semgrep's advanced dataflow features, see documentation of experimental feature [Displaying propagated value of metavariable](/writing-rules/experiments/display-propagated-metavariable).

--- a/docs/writing-rules/rule-ideas.md
+++ b/docs/writing-rules/rule-ideas.md
@@ -13,7 +13,7 @@ Not sure what to write a rule for? Below are some common questions, ideas, and t
 
 _Time to write this rule: **5 minutes**_
 
-You can use Semgrep and its GitHub integration to [automate PR comments](/semgrep-code/notifications/) that you frequently make in code reviews. Writing a custom rule for the code pattern you want to target is usually straightforward. If you want to understand the Semgrep syntax, see the [documentation](../pattern-syntax/) or try the [tutorial](https://semgrep.dev/learn). 
+You can use Semgrep and its GitHub integration to [automate PR comments](/semgrep-code/notifications/) that you frequently make in code reviews. Writing a custom rule for the code pattern you want to target is usually straightforward. If you want to understand the Semgrep syntax, see the [documentation](../pattern-syntax/) or try the [tutorial](https://semgrep.dev/learn).
 
 ![A reviewer writes a Semgrep rule and adds it to an organization-wide policy](/img/semgrep-ci.gif)
 <br />
@@ -26,7 +26,7 @@ _Time to write this rule: **5 minutes**_
 
 Semgrep can detect dangerous APIs in code. If integrated into CI/CD pipelines, you can use Semgrep to block merges or flag for review when someone adds such dangerous APIs to the code. For example, a rule that detects React's `dangerouslySetInnerHTML` looks like this.
 
-<iframe src="https://semgrep.dev/embed/editor?snippet=minusworld:docs-dangerously-set-inner-html" title="Ban dangerous APIs with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
+<iframe src="https://semgrep.dev/embed/editor?snippet=r6UkbR" title="Ban dangerous APIs with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
 
 
 ### Exempting special cases of dangerous APIs
@@ -35,7 +35,7 @@ _Time to write this rule: **5 minutes**_
 
 If you have a legitimate use case for a dangerous API, you can exempt a specific use of the API using a `nosemgrep` comment. The rule below checks for React's `dangerouslySetInnerHTML`, but the code is annotated with a `nosemgrep` comment. Semgrep will not detect this line. This allows Semgrep to continuously check for future uses of `dangerouslySetInnerHTML` while allowing for this specific use.
 
-<iframe src="https://semgrep.dev/embed/editor?snippet=minusworld:docs-dangerously-set-inner-html-nosem" title="Exempt special cases of dangerous APIs with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
+<iframe src="https://semgrep.dev/embed/editor?snippet=nJUYdL" title="Exempt special cases of dangerous APIs with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
 
 ### Detect tainted data flowing into a dangerous sink
 
@@ -43,9 +43,9 @@ _Time to write this rule: **5 minutes**_
 
 Semgrep's [dataflow engine with support for taint tracking](/writing-rules/data-flow/data-flow-overview/) can be used to detect when data flows from a user-provided value into a security-sensitive function.
 
-This rule detects when a user of the ExpressJS framework passes user data into the `run()` method of a sandbox. 
+This rule detects when a user of the ExpressJS framework passes user data into the `run()` method of a sandbox.
 
-<iframe src="https://semgrep.dev/embed/editor?snippet=ievans:simple-taint-dataflow" title="ExpressJS dataflow to sandbox.run" width="100%" height="432px" frameBorder="0"></iframe>
+<iframe src="https://semgrep.dev/embed/editor?snippet=BYUddg" title="ExpressJS dataflow to sandbox.run" width="100%" height="432px" frameBorder="0"></iframe>
 
 
 ### Detect security violations
@@ -56,7 +56,7 @@ Use Semgrep to flag specific uses of APIs too, not just their presence in code. 
 
 This rule detects when HTML autoescaping is explicitly disabled for a Django template.
 
-<iframe src="https://semgrep.dev/embed/editor?snippet=minusworld:docs-context-autoescape-off" title="Detect security violations in code with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
+<iframe src="https://semgrep.dev/embed/editor?snippet=bwUOxg" title="Detect security violations in code with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
 
 
 ### Scan configuration files using JSON, YAML, or Generic pattern matching
@@ -65,11 +65,11 @@ _Time to write this rule: **10 minutes**_
 
 Semgrep [natively supports JSON and YAML](../supported-languages.md) and can be used to write rules for configuration files. This rule checks for skipped TLS verification in Kubernetes clusters.
 
-<iframe src="https://semgrep.dev/embed/editor?snippet=minusworld:docs-kubernetes-skip-tls-verify" title="Match configuration files with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
+<iframe src="https://semgrep.dev/embed/editor?snippet=kxURrE" title="Match configuration files with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
 
 The [Generic pattern matching](/writing-rules/generic-pattern-matching/) mode is for languages and file formats that Semgrep does not natively support. For example, you can write rules for Dockerfiles using the generic mode. The Dockerfile rule below checks for invalid port numbers.
 
-<iframe src="https://semgrep.dev/embed/editor?snippet=minusworld:docs-dockerfile-invalid-port" title="Match Dockerfiles with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
+<iframe src="https://semgrep.dev/embed/editor?snippet=wdU84r" title="Match Dockerfiles with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
 
 
 ### Enforce authentication patterns
@@ -78,7 +78,7 @@ _Time to write this rule: **15 minutes**_
 
 If a project has a "correct" way of doing authentication, Semgrep can be used to enforce this so that authentication mishaps do not happen. In the example below, this Flask app requires an authentication decorator on all routes. The rule detects routes that are missing authentication decorators. If deployed in CI/CD pipelines, Semgrep can block undecorated routes or flag a security member for further investigation.
 
-<iframe src="https://semgrep.dev/embed/editor?snippet=minusworld:docs-missing-auth-annotation" title="Enforce authentication patterns in code with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
+<iframe src="https://semgrep.dev/embed/editor?snippet=x8UW9P" title="Enforce authentication patterns in code with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
 
 
 ### Systematize project-specific coding patterns
@@ -96,7 +96,7 @@ In this example, a legacy API requires calling `verify_transaction(t)` before ca
 
 _Time to write this rule: **15 minutes**_
 
-Semgrep metavariables can be used as output in the `message` key. This can be used to extract and collate information about a codebase. Click through to [this example](https://semgrep.dev/s/clintgibler:spring-routes) which extracts Java Spring routes. This can be used to quickly see all the exposed routes of an application.
+Semgrep metavariables can be used as output in the `message` key. This can be used to extract and collate information about a codebase. Click through to [this example](https://semgrep.dev/s/zdUAnN) which extracts Java Spring routes. This can be used to quickly see all the exposed routes of an application.
 
 
 ### Burn down deprecated APIs
@@ -107,7 +107,7 @@ Semgrep can detect deprecated APIs just as easily as dangerous APIs. Identifying
 
 This rule example detects a function that is deprecated as of Django 4.0.
 
-<iframe src="https://semgrep.dev/embed/editor?snippet=minusworld:docs-deprecated-api" title="Burn down deprecated APIs with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
+<iframe src="https://semgrep.dev/embed/editor?snippet=OrUG41" title="Burn down deprecated APIs with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
 
 
 ### Promote secure alternatives
@@ -116,7 +116,7 @@ _Time to write this rule: **5 minutes**_
 
 Some libraries or APIs have safe alternatives, such as [Google's `re2`](https://github.com/google/re2), an implementation of the standard `re` interface that ships with Python that is resistant to regular expression denial-of-service. This rule detects the use of `re` and recommends `re2` as a safe alternative with the same interface.
 
-<iframe src="https://semgrep.dev/embed/editor?snippet=minusworld:docs-use-re2" title="Promote secure alternatives with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
+<iframe src="https://semgrep.dev/embed/editor?snippet=EwU4dw" title="Promote secure alternatives with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
 
 
 ## Prompts for writing custom rules

--- a/docs/writing-rules/rule-syntax.md
+++ b/docs/writing-rules/rule-syntax.md
@@ -59,7 +59,7 @@ The below optional fields must reside underneath a `patterns` field.
 The `pattern` operator looks for code matching its expression. This can be basic expressions like `$X == $X` or unwanted function calls like `hashlib.md5(...)`.
 
 :::note Example
-Try this pattern in the [Semgrep Playground](https://semgrep.dev/s/gJo5). 
+Try this pattern in the [Semgrep Playground](https://semgrep.dev/s/gJo5).
 :::
 
 ### `patterns`
@@ -187,7 +187,7 @@ Try this pattern in the [Semgrep Playground](https://semgrep.dev/s/ved8).
 :::
 
 :::info
-Include quotes in your regular expression when using `metavariable-regex` to search string literals. See [this snippet](https://semgrep.dev/s/mschwager:include-quotes) for more details. [String matching](pattern-syntax.mdx#string-matching) functionality can also be used to search string literals.
+Include quotes in your regular expression when using `metavariable-regex` to search string literals. See [this snippet](https://semgrep.dev/r/eqU83x/mschwager.include-quotes) for more details. [String matching](pattern-syntax.mdx#string-matching) functionality can also be used to search string literals.
 :::
 
 ### `metavariable-pattern`


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
