### PR TITLE
fix: change regex capture group docs

### DIFF
--- a/docs/writing-rules/rule-syntax.md
+++ b/docs/writing-rules/rule-syntax.md
@@ -112,7 +112,7 @@ Note that you may bind a section of a regular expression to a metavariable, by u
 this case, the name of the capturing group must be a valid metavariable name.
 
 :::note Example
-Try this pattern in the [Semgrep Playground](https://semgrep.dev/playground/s/p8OL).
+Try this pattern in the [Semgrep Playground](https://semgrep.dev/s/p8OL).
 :::
 
 ### `pattern-not-regex`

--- a/docs/writing-rules/rule-syntax.md
+++ b/docs/writing-rules/rule-syntax.md
@@ -108,10 +108,11 @@ PCRE supports only a [limited number of Unicode character properties](https://ww
 Single (`'`) and double (`"`) quotes [behave differently](https://docs.octoprint.org/en/master/configuration/yaml.html#scalars) in YAML syntax. Single quotes are typically preferred when using backslashes (`\`) with `pattern-regex`.
 :::
 
-Note that if the regex uses groups, the metavariables such as `$1`, `$2`, `$3` (and following), are bound to the content of the captured group.
+Note that you may bind a section of a regular expression to a metavariable, by using [named capturing groups](https://www.regular-expressions.info/named.html). In 
+this case, the name of the capturing group must be a valid metavariable name.
 
 :::note Example
-Try this pattern in the [Semgrep Playground](https://semgrep.dev/s/8RkB).
+Try this pattern in the [Semgrep Playground](https://semgrep.dev/playground/s/p8OL).
 :::
 
 ### `pattern-not-regex`


### PR DESCRIPTION
## What:
This PR just changes the rule syntax to reflect https://github.com/returntocorp/semgrep/pull/8115, which causes numeric capture group metavariables to no longer exist.

Closes PA-2896

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [X] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [X] This change has no security implications or else you have pinged the security team
- [X] Redirects are added if the PR changes page URLs
- [X] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
