### PR TITLE
Scan troubleshooting: Move more content to KB, move some to Contributing

### DIFF
--- a/docs/contributing/semgrep-core-contributing.md
+++ b/docs/contributing/semgrep-core-contributing.md
@@ -161,40 +161,34 @@ Substitute the optional placeholder <code><span className="placeholder">PATH/TO/
 Here is an example result object.
 
 ```JSON
-{
-  "errors": [],
-  "results": [],
   "time": {
+    "max_memory_bytes": 48693248,
     "profiling_times": {
-      "config_time": 0.10301780700683594,
-      "core_time": 0.0883018970489502,
-      "ignores_time": 2.7894973754882812e-05,
-      "total_time": 0.1915416717529297
+      "config_time": 0.0624239444732666,
+      "core_time": 0.11341428756713867,
+      "ignores_time": 0.00017690658569335938,
+      "total_time": 0.17628788948059082
     },
-    "rule_parse_info": [
-      0.0011630058288574219
-    ],
     "rules": [
       {
-        "id": "Users.emma.workspace.testing.error_configs.use-sys-exit"
+        "id": "test-rule"
       }
     ],
+    "rules_parse_time": 0.0013418197631835938,
     "targets": [
       {
         "match_times": [
-          0
+          5.9604644775390625e-06
         ],
-        "num_bytes": 444,
+        "num_bytes": 340,
         "parse_times": [
-          0
+          0.0071868896484375
         ],
-        "path": "/Users/emma/workspace/testing/situations_test/no_token_location.py",
-        "run_times": [
-          0.0006248950958251953
-        ]
+        "path": "test_functions.java",
+        "run_time": 0.011521100997924805
       }
     ],
-    "total_bytes": 444
+    "total_bytes": 340
   }
 }
 ```
@@ -208,13 +202,13 @@ The first section is `profiling_times`. This contains wall time durations of var
 
 The `total_time` field represents the sum of these steps.
 
-The remaining fields report engine performance. Together, `rule_parse_info` and `targets` should capture all the time spent running `semgrep-core`.
+The remaining fields report engine performance. Together, `rule_parse_time` and `targets` should capture all the time spent running `semgrep-core`.
 
-`rule_parse_info` is straightforward. It records the time spent parsing each rule.
+`rule_parse_time` is straightforward. It records the time spent parsing the rules file.
 
-`targets` poses more difficulty. Since files are run in parallel, the amount of time spent parsing (`parse_times`) and matching (`match_times`) will inevitably be meaningless compared against `total_time` or `core_time`. Therefore, the total run time (`run_times`) of each target for each rule is taken within the parallel run. This helps contextualize the time spent parsing and matching each target. The sum of the run times thus can (and usually should) be longer than the total time.
+`targets` poses more difficulty. Since files are run in parallel, the amount of time spent parsing (`parse_times`) and matching (`match_times`) will inevitably be meaningless compared against `total_time` or `core_time`. Therefore, the total run time (`run_time`) of each target for each rule is taken within the parallel run. This helps contextualize the time spent parsing and matching each target. The sum of the run times thus can (and usually should) be longer than the total time.
 
-The lists `rule_parse_info`, `match_times`, `parse_times`, and `run_times` are all in the same order as `rules`. That is, the parse time of rule `rules[0]` is `rule_parse_info[0]`.
+The lists `match_times` and `parse_times` are in the same order as `rules`. That is, the match time of rule `rules[0]` is `match_times[0]`.
 
 Note that `parse_times` is given for each rule, but a file should only be parsed once (the first number). Afterwards, the parse time represents the time spent retrieving the file's AST from the cache.
 

--- a/docs/contributing/semgrep-core-contributing.md
+++ b/docs/contributing/semgrep-core-contributing.md
@@ -150,7 +150,9 @@ code .
 
 #### Interpreting the result object
 
-For full timing information, run Semgrep with `--time` and `--json`. In addition, you will want to `time` the entire command to get the true wall time. The `--json` argument produces a large amount of output, so redirecting the output to a file with `-o` is recommended. The full command would look sometthing like:
+For full timing information, run Semgrep with `--time` and `--json` flags. In addition, you can add `time` at the beginning of the command to get the true wall time. The `--json` argument produces a large amount of output, so redirecting the output to a file with `-o` is recommended. 
+
+See the following example for the full command:
 
 <pre class="language-bash"><code>time semgrep --config=auto --time --json -o result.json <span className="placeholder">PATH/TO/SRC</span></code></pre>
 
@@ -199,7 +201,12 @@ Here is an example result object.
 
 All the information about timing is contained under `time`.
 
-The first section is `profiling_times`. This contains wall time durations of various steps we consider interesting: getting the rule config files (`config_time`), running the main engine (`core_time`), and processing the ignores (`ignores_time`). The `total_time` field represents the sum of these steps.
+The first section is `profiling_times`. This contains wall time durations of various relevant steps:
+* Getting the rule config files (`config_time`)
+* Running the main engine (`core_time`)
+* Processing the ignores (`ignores_time`) 
+
+The `total_time` field represents the sum of these steps.
 
 The remaining fields report engine performance. Together, `rule_parse_info` and `targets` should capture all the time spent running `semgrep-core`.
 
@@ -217,7 +224,7 @@ When a time is not measured, by default it has the value -1. It is common to a h
 
 #### Tips for exploring Semgrep results
 
-There are several scripts already written to analyze and summarize these timing data. Find them in [`scripts/processing-output`](https://github.com/returntocorp/semgrep/tree/develop/scripts/processing-output). If you have a timing file, you will probably want to run
+There are several scripts already written to analyze and summarize these timing data. Find them in [`scripts/processing-output`](https://github.com/returntocorp/semgrep/tree/develop/scripts/processing-output). If you have a timing file, you can run
 
 ```bash
 python read_timing.py [your_timing_file]

--- a/docs/contributing/semgrep-core-contributing.md
+++ b/docs/contributing/semgrep-core-contributing.md
@@ -146,6 +146,85 @@ code .
 
 ## Testing performance
 
+### Exploring results from a slow run of Semgrep
+
+#### Interpreting the result object
+
+For full timing information, run Semgrep with `--time` and `--json`. In addition, you will want to `time` the entire command to get the true wall time. The `--json` argument produces a large amount of output, so redirecting the output to a file with `-o` is recommended. The full command would look sometthing like:
+
+<pre class="language-bash"><code>time semgrep --config=auto --time --json -o result.json <span className="placeholder">PATH/TO/SRC</span></code></pre>
+
+Substitute the optional placeholder <code><span className="placeholder">PATH/TO/SRC</span></code> with the path to your source code.
+
+Here is an example result object.
+
+```JSON
+{
+  "errors": [],
+  "results": [],
+  "time": {
+    "profiling_times": {
+      "config_time": 0.10301780700683594,
+      "core_time": 0.0883018970489502,
+      "ignores_time": 2.7894973754882812e-05,
+      "total_time": 0.1915416717529297
+    },
+    "rule_parse_info": [
+      0.0011630058288574219
+    ],
+    "rules": [
+      {
+        "id": "Users.emma.workspace.testing.error_configs.use-sys-exit"
+      }
+    ],
+    "targets": [
+      {
+        "match_times": [
+          0
+        ],
+        "num_bytes": 444,
+        "parse_times": [
+          0
+        ],
+        "path": "/Users/emma/workspace/testing/situations_test/no_token_location.py",
+        "run_times": [
+          0.0006248950958251953
+        ]
+      }
+    ],
+    "total_bytes": 444
+  }
+}
+```
+
+All the information about timing is contained under `time`.
+
+The first section is `profiling_times`. This contains wall time durations of various steps we consider interesting: getting the rule config files (`config_time`), running the main engine (`core_time`), and processing the ignores (`ignores_time`). The `total_time` field represents the sum of these steps.
+
+The remaining fields report engine performance. Together, `rule_parse_info` and `targets` should capture all the time spent running `semgrep-core`.
+
+`rule_parse_info` is straightforward. It records the time spent parsing each rule.
+
+`targets` poses more difficulty. Since files are run in parallel, the amount of time spent parsing (`parse_times`) and matching (`match_times`) will inevitably be meaningless compared against `total_time` or `core_time`. Therefore, the total run time (`run_times`) of each target for each rule is taken within the parallel run. This helps contextualize the time spent parsing and matching each target. The sum of the run times thus can (and usually should) be longer than the total time.
+
+The lists `rule_parse_info`, `match_times`, `parse_times`, and `run_times` are all in the same order as `rules`. That is, the parse time of rule `rules[0]` is `rule_parse_info[0]`.
+
+Note that `parse_times` is given for each rule, but a file should only be parsed once (the first number). Afterwards, the parse time represents the time spent retrieving the file's AST from the cache.
+
+#### Negative values in the metrics
+
+When a time is not measured, by default it has the value -1. It is common to a have a normal runtime, but -1 for the parse time or match time; this indicates an error in parsing.
+
+#### Tips for exploring Semgrep results
+
+There are several scripts already written to analyze and summarize these timing data. Find them in [`scripts/processing-output`](https://github.com/returntocorp/semgrep/tree/develop/scripts/processing-output). If you have a timing file, you will probably want to run
+
+```bash
+python read_timing.py [your_timing_file]
+```
+
+You may need to adjust the line `result_times = results` based on whether you have a timing file or the full results (in which case this should be `result_times = results["time"]`)
+
 ### Profiling code
 
 You can pass the -profile command-line argument to semgrep-core to get

--- a/docs/contributing/semgrep-core-contributing.md
+++ b/docs/contributing/semgrep-core-contributing.md
@@ -161,6 +161,9 @@ Substitute the optional placeholder <code><span className="placeholder">PATH/TO/
 Here is an example result object.
 
 ```JSON
+      { "results": [], 
+        "paths": {},
+        "errors": [],
   "time": {
     "max_memory_bytes": 48693248,
     "profiling_times": {

--- a/docs/kb/semgrep-code/semgrep-scan-troubleshooting.md
+++ b/docs/kb/semgrep-code/semgrep-scan-troubleshooting.md
@@ -19,15 +19,23 @@ Semgrep verbose or debug logs can be quite lengthy. To prevent flooding your ter
 
 ## Memory usage issues (OOM errors)
 
-Memory usage is a common issue with scans, especially in memory-constrained environments such as continuous integration (CI) providers. 
+Memory usage is a common issue with scans, especially in memory-constrained environments such as continuous integration (CI) providers. Semgrep may exit with code -11 (or -9), which are the POSIX signals raised to cause the crash.
 
-See [Semgrep exited with code -11 (or -9)](/docs/troubleshooting/semgrep/#semgrep-exited-with-code--11-or--9) for further troubleshooting.
+* Try increasing the memory available if you are working in a container or managed instance where you can manage the amount of memory.
+* Use the `--max-memory LIMIT` option for your Semgrep run. This option stops a rule/file scan if it reaches the set limit, and moves to the next rule / file.
+* Run Semgrep in single-threaded mode with `--jobs 1`. This reduces the amount of memory used compared to running multiple jobs.
+* Try increasing your stack limit, if a limit is set for the context where you invoke Semgrep (`ulimit -s [limit]`).
 
 ## Slow scans
 
-If you suspect the presence of a large file slowing Semgrep's analysis, decrease the maximum size of files scanned with `--max-target-bytes BYTES`. The default is 1000000 bytes (~1 MB).
+The first step to improving Semgrep's speed is limiting its run to only the files you care about. You can do this by adding a `.semgrepignore` file. See [how to ignore files & directories in Semgrep CI](/ignoring-files-folders-code/).
 
-Review [I just want Semgrep to run faster](/docs/troubleshooting/semgrep/#i-just-want-semgrep-to-run-faster) for additional guidance on speeding up scans.
+After addressing files to ignore:
+
+* If you suspect the presence of a large file slowing Semgrep's analysis, decrease the maximum size of files scanned with `--max-target-bytes BYTES`. The default is 1000000 bytes (~1 MB).
+* Run Semgrep with the `--time` flag. This outputs a list of the rules and files that took the longest.
+  * Identify the slowest files from the list. You may find that you can add some of those files to your ignore list as well.
+  * Identify the slowest rules from the list. You may find that some of them don't apply to your codebase and can be skipped.
 
 ## 401 error when scanning with Semgrep Registry rules
 
@@ -52,9 +60,18 @@ If the error you receive is not that specific, try one of these options:
 2. Use `--exclude` to exclude a file or files from the scan. You can use wildcards in file exclusions to exclude files matching particular patterns.
 3. Use `--include` with a pattern specifying an extension for a particular language, to limit the scan to primarily files in that language.
 
+## Reporting crashes or analysis errors
+
 Once you have isolated the issue:
 
-1. Identify the file and lines (if available) where Semgrep encountered the error.
+1. Identify the rule, file and lines (if available) where Semgrep encountered the error.
 2. Determine whether you can share a minimal example of the code or rule that is causing the issue.
   * If the issue occurs with Semgrep Pro Engine, or the code is internal or sensitive and cannot be sufficiently redacted, [reach out for help](/docs/support), and include what you've determined so far.
   * Otherwise, share the issue details and related code with Semgrep via https://github.com/returntocorp/semgrep/issues.
+
+If you are encountering memory usage issues, please include in your report:
+
+* the total size of the files
+* the number of files being scanned
+* the maximum memory used by Semgrep (an estimate from `top` is fine)
+* the system specifications

--- a/docs/kb/semgrep-code/semgrep-scan-troubleshooting.md
+++ b/docs/kb/semgrep-code/semgrep-scan-troubleshooting.md
@@ -71,7 +71,7 @@ Once you have isolated the issue:
 
 If you are encountering memory usage issues, please include in your report:
 
-* the total size of the files
-* the number of files being scanned
-* the maximum memory used by Semgrep (an estimate from `top` is fine)
-* the system specifications
+* The total size of the files
+* The number of files being scanned
+* The maximum memory used by Semgrep (an estimate from `top` is fine)
+* The system specifications

--- a/docs/kb/semgrep-code/semgrep-scan-troubleshooting.md
+++ b/docs/kb/semgrep-code/semgrep-scan-troubleshooting.md
@@ -28,11 +28,11 @@ Memory usage is a common issue with scans, especially in memory-constrained envi
 
 ## Slow scans
 
-The first step to improving Semgrep's speed is limiting its run to only the files you care about. You can do this by adding a `.semgrepignore` file. See [how to ignore files & directories in Semgrep CI](/ignoring-files-folders-code/).
+The first step to improving Semgrep's speed is limiting its run to only the files you care about. Most commonly, it's limited using a `.semgrepignore` file. See [Ignoring files, folders, or parts of code](/ignoring-files-folders-code/).
 
 After addressing files to ignore:
 
-* If you suspect the presence of a large file slowing Semgrep's analysis, decrease the maximum size of files scanned with `--max-target-bytes BYTES`. The default is 1000000 bytes (~1 MB).
+* If you suspect the presence of a large file slowing Semgrep's analysis, decrease the maximum size of files scanned with `--max-target-bytes BYTES`.
 * Run Semgrep with the `--time` flag. This outputs a list of the rules and files that took the longest.
   * Identify the slowest files from the list. You may find that you can add some of those files to your ignore list as well.
   * Identify the slowest rules from the list. You may find that some of them don't apply to your codebase and can be skipped.
@@ -58,13 +58,13 @@ If the error you receive is not that specific, try one of these options:
 
 1. Use `--exclude-rule` to exclude a rule from the scan. This allows isolating the problem to the particular rule.
 2. Use `--exclude` to exclude a file or files from the scan. You can use wildcards in file exclusions to exclude files matching particular patterns.
-3. Use `--include` with a pattern specifying an extension for a particular language, to limit the scan to primarily files in that language.
+3. Use `--include` with a pattern specifying a path or an extension for a particular language, to limit the scan to that path, or to files in that language.
 
 ## Reporting crashes or analysis errors
 
 Once you have isolated the issue:
 
-1. Identify the rule, file and lines (if available) where Semgrep encountered the error.
+1. Identify the rule, file, and lines (if available) where Semgrep encountered the error.
 2. Determine whether you can share a minimal example of the code or rule that is causing the issue.
   * If the issue occurs with Semgrep Pro Engine, or the code is internal or sensitive and cannot be sufficiently redacted, [reach out for help](/docs/support), and include what you've determined so far.
   * Otherwise, share the issue details and related code with Semgrep via https://github.com/returntocorp/semgrep/issues.

--- a/docs/troubleshooting/semgrep.md
+++ b/docs/troubleshooting/semgrep.md
@@ -28,6 +28,6 @@ Review troubleshooting steps for slow scans at [Semgrep scan troubleshooting: Sl
 
 Thank you! Check out the [Contributing docs](/docs/contributing/contributing/) to get started. 
 
-The section [Exploring results from a slow run of Semgrep](/docs/contributing/semgrep-core-contributing/#exploring-results-from-a-slow-run-of-semgrep) will be especially helpful if you haven't previously investigated Semgrep performance.
+The section [Exploring results from a slow run of Semgrep](/docs/contributing/semgrep-core-contributing/#exploring-results-from-a-slow-run-of-semgrep) is helpful if you haven't previously investigated Semgrep performance.
 
 <MoreHelp />

--- a/docs/troubleshooting/semgrep.md
+++ b/docs/troubleshooting/semgrep.md
@@ -12,11 +12,9 @@ import MoreHelp from "/src/components/MoreHelp"
 
 ## Semgrep exited with code -11 (or -9)
 
-This can happen when Semgrep crashes, usually as a result of memory exhaustion. `-11` and `-9` are the POSIX signals raised to cause the crash. Try increasing your stack limit, as suggested (`ulimit -s [limit]`). If you are working in a container where you can set the memory you are working with, you can also try increasing this limit. Alternatively, you can add `--max-memory [limit]` to your Semgrep run, which will stop a rule/file scan if it reaches the limit.
+This can happen when Semgrep crashes, usually as a result of memory exhaustion. `-11` and `-9` are the POSIX signals raised to cause the crash.
 
-Additionally, you can run Semgrep in single-threaded mode with `--jobs 1`. This reduces the amount of memory used compared to running multiple jobs.
-
-When reporting these errors, please include the rule it failed on, the total size of the files (or the files themselves if possible!), the maximum memory used by Semgrep (an estimate from `top` is fine), and your system specifications.
+Review troubleshooting steps for memory exhaustion at [Semgrep scan troubleshooting: Memory usage issues](/docs/kb/semgrep-code/semgrep-scan-troubleshooting/#memory-usage-issues-oom-errors).
 
 ## Semgrep is too slow
 
@@ -24,92 +22,12 @@ We record Semgrep runtimes for each file and rule. This information is displayed
 
 ### I just want Semgrep to run faster
 
-Just run Semgrep with `--time` and not `--json`. This will output a list of the rules and files that took the longest. Often, you will find that those files shouldn't have been scanned in the first place.
-
-The first step to improving Semgrep's speed is limiting its run to only the files you care about. You can do this by adding a `.semgrepignore` file. See [how to ignore files & directories in Semgrep CI](/ignoring-files-folders-code/).
-
-If Semgrep is still running slowly, examine the output and identify the slowest rules. You may find that some of them don't apply to your codebase and can be skipped.
+Review troubleshooting steps for slow scans at [Semgrep scan troubleshooting: Slow scans](/docs/kb/semgrep-code/semgrep-scan-troubleshooting/#slow-scans).
 
 ### I am a contributor who wants to improve Semgrep's engine
 
-#### Interpreting the result object
+Thank you! Check out the [Contributing docs](/docs/contributing/contributing/) to get started. 
 
-For full timing information, run Semgrep with `--time` and `--json`. In addition, you will want to `time` the entire command to get the true wall time. The `--json` argument produces a large amount of output, so redirecting the output to a file with `-o` is recommended. The full command would look sometthing like:
-
-<pre class="language-bash"><code>time semgrep --config=auto --time --json -o result.json <span className="placeholder">PATH/TO/SRC</span></code></pre>
-Substitute the optional placeholder <code><span className="placeholder">PATH/TO/SRC</span></code> with the path to your source code.
-
-Here is an example result object.
-
-```JSON
-{
-  "errors": [],
-  "results": [],
-  "time": {
-    "profiling_times": {
-      "config_time": 0.10301780700683594,
-      "core_time": 0.0883018970489502,
-      "ignores_time": 2.7894973754882812e-05,
-      "total_time": 0.1915416717529297
-    },
-    "rule_parse_info": [
-      0.0011630058288574219
-    ],
-    "rules": [
-      {
-        "id": "Users.emma.workspace.testing.error_configs.use-sys-exit"
-      }
-    ],
-    "targets": [
-      {
-        "match_times": [
-          0
-        ],
-        "num_bytes": 444,
-        "parse_times": [
-          0
-        ],
-        "path": "/Users/emma/workspace/testing/situations_test/no_token_location.py",
-        "run_times": [
-          0.0006248950958251953
-        ]
-      }
-    ],
-    "total_bytes": 444
-  }
-}
-```
-
-All the information about timing is contained under `time`.
-
-The first section is `profiling_times`. This contains wall time durations of various steps we consider interesting: getting the rule config files (`config_time`), running the main engine (`core_time`), and processing the ignores (`ignores_time`). The `total_time` field represents the sum of these steps.
-
-The remaining fields report engine performance. Together, `rule_parse_info` and `targets` should capture all the time spent running `semgrep-core`.
-
-`rule_parse_info` is straightforward. It records the time spent parsing each rule.
-
-`targets` poses more difficulty. Since files are run in parallel, the amount of time spent parsing (`parse_times`) and matching (`match_times`) will inevitably be meaningless compared against `total_time` or `core_time`. Therefore, the total run time (`run_times`) of each target for each rule is taken within the parallel run. This helps contextualize the time spent parsing and matching each target. The sum of the run times thus can (and usually should) be longer than the total time.
-
-The lists `rule_parse_info`, `match_times`, `parse_times`, and `run_times` are all in the same order as `rules`. That is, the parse time of rule `rules[0]` is `rule_parse_info[0]`.
-
-Note that `parse_times` is given for each rule, but a file should only be parsed once (the first number). Afterwards, the parse time represents the time spent retrieving the file's AST from the cache.
-
-#### Negative values in the metrics
-
-When a time is not measured, by default it has the value -1. It is common to a have a normal runtime but -1 for the parse time or match time; this indicates an error in parsing.
-
-#### Tips for exploring Semgrep results
-
-There are several scripts already written to analyze and summarize these timing data. Find them in [`scripts/processing-output`](https://github.com/returntocorp/semgrep/tree/develop/scripts/processing-output). If you have a timing file, you will probably want to run
-
-```bash
-python read_timing.py [your_timing_file]
-```
-
-You may need to adjust the line `result_times = results` based on whether you have a timing file or the full results (in which case this should be `result_times = results["time"]`)
-
-## How to get help
-
-Please check the [Support](/support/) page to get help from the Semgrep maintainers & community, via Slack, GitHub, email, or phone.
+The section [Exploring results from a slow run of Semgrep](/docs/contributing/semgrep-core-contributing/#exploring-results-from-a-slow-run-of-semgrep) will be especially helpful if you haven't previously investigated Semgrep performance.
 
 <MoreHelp />


### PR DESCRIPTION
Addresses [CSE-527](https://linear.app/semgrep/issue/CSE-527/update-scan-troubleshooting) (internal link). 

Move some troubleshooting material to the KB, and move contributor-related content to the Contribution docs.

For now we'll go with the "move & link" approach but we might consider delete & redirect later.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
