### PR TITLE
add Ruby back to OSS supported languages

### DIFF
--- a/src/components/reference/_supported-languages-table.mdx
+++ b/src/components/reference/_supported-languages-table.mdx
@@ -6,8 +6,9 @@
 | Java       | GA | Beta | ✅ |      
 | Kotlin     | GA | Beta | ✅ |                
 | JavaScript | GA | Beta | ✅ | 
-| TypeScript | GA | Beta | ✅ |  
-| C#         | GA | -- | ✅ |                  
+| TypeScript | GA | Beta | ✅ |
+| C#         | GA | -- | ✅ |
+| Ruby       | GA | -- | ✅ |                      
 | JSON       | GA | -- | ✅ |                    
 | JSX        | GA | -- | ✅ |                       
 | PHP        | GA | -- | ✅ |                   


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
