### PR TITLE
Update "Installing and running..." section: provide correct Docker commands

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,65 +22,102 @@ Install and run the [Semgrep command-line interface](https://github.com/returnto
 Semgrep CLI requires Python 3.7 or later.
 :::
 
-1. To install Semgrep OSS Engine, use one of the following options:
-    <Tabs
-        defaultValue="macOS"
-        values={[
-        {label: 'macOS', value: 'macOS'},
-        {label: 'Linux', value: 'Linux'},
-        {label: 'Windows Subsystem for Linux (WSL)', value: 'Windows Subsystem for Linux (WSL)'},
-        {label: 'Docker', value: 'Docker'},
-        ]}
-    >
+To install and run Semgrep OSS Engine, use one of the following options:
 
-    <TabItem value='macOS'>
+<Tabs
+    defaultValue="macOS"
+    values={[
+    {label: 'macOS', value: 'macOS'},
+    {label: 'Linux', value: 'Linux'},
+    {label: 'Windows Subsystem for Linux (WSL)', value: 'Windows Subsystem for Linux (WSL)'},
+    {label: 'Docker', value: 'Docker'},
+    ]}
+>
 
-    ```bash
-    brew install semgrep
-    ```
+  <TabItem value='macOS'>
 
-    Alternatively:
+  1. Install:
+      ```bash
+      brew install semgrep
+      ```
 
-    ```bash
-    python3 -m pip install semgrep
-    ```
+      Alternatively:
 
-    </TabItem>
+      ```bash
+      python3 -m pip install semgrep
+      ```
 
-    <TabItem value='Linux'>
+  2. Confirm installation by the following command:
+      ```sh
+      semgrep --version
+      ```
+  3. Run recommended Semgrep Registry rules:
+      <pre class="language-bash"><code>semgrep --config=auto <span className="placeholder">PATH/TO/SRC</span></code></pre>
+      Substitute the optional placeholder <code><span className="placeholder">PATH/TO/SRC</span></code> with the path to your source code.
 
-    ```bash
-    python3 -m pip install semgrep
-    ```
 
-    </TabItem>
+  </TabItem>
 
-    <TabItem value='Windows Subsystem for Linux (WSL)'>
+  <TabItem value='Linux'>
 
-    ```bash
-    python3 -m pip install semgrep
-    ```
+  1. Install:
+      ```bash
+      python3 -m pip install semgrep
+      ```
+  
+  2. Confirm installation by the following command:
+      ```sh
+      semgrep --version
+      ```
+  3. Run recommended Semgrep Registry rules:
+      <pre class="language-bash"><code>semgrep --config=auto <span className="placeholder">PATH/TO/SRC</span></code></pre>
+      Substitute the optional placeholder <code><span className="placeholder">PATH/TO/SRC</span></code> with the path to your source code.
 
-    </TabItem>
 
-    <TabItem value='Docker'>
+  </TabItem>
 
+  <TabItem value='Windows Subsystem for Linux (WSL)'>
+
+  1. Install:
+      ```bash
+      python3 -m pip install semgrep
+      ```
+
+  2. Confirm installation by the following command:
+      ```sh
+      semgrep --version
+      ```
+
+  3. Run recommended Semgrep Registry rules:
+      <pre class="language-bash"><code>semgrep --config=auto <span className="placeholder">PATH/TO/SRC</span></code></pre>
+      Substitute the optional placeholder <code><span className="placeholder">PATH/TO/SRC</span></code> with the path to your source code.
+
+
+  </TabItem>
+
+  <TabItem value='Docker'>
+
+  1. Pull latest image locally:
+     ```sh
+     docker pull returntocorp/semgrep
+     ```
+   
+  2. Confirm version by the following command:
+      ```sh
+      docker run --rm returntocorp/semgrep semgrep --version
+      ```
+
+  3. Run recommended Semgrep Registry rules:
     ```bash
     docker run --rm -v "${PWD}:/src" returntocorp/semgrep semgrep --config=auto
     ```
 
-    </TabItem>
-
-    </Tabs>
+    The provided `-v` option mounts the current directory into the container to be scanned. Change directories locally or provide a specific local directory in the command to scan a different directory.
 
 
-2. Confirm installation by the following command:
-    ```sh
-    semgrep --version
-    ```
-3. Run recommended Semgrep Registry rules:
-    <pre class="language-bash"><code>semgrep --config=auto <span className="placeholder">PATH/TO/SRC</span></code></pre>
-    Substitute the optional placeholder <code><span className="placeholder">PATH/TO/SRC</span></code> with the path to your source code.
+  </TabItem>
+
+</Tabs>
 
 :::note
 - By default, when Semgrep Registry is used, Semgrep collects [usage metrics](./metrics.md).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,7 +34,7 @@ To install and run Semgrep OSS Engine, use one of the following options:
     ]}
 >
 
-  <TabItem value='macOS'>
+<TabItem value='macOS'>
 
   1. Install:
       ```bash
@@ -56,27 +56,9 @@ To install and run Semgrep OSS Engine, use one of the following options:
       Substitute the optional placeholder <code><span className="placeholder">PATH/TO/SRC</span></code> with the path to your source code.
 
 
-  </TabItem>
+</TabItem>
 
-  <TabItem value='Linux'>
-
-  1. Install:
-      ```bash
-      python3 -m pip install semgrep
-      ```
-  
-  2. Confirm installation by the following command:
-      ```sh
-      semgrep --version
-      ```
-  3. Run recommended Semgrep Registry rules:
-      <pre class="language-bash"><code>semgrep --config=auto <span className="placeholder">PATH/TO/SRC</span></code></pre>
-      Substitute the optional placeholder <code><span className="placeholder">PATH/TO/SRC</span></code> with the path to your source code.
-
-
-  </TabItem>
-
-  <TabItem value='Windows Subsystem for Linux (WSL)'>
+<TabItem value='Linux'>
 
   1. Install:
       ```bash
@@ -93,9 +75,28 @@ To install and run Semgrep OSS Engine, use one of the following options:
       Substitute the optional placeholder <code><span className="placeholder">PATH/TO/SRC</span></code> with the path to your source code.
 
 
-  </TabItem>
+</TabItem>
 
-  <TabItem value='Docker'>
+<TabItem value='Windows Subsystem for Linux (WSL)'>
+
+  1. Install:
+      ```bash
+      python3 -m pip install semgrep
+      ```
+
+  2. Confirm installation by the following command:
+      ```sh
+      semgrep --version
+      ```
+
+  3. Run recommended Semgrep Registry rules:
+      <pre class="language-bash"><code>semgrep --config=auto <span className="placeholder">PATH/TO/SRC</span></code></pre>
+      Substitute the optional placeholder <code><span className="placeholder">PATH/TO/SRC</span></code> with the path to your source code.
+
+
+</TabItem>
+
+<TabItem value='Docker'>
 
   1. Pull latest image locally:
      ```sh
@@ -115,7 +116,7 @@ To install and run Semgrep OSS Engine, use one of the following options:
     The provided `-v` option mounts the current directory into the container to be scanned. Change directories locally or provide a specific local directory in the command to scan a different directory.
 
 
-  </TabItem>
+</TabItem>
 
 </Tabs>
 


### PR DESCRIPTION
The steps under "To install and run Semgrep OSS Engine, use one of the following options" previously had a single step that was in a tab set - the installation step for the platform - followed by two steps outside the tab set, to verify and run that were the same for each platform.

However, this doesn't work for Docker - if you're running Semgrep locally via Docker, the invocation is different. With this revision, all steps are in a tab set - which leads to some duplication - but the steps are also all correct. 😄 

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
