### PR TITLE
chore: include permalinks, additional minor formatting and textual edits

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -64,7 +64,7 @@ All users can contact Semgrep, Inc support. Regardless if you are a free tier or
 Embed a special version of Semgrep Playground with an `iframe`. The source is `https://semgrep.dev/embed/editor?snippet=<snippet-id>` where the `snippet-id` is either the short identifier generated when you share a Playground link (this usually looks like `DzKv`) or the named identifier from a saved rule (this usually looks like `username:rule-name`).
 
 ```html
-<iframe title="Semgrep example no prints" src="https://semgrep.dev/embed/editor?snippet=3qUzQD" width="100%" height="432" frameborder="0"></iframe>
+<iframe title="Semgrep example no prints" src="https://semgrep.dev/embed/editor?snippet=KPzL" width="100%" height="432" frameborder="0"></iframe>
 ```
 
 ## Comparisons
@@ -87,7 +87,7 @@ If you are shipping code daily a code analysis tool that takes a week to run is 
 
 Semgrep automatically handles the nuance of “there’s more than one way to do it”: you write your query and all equivalent variations of that code are automatically matched.
 
-As Semgrep evolves, queries similar to `foo("password")` become smarter. In the original version of Semgrep, this query would only match the code `foo("password")`. But a few months after release Semgrep would match `const x = "password"; foo(x)`. Today Semgrep can [do even more with intraprocedural dataflow](https://semgrep.dev/s/AbUGbp) analysis, and we’re working on adding more of these semantic features with every release.
+As Semgrep evolves, queries similar to `foo("password")` become smarter. In the original version of Semgrep, this query would only match the code `foo("password")`. But a few months after release Semgrep would match `const x = "password"; foo(x)`. Today Semgrep can [do even more with intraprocedural dataflow](https://semgrep.dev/s/50zj) analysis, and we’re working on adding more of these semantic features with every release.
 
 **3. Integrated: Semgrep understands git and other version-control systems**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,13 +31,13 @@ The code is kept here for easy maintenance.
 </p>
 <h3 align="center">Code scanning at ludicrous speed.<br />Find bugs and reachable dependency vulnerabilities in code.<br />Enforce your code standards on every commit.</h3>
 
-Semgrep is a fast, open source, static analysis engine for finding bugs, detecting dependency vulnerabilities, and enforcing code standards. [Get started →](getting-started/)
+Semgrep is a fast, open-source, static analysis engine for finding bugs, detecting dependency vulnerabilities, and enforcing code standards. [Get started →](getting-started/)
 
 Semgrep analyzes code locally on your computer or in your build environment: **code is never uploaded**.
 
-Its rules look like the code you already write; no abstract syntax trees, regex wrestling, or painful DSLs. Here's a quick rule for finding Python `print()` statements. Run it by clicking the [▸] button:
+Its rules look like the code you already write; no abstract syntax trees, regex wrestling, or painful DSLs. Here's a rule for finding Python `print()` statements. Run it by clicking the [▸] button:
 
-<iframe title="Semgrep example no prints" src="https://semgrep.dev/embed/editor?snippet=3qUzQD" width="100%" height="432px" frameBorder="0"></iframe>
+<iframe title="Semgrep example no prints" src="https://semgrep.dev/embed/editor?snippet=KPzL" width="100%" height="432px" frameBorder="0"></iframe>
 <br />
 
 The Semgrep ecosystem includes the following products:

--- a/docs/playground.md
+++ b/docs/playground.md
@@ -152,7 +152,7 @@ Another method of creating rules is by **forking** or **copying** from existing 
 6. Click **Run** to validate your rule.
 7. Click **Save** to save your rule. The following rule displays the end result.
 
-<iframe title="Prevent use of MD2" src="https://semgrep.dev/embed/editor?snippet=KxU5pW" width="100%" height="432px" frameBorder="0"></iframe>
+<iframe title="Prevent use of MD2" src="https://semgrep.dev/embed/editor?snippet=RDxN" width="100%" height="432px" frameBorder="0"></iframe>
 
 ## Setting code standards by adding a rule to the Rule Board
 

--- a/docs/semgrep-code/editor.md
+++ b/docs/semgrep-code/editor.md
@@ -105,7 +105,7 @@ Another method of creating rules is by **forking/copying** from existing rules f
 6. Click **Run** to validate your rule.
 7. Click **Save** to save your rule. The following rule displays the end result.
 
-<iframe title="Prevent use of MD2" src="https://semgrep.dev/embed/editor?snippet=KxU5pW" width="100%" height="432px" frameBorder="0"></iframe>
+<iframe title="Prevent use of MD2" src="https://semgrep.dev/embed/editor?snippet=RDxN" width="100%" height="432px" frameBorder="0"></iframe>
 
 ### Debugging syntax issues
 

--- a/docs/writing-rules/experiments/display-propagated-metavariable.md
+++ b/docs/writing-rules/experiments/display-propagated-metavariable.md
@@ -45,4 +45,4 @@ Regular Semgrep syntax for displaying matched metavariables in rule messages is 
 
 Run the following example in Semgrep Playground to see the message (click **Open in Editor**, and then **Run**, unroll the **1 Match** to see the message):
 
-<iframe title="Metavariable value in message example" src="https://semgrep.dev/embed/editor?snippet=3qU28g" width="100%" height="432" frameborder="0"></iframe>
+<iframe title="Metavariable value in message example" src="https://semgrep.dev/embed/editor?snippet=Dr0G" width="100%" height="432" frameborder="0"></iframe>

--- a/docs/writing-rules/generic-pattern-matching.md
+++ b/docs/writing-rules/generic-pattern-matching.md
@@ -104,7 +104,7 @@ With respect to Semgrep operators and features:
 * metavariable support is limited to capturing a single “word”, which is a token of the form [A-Za-z0-9_]+. They can’t capture sequences of tokens such as hello, world (in this case there are 3 tokens: `hello`, `,`, and `world`).
 * the ellipsis operator is supported and spans at most 10 lines
 * pattern operators like either/not/inside are supported
-* inline regular expressions for strings (`"=~/word.*/"`) is not supported
+* inline regular expressions for strings (`"=~/word.*/"`) are not supported
 
 ## Troubleshooting
 
@@ -225,7 +225,7 @@ To match an arbitrary sequence of items and capture their value in the example:
     ```
 
     This option forces the ellipsis operator to match patterns within a single line.
-    Example of the [resulting rule](https://semgrep.dev/playground/r/L1UkAg/returntocorp.password-in-config-file):
+    Example of the [resulting rule](https://semgrep.dev/playground/s/KPzn):
 
     ```yaml
     id: password-in-config-file

--- a/docs/writing-rules/pattern-syntax.mdx
+++ b/docs/writing-rules/pattern-syntax.mdx
@@ -476,16 +476,7 @@ class Test {
 }
 ```
 
-If you searched for `$X.log(...)`, you would also match `Math.log(num)`. Instead, you can search for
-
-```
-(Logger $X).log(...)
-```
-
-which will only give you the call to `logger`.
-
-See the rule [here](https://semgrep.dev/r/ReUyBA/emjin.logger_search)
-
+If you searched for `$X.log(...)`, you can also match `Math.log(num)`. Instead, you can search for `(Logger $X).log(...)` which gives you the call to `logger`. See the rule [logger_search](https://semgrep.dev/playground/s/lgAo).
 
 :::caution
 Since matching happens within a single file, this is only guaranteed to work for local variables and arguments. Additionally, Semgrep currently understands types on a shallow level. For example, if you have `int[] A`, it will not recognize `A[0]` as an integer. If you have a class with fields, you will not be able to use typechecking on field accesses, and it will not recognize the class’s field as the expected type. Literal types are understood to a limited extent. Expanded type support is under active development.
@@ -530,7 +521,7 @@ Setting a password on user
 
 Run the following example in Semgrep Playground to see the message (click **Open in Editor**, and then **Run**, unroll the **1 Match** to see the message):
 
-<iframe title="Metavariable value in message example" src="https://semgrep.dev/embed/editor?snippet=KxU84Y" width="100%" height="432" frameborder="0"></iframe>
+<iframe title="Metavariable value in message example" src="https://semgrep.dev/embed/editor?snippet=6KpK" width="100%" height="432" frameborder="0"></iframe>
 
 :::info
 If you're using Semgrep's advanced dataflow features, see documentation of experimental feature [Displaying propagated value of metavariable](/writing-rules/experiments/display-propagated-metavariable).

--- a/docs/writing-rules/rule-ideas.md
+++ b/docs/writing-rules/rule-ideas.md
@@ -26,8 +26,7 @@ _Time to write this rule: **5 minutes**_
 
 Semgrep can detect dangerous APIs in code. If integrated into CI/CD pipelines, you can use Semgrep to block merges or flag for review when someone adds such dangerous APIs to the code. For example, a rule that detects React's `dangerouslySetInnerHTML` looks like this.
 
-<iframe src="https://semgrep.dev/embed/editor?snippet=r6UkbR" title="Ban dangerous APIs with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
-
+<iframe src="https://semgrep.dev/embed/editor?snippet=zEXn" title="Ban dangerous APIs with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
 
 ### Exempting special cases of dangerous APIs
 
@@ -35,7 +34,7 @@ _Time to write this rule: **5 minutes**_
 
 If you have a legitimate use case for a dangerous API, you can exempt a specific use of the API using a `nosemgrep` comment. The rule below checks for React's `dangerouslySetInnerHTML`, but the code is annotated with a `nosemgrep` comment. Semgrep will not detect this line. This allows Semgrep to continuously check for future uses of `dangerouslySetInnerHTML` while allowing for this specific use.
 
-<iframe src="https://semgrep.dev/embed/editor?snippet=nJUYdL" title="Exempt special cases of dangerous APIs with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
+<iframe src="https://semgrep.dev/embed/editor?snippet=2B3r" title="Exempt special cases of dangerous APIs with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
 
 ### Detect tainted data flowing into a dangerous sink
 
@@ -45,7 +44,7 @@ Semgrep's [dataflow engine with support for taint tracking](/writing-rules/data-
 
 This rule detects when a user of the ExpressJS framework passes user data into the `run()` method of a sandbox.
 
-<iframe src="https://semgrep.dev/embed/editor?snippet=BYUddg" title="ExpressJS dataflow to sandbox.run" width="100%" height="432px" frameBorder="0"></iframe>
+<iframe src="https://semgrep.dev/embed/editor?snippet=jEGP" title="ExpressJS dataflow to sandbox.run" width="100%" height="432px" frameBorder="0"></iframe>
 
 
 ### Detect security violations
@@ -56,7 +55,7 @@ Use Semgrep to flag specific uses of APIs too, not just their presence in code. 
 
 This rule detects when HTML autoescaping is explicitly disabled for a Django template.
 
-<iframe src="https://semgrep.dev/embed/editor?snippet=bwUOxg" title="Detect security violations in code with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
+<iframe src="https://semgrep.dev/embed/editor?snippet=9Yjy" title="Detect security violations in code with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
 
 
 ### Scan configuration files using JSON, YAML, or Generic pattern matching
@@ -65,11 +64,11 @@ _Time to write this rule: **10 minutes**_
 
 Semgrep [natively supports JSON and YAML](../supported-languages.md) and can be used to write rules for configuration files. This rule checks for skipped TLS verification in Kubernetes clusters.
 
-<iframe src="https://semgrep.dev/embed/editor?snippet=kxURrE" title="Match configuration files with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
+<iframe src="https://semgrep.dev/embed/editor?snippet=rEqJ" title="Match configuration files with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
 
 The [Generic pattern matching](/writing-rules/generic-pattern-matching/) mode is for languages and file formats that Semgrep does not natively support. For example, you can write rules for Dockerfiles using the generic mode. The Dockerfile rule below checks for invalid port numbers.
 
-<iframe src="https://semgrep.dev/embed/editor?snippet=wdU84r" title="Match Dockerfiles with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
+<iframe src="https://semgrep.dev/embed/editor?snippet=NGXN" title="Match Dockerfiles with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
 
 
 ### Enforce authentication patterns
@@ -78,7 +77,7 @@ _Time to write this rule: **15 minutes**_
 
 If a project has a "correct" way of doing authentication, Semgrep can be used to enforce this so that authentication mishaps do not happen. In the example below, this Flask app requires an authentication decorator on all routes. The rule detects routes that are missing authentication decorators. If deployed in CI/CD pipelines, Semgrep can block undecorated routes or flag a security member for further investigation.
 
-<iframe src="https://semgrep.dev/embed/editor?snippet=x8UW9P" title="Enforce authentication patterns in code with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
+<iframe src="https://semgrep.dev/embed/editor?snippet=wEQd" title="Enforce authentication patterns in code with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
 
 
 ### Systematize project-specific coding patterns
@@ -96,7 +95,7 @@ In this example, a legacy API requires calling `verify_transaction(t)` before ca
 
 _Time to write this rule: **15 minutes**_
 
-Semgrep metavariables can be used as output in the `message` key. This can be used to extract and collate information about a codebase. Click through to [this example](https://semgrep.dev/s/zdUAnN) which extracts Java Spring routes. This can be used to quickly see all the exposed routes of an application.
+Semgrep metavariables can be used as output in the `message` key. This can be used to extract and collate information about a codebase. Click through to [this example](https://semgrep.dev/s/ORpk) which extracts Java Spring routes. This can be used to quickly see all the exposed routes of an application.
 
 
 ### Burn down deprecated APIs
@@ -107,7 +106,7 @@ Semgrep can detect deprecated APIs just as easily as dangerous APIs. Identifying
 
 This rule example detects a function that is deprecated as of Django 4.0.
 
-<iframe src="https://semgrep.dev/embed/editor?snippet=OrUG41" title="Burn down deprecated APIs with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
+<iframe src="https://semgrep.dev/embed/editor?snippet=vEQ0" title="Burn down deprecated APIs with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
 
 
 ### Promote secure alternatives
@@ -116,7 +115,7 @@ _Time to write this rule: **5 minutes**_
 
 Some libraries or APIs have safe alternatives, such as [Google's `re2`](https://github.com/google/re2), an implementation of the standard `re` interface that ships with Python that is resistant to regular expression denial-of-service. This rule detects the use of `re` and recommends `re2` as a safe alternative with the same interface.
 
-<iframe src="https://semgrep.dev/embed/editor?snippet=EwU4dw" title="Promote secure alternatives with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
+<iframe src="https://semgrep.dev/embed/editor?snippet=ZoA4" title="Promote secure alternatives with Semgrep" width="100%" height="432px" frameBorder="0"></iframe>
 
 
 ## Prompts for writing custom rules

--- a/docs/writing-rules/rule-syntax.md
+++ b/docs/writing-rules/rule-syntax.md
@@ -187,7 +187,7 @@ Try this pattern in the [Semgrep Playground](https://semgrep.dev/s/ved8).
 :::
 
 :::info
-Include quotes in your regular expression when using `metavariable-regex` to search string literals. See [this snippet](https://semgrep.dev/r/eqU83x/mschwager.include-quotes) for more details. [String matching](pattern-syntax.mdx#string-matching) functionality can also be used to search string literals.
+Include quotes in your regular expression when using `metavariable-regex` to search string literals. For more details, see [include-quotes](https://semgrep.dev/playground/s/EbDB) code snippet. [String matching](pattern-syntax.mdx#string-matching) functionality can also be used to search string literals.
 :::
 
 ### `metavariable-pattern`


### PR DESCRIPTION
In https://github.com/returntocorp/semgrep-docs/pull/1082/files many links to our rules have been fixed. @jbergler suggested to change these links to permalinks.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
