### PR TITLE
[New KB Article] Resolve SSO attribute error

### DIFF
--- a/docs/kb/semgrep-cloud-platform/sso-attribute-error.md
+++ b/docs/kb/semgrep-cloud-platform/sso-attribute-error.md
@@ -1,0 +1,27 @@
+---
+description: Ensure that you're sending the required name and email attributes to Semgrep Cloud Platform.
+tags:
+  - Semgrep Cloud Platform
+  - SSO
+  - SAML
+---
+
+import MoreHelp from "/src/components/MoreHelp"
+
+# Resolving SSO error BadRequest: Missing attribute
+
+When setting up SAML-based SSO for Semgrep Cloud Platform, you may see the following error:
+
+```
+Semgrep encountered an SSO error BadRequest. 
+Please email support@semgrep.com and let us know so we can fix it! 
+Could not process SAML parameters. Missing attribute: email
+```
+
+Semgrep Cloud Platform requires two SAML attributes to be sent: `name` and `email`. If either one is missing, this error appears during the login process, referring to the attribute that is missing.
+
+Most commonly, the data is present, but the name or namespace of the attribute isn't an exact match for `name` or `email`. 
+
+Review step 4 of the [SAML setup process](/docs/semgrep-cloud-platform/sso/#saml-20) for guidance in setting up the attributes. For Azure Active Directory, see steps 4 and 5 of [Setting up SAML SSO for your new Enterprise App](/docs/semgrep-cloud-platform/sso/#setting-up-saml-sso-for-your-new-enterprise-app).
+
+<MoreHelp />


### PR DESCRIPTION
Addresses [CSE-505](https://linear.app/semgrep/issue/CSE-505/missing-attribute-sso-error-badrequest-saml) (internal link), explains likely reasons for error and links to related docs.

I tested out use of the `MoreHelp` component in the KB here, and have submitted a potential update to that component to link to the Support page so that it isn't just pointing to Community Slack, as those running into SSO errors likely have additional options (https://github.com/returntocorp/semgrep-docs/pull/1108).

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
