### PR TITLE
Add link to Support page to MoreHelp

### DIFF
--- a/src/components/MoreHelp.js
+++ b/src/components/MoreHelp.js
@@ -4,7 +4,7 @@ const MoreHelp = () => {
   return (
     <div>
       <hr />
-      Find what you needed in this doc? Join the <a href="https://go.semgrep.dev/slack">Semgrep Community Slack group</a> to ask the maintainers and the community if you need help.
+      <p>Find what you needed in this doc? Join the <a href="https://go.semgrep.dev/slack">Semgrep Community Slack group</a> to ask the maintainers and the community if you need help, or <a href="/docs/support/">check out other ways to get help</a>.</p>
     </div>
   );
 }


### PR DESCRIPTION
The MoreHelp component previously only referred to the Community Slack group - this change adds a link to the existing page on the docs that describes all the different ways for users to get help.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
