### PR TITLE
[New KB Article] Why did the comments on a PR or MR not appear inline?

### DIFF
--- a/docs/kb/semgrep-cloud-platform/inline-pr-comments.md
+++ b/docs/kb/semgrep-cloud-platform/inline-pr-comments.md
@@ -8,20 +8,20 @@ import MoreHelp from "/src/components/MoreHelp"
 
 # Why did the comments on a PR or MR not appear inline?
 
-When Semgrep comments on PR or MR findings, the comments are usually added on the line of code where the finding is identified (inline). However, there are two common reasons why comments may not appear inline.
+When Semgrep comments on PR or MR findings, the comments are usually posted on the line of code where the finding is identified (inline). However, there are two common reasons why comments may not appear inline.
 
 ## Avoiding excessive inline comments
 
-For rules with several findings in the same PR or MR, inline comments for every individual finding occupy a significant amount of space without adding much additional information. Therefore, if the same finding occurs three or more times in a PR or MR, the related comment is left as a summary (overall) comment.
+For rules with several findings in the same PR or MR, inline comments for every individual finding occupy a significant amount of space without adding much additional information. Therefore, if the same finding occurs three or more times in a PR or MR, the related comment is posted as a summary (overall) comment.
 
 ## Available lines in the displayed diff
 
 ### GitHub PRs
 
-GitHub only allows PR comments to be left on lines of code that are shown in the default file-diff (Files changed) view on GitHub. If a finding appears outside those lines, Semgrep attempts to create the comment as close to the finding as feasible. If that fails, it creates the comment as a summary comment, visible in the Conversation view.
+GitHub only allows PR comments to be posted on lines of code that are shown in the default file-diff (Files changed) view on GitHub. If a finding appears outside those lines, Semgrep attempts to post the comment as close to the finding as feasible. If that fails, it posts the comment as a summary comment, visible in the Conversation view.
 
 ### GitLab MRs
 
-GitLab allows comments to be left on lines of code outside the default file-diff view, but the comments don't appear in the file-diff (Changes) view. However, they do appear as diff-related comments on the Overview.
+GitLab allows comments to be posted on lines of code outside the default file-diff view, but the comments don't appear in the file-diff (Changes) view. However, they do appear as diff-related comments on the Overview.
 
 <MoreHelp />

--- a/docs/kb/semgrep-cloud-platform/inline-pr-comments.md
+++ b/docs/kb/semgrep-cloud-platform/inline-pr-comments.md
@@ -1,0 +1,27 @@
+---
+tags:
+  - Semgrep CI
+  - PR comments
+---
+
+import MoreHelp from "/src/components/MoreHelp"
+
+# Why did the comments on a PR or MR not appear inline?
+
+When Semgrep comments on PR or MR findings, the comments are usually added on the line of code where the finding is identified (inline). However, there are two common reasons why comments may not appear inline.
+
+## Avoiding excessive inline comments
+
+For rules with several findings in the same PR or MR, inline comments for every individual finding occupy a significant amount of space without adding much additional information. Therefore, if the same finding occurs three or more times in a PR or MR, the related comment is left as a summary (overall) comment.
+
+## Available lines in the displayed diff
+
+### GitHub PRs
+
+GitHub only allows PR comments to be left on lines of code that are shown in the default file-diff (Files changed) view on GitHub. If a finding appears outside those lines, Semgrep attempts to create the comment as close to the finding as feasible. If that fails, it creates the comment as a summary comment, visible in the Conversation view.
+
+### GitLab MRs
+
+GitLab allows comments to be left on lines of code outside the default file-diff view, but the comments don't appear in the file-diff (Changes) view. However, they do appear as diff-related comments on the Overview.
+
+<MoreHelp />

--- a/docs/kb/semgrep-cloud-platform/inline-pr-comments.md
+++ b/docs/kb/semgrep-cloud-platform/inline-pr-comments.md
@@ -12,7 +12,7 @@ When Semgrep comments on PR or MR findings, the comments are usually posted on t
 
 ## Avoiding excessive inline comments
 
-For rules with several findings in the same PR or MR, inline comments for every individual finding occupy a significant amount of space without adding much additional information. Therefore, if the same finding occurs three or more times in a PR or MR, the related comment is posted as a summary (overall) comment.
+For rules with several findings in the same PR or MR, inline comments for every individual finding occupy a significant amount of space without providing much additional information. Therefore, if the same finding occurs five or more times in a PR or MR, the related comment is posted as a summary (overall) comment.
 
 ## Available lines in the displayed diff
 

--- a/docs/kb/semgrep-cloud-platform/inline-pr-comments.md
+++ b/docs/kb/semgrep-cloud-platform/inline-pr-comments.md
@@ -12,7 +12,7 @@ When Semgrep comments on PR or MR findings, the comments are usually posted on t
 
 ## Avoiding excessive inline comments
 
-For rules with several findings in the same PR or MR, inline comments for every individual finding occupy a significant amount of space without providing much additional information. Therefore, if the same finding occurs five or more times in a PR or MR, the related comment is posted as a summary (overall) comment.
+For rules with several findings in the same PR or MR, inline comments for every individual finding occupy a significant amount of space without providing much additional information. Therefore, if the same finding occurs more than five times in a PR or MR, the related comment is posted as a summary (overall) comment.
 
 ## Available lines in the displayed diff
 


### PR DESCRIPTION
[CSE-519](https://linear.app/semgrep/issue/CSE-519/why-were-prmr-comments-left-as-summary-comments-instead-of-inline) (internal link).

Explains the two most common reasons why Semgrep comments on a PR or MR might not appear inline.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
