### PR TITLE
Add definition of Undetermined to SSC overview

### DIFF
--- a/docs/semgrep-supply-chain/overview.md
+++ b/docs/semgrep-supply-chain/overview.md
@@ -40,7 +40,7 @@ Semgrep Supply Chain generates a **finding** when it detects a match. If the dep
 
 A finding is **unreachable** if the dependency contains a known vulnerability, but the vulnerable matching code is not used in your codebase.
 
-A finding is **undetermined** if Semgrep detects a match for the dependency in the vulnerable version range, but does not scan for the reachability of this vulnerability. This is most common with older or lower severity vulnerabilities.
+A finding is **undetermined** if Semgrep detects a match for the dependency in the vulnerable version range, but does not have a reachability rule for this vulnerability. This is most common with older or lower severity vulnerabilities.
 
 In Semgrep Cloud Platform, specific findings of a dependency and code match are called **usages**. Usages are grouped by their **vulnerability**. Vulnerabilities in Semgrep Supply Chain typically have a CVE number corresponding to the record in the [CVE Program](https://www.cve.org/About/Overview).
 

--- a/docs/semgrep-supply-chain/overview.md
+++ b/docs/semgrep-supply-chain/overview.md
@@ -40,6 +40,8 @@ Semgrep Supply Chain generates a **finding** when it detects a match. If the dep
 
 A finding is **unreachable** if the dependency contains a known vulnerability, but the vulnerable matching code is not used in your codebase.
 
+A finding is **undetermined** if Semgrep detects a match for the dependency in the vulnerable version range, but does not scan for the reachability of this vulnerability. This is most common with older or lower severity vulnerabilities.
+
 In Semgrep Cloud Platform, specific findings of a dependency and code match are called **usages**. Usages are grouped by their **vulnerability**. Vulnerabilities in Semgrep Supply Chain typically have a CVE number corresponding to the record in the [CVE Program](https://www.cve.org/About/Overview).
 
 Semgrep Cloud Platform also includes a list of **Advisories** for reference. Advisories include all vulnerabilities covered by Semgrep Supply Chain, regardless of whether the related dependency is used in scanned code.


### PR DESCRIPTION
We get a fair number of questions about this term, and previously it was only defined in the filter descriptions. This PR adds it to the overview page along with the other possibilities.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
