### PR TITLE
Add version check to Prerequisites due to recent change in comment auth

### DIFF
--- a/docs/semgrep-cloud-platform/gitlab-mr-comments.md
+++ b/docs/semgrep-cloud-platform/gitlab-mr-comments.md
@@ -27,6 +27,7 @@ Object.entries(frontMatter).filter(
 :::info Prerequisites
 * Pull request (PR) comments can only be enabled through Semgrep Cloud Platform (SCP). [Create an account](/semgrep-code/getting-started/#signing-in-to-semgrep-cloud-platform) to set up Slack notifications.
 * To receive alerts and notifications, you must [add or onboard a project](/semgrep-code/getting-started/#option-b-adding-a-repository-from-github-gitlab-or-bitbucket) (repository) to Semgrep Cloud Platform for scanning.
+* Ensure you are running a [supported version of Semgrep](/semgrep-cloud-platform/getting-started/) with Semgrep Cloud Platform. Semgrep versions prior to 1.13.0 used a different approach to posting MR comments that is no longer supported.
 :::
 
 This section documents how to enable Semgrep Cloud Platform to post comments on merge requests.


### PR DESCRIPTION
Strictly speaking the Cloud Platform support is already beyond the called-out version, but there was a specific change that will make comments not work with lower versions, which (I think) is worth calling out for now.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
