### PR TITLE
update typo tolerance

### DIFF
--- a/algolia-config.json
+++ b/algolia-config.json
@@ -39,6 +39,19 @@
   },
   "strip_chars": " .,;:#",
   "custom_settings": {
+    "indexLanguages" : [
+      "en"
+    ],
+    "queryLanguages" : [
+      "en"
+    ],
+    "disableTypoToleranceOnWords" : [
+      "severity",
+      "security",
+      "git",
+      "coverage",
+      "leverage"
+    ],
     "separatorsToIndex": "_",
     "attributesForFaceting": [
       "language",


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

~~- [ ] A subject matter expert (SME) reviews the content~~ Sara is the SME
- [x] ~~A technical writer~~ SOMEONE reviews the content or PR
~~- [ ] This change has no security implications or else you have pinged the security team~~
~~- [ ] Redirects are added if the PR changes page URLs~~
~~- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link~~

Yet again I tried to change the settings from the Algolia dashboard and yet again they were overwritten by our algolia config json upon build and so here we are, me, at the crossover of the ["you can't stop me, cuz I can't read"](https://i.kym-cdn.com/entries/icons/original/000/024/196/sign.jpg) meme and Sisyphus rolling a boulder up.

This finalizes the fix and hopefully I will learn my lesson and stick to controlling Algolia from our source of truth.

It is tested! Type "severity" into the prod docs and you'll get... an exact match.

Linear: [https://linear.app/semgrep/issue/MKT-665/add-git-as-a-term-in-algolia](https://linear.app/semgrep/issue/MKT-665/add-git-as-a-term-in-algolia)