### PR TITLE
[New KB Article] Matching multiple tokens with ellipsis metavariables

### DIFF
--- a/docs/kb/rules/ellipsis-metavariables.md
+++ b/docs/kb/rules/ellipsis-metavariables.md
@@ -31,7 +31,7 @@ If you remove the ellipsis in the `$...ID` variable, the second example no longe
 
 ## Alternative: try the Aliengrep experiment
 
-Semgrep's generic matching mode is [somewhat limited](/docs/writing-rules/generic-pattern-matching/#caveats-and-limitations-of-generic-mode). To address some of the limitations, the team is experimenting with a new mode called [Aliengrep](/docs/writing-rules/experiments/aliengrep/). 
+Semgrep's generic matching mode contains [caveats and limitations](/docs/writing-rules/generic-pattern-matching/#caveats-and-limitations-of-generic-mode). To address some of the limitations, the team is experimenting with a new mode called [Aliengrep](/docs/writing-rules/experiments/aliengrep/). 
 
 With Aliengrep, you can [configure what characters are allowed as part of a word token](/docs/writing-rules/experiments/aliengrep/#additional-word-characters-captured-by-metavariables) as well as [have even more fun with ellipses](/docs/writing-rules/experiments/aliengrep/#ellipsis-).
 

--- a/docs/kb/rules/ellipsis-metavariables.md
+++ b/docs/kb/rules/ellipsis-metavariables.md
@@ -15,11 +15,11 @@ Using ellipsis (`...`) to match a sequence of items is one of the most common co
 
 Most commonly, ellipsis metavariables like `$...ARGS` are used for purposes like matching multiple arguments to a function, [while capturing the values for later re-use](/docs/writing-rules/pattern-syntax/#ellipsis-metavariables).
 
-However, they can also be used to match multiple word tokens. This is especially handy in [Generic pattern matching mode](/docs/writing-rules/generic-pattern-matching/), where a token is defined as a sequence of characters in the set `[A-z0-9_]`. 
+However, they can also be used to match multiple word tokens. This is especially handy in [Generic pattern matching mode](/docs/writing-rules/generic-pattern-matching/), where a token is defined as a sequence of characters in the set `[A-z0-9_]`, which is not a fit for all languages.
 
 ## Capturing multiple tokens with ellipsis metavariables
 
-In `generic` mode, `ABC_DEF` is one token, and a metavariable such as `$VAR` captures the entire sequence. However, `ABC-DEF` is two tokens, and a metavariable such as `$VAR` does not capture the entire sequence. 
+In `generic` mode, `ABC_DEF` is one token, and a metavariable such as `$VAR` captures the entire sequence. However, `ABC-DEF` is two tokens, and a metavariable such as `$VAR` does not capture the entire sequence.
 
 If the language you're working with allows other characters in tokens, using ellipsis metavariables can prevent problems with matching too little of the pattern.
 
@@ -33,7 +33,7 @@ If you remove the ellipsis in the `$...ID` variable, the second example no longe
 
 Semgrep's generic matching mode is [somewhat limited](/docs/writing-rules/generic-pattern-matching/#caveats-and-limitations-of-generic-mode). To address some of the limitations, the team is experimenting with a new mode called [Aliengrep](/docs/writing-rules/experiments/aliengrep/). 
 
-With Aliengrep, you can [configure what characters are allowed as part of a word token](/docs/writing-rules/experiments/aliengrep/#additional-word-characters-captured-by-metavariables) as well as have [even more fun with ellipses](/docs/writing-rules/experiments/aliengrep/#ellipsis-). 
+With Aliengrep, you can [configure what characters are allowed as part of a word token](/docs/writing-rules/experiments/aliengrep/#additional-word-characters-captured-by-metavariables) as well as [have even more fun with ellipses](/docs/writing-rules/experiments/aliengrep/#ellipsis-).
 
 Give it a try and share your thoughts!
 

--- a/docs/kb/rules/ellipsis-metavariables.md
+++ b/docs/kb/rules/ellipsis-metavariables.md
@@ -1,0 +1,36 @@
+---
+description: Ellipsis metavariables can help with matching multiple word tokens.
+tags:
+  - Rules
+  - Semgrep Code
+---
+
+import MoreHelp from "/src/components/MoreHelp"
+
+# Using ellipsis metavariables to match multiple tokens
+
+Ellipses (`...`) to match a sequence of items are one of the most-used constructs in Semgrep rules, and they can even be used with metavariables ($VAR) to increase matching scope!
+
+Most commonly, ellipsis metavariables like `$...ARGS` are used to match sequences of items, like multiple arguments to a function, [while capturing the values for later re-use](/docs/writing-rules/pattern-syntax/#ellipsis-metavariables).
+
+However, they can also be used to match multiple word tokens. This is especially handy in [Generic pattern matching mode](/docs/writing-rules/generic-pattern-matching/), where a token is defined as a sequence of characters in the set `[A-z0-9_]`. 
+
+In `generic` mode, `ABC_DEF` is one token, and a metavariable such as $VAR captures the entire sequence. However, `ABC-DEF` is two tokens, and a metavariable such as $VAR does not capture the entire sequence. If the language you're working with allows other characters in tokens, using ellipsis metavariables can prevent problems with matching too little of the pattern.
+
+## Capturing multiple tokens with ellipsis metavariables
+
+To match `ABC-DEF` in `generic` mode, use an ellipsis metavariable, `$...VAR`. Here is an example rule:
+
+<iframe src="https://semgrep.dev/embed/editor?snippet=J6Ro" title="pattern-not rule for unverified transactions" width="100%" height="432px" frameBorder="0"></iframe>
+
+If you remove the ellipsis in the `$...ID` variable, the second example no longer matches.
+
+## Alternative: try the aliengrep experiment
+
+Semgrep's generic matching mode is [somewhat limited](/docs/writing-rules/generic-pattern-matching/#caveats-and-limitations-of-generic-mode). To address some of the limitations, the team is experimenting with a new mode called [Aliengrep](/docs/writing-rules/experiments/aliengrep/). 
+
+With Aliengrep, you can [configure what characters are allowed as part of a word token](/docs/writing-rules/experiments/aliengrep/#additional-word-characters-captured-by-metavariables) as well as have [even more fun with ellipses](/docs/writing-rules/experiments/aliengrep/#ellipsis-). 
+
+Give it a try and share your thoughts!
+
+<MoreHelp />

--- a/docs/kb/rules/ellipsis-metavariables.md
+++ b/docs/kb/rules/ellipsis-metavariables.md
@@ -9,31 +9,37 @@ import MoreHelp from "/src/components/MoreHelp"
 
 # Matching multiple tokens with ellipsis metavariables
 
+Using ellipsis (`...`) to match a sequence of items (for example, arguments, statements, or fields) is one of the most common constructs in Semgrep rules. Likewise, using metavariables ($VAR) to capture values (such as variables, functions, arguments, classes, and methods) is extremely common and powerful for tracking the use of values across a code scope.
+
 ## Introduction to ellipsis metavariables
 
-Using ellipsis (`...`) to match a sequence of tokens (for example, items in an array) is one of the most common constructs in Semgrep rules, and ellipses can even be used with metavariables ($VAR) to increase matching scope!
+Ellipses can be combined with metavariables to increase matching scope from a single item to a sequence of items, [while capturing the values for later re-use](/docs/writing-rules/pattern-syntax/#ellipsis-metavariables).
 
-Most commonly, ellipsis metavariables like `$...ARGS` are used for purposes like matching multiple arguments to a function, [while capturing the values for later re-use](/docs/writing-rules/pattern-syntax/#ellipsis-metavariables).
+Most commonly, ellipsis metavariables like `$...ARGS` are used for purposes like matching multiple arguments to a function or items in an array.
 
-However, they can also be used to match multiple word tokens. This is especially handy in [Generic pattern matching mode](/docs/writing-rules/generic-pattern-matching/), where a token is defined as a sequence of characters in the set `[A-z0-9_]`. Not all languages you might match with Generic mode share the same definition of word tokens. If you're matching patterns in one of these languages, your metavariables might not match as much of a word token as you expect.
+However, they can also be used to match multiple word tokens. As part of Semgrep's pattern matching, it separates the analyzed language into tokens, which are single units that make up a larger text. Some tokens, typically alphanumeric tokens, are "words", and some are word separators (like punctuation and whitespace).
+
+Using ellipsis metavariables to match multiple word tokens is especially helpful in [Generic pattern matching mode](/docs/writing-rules/generic-pattern-matching/). Because this mode is generic, it's not aware of the semantics of any particular language, and that comes with [caveats and limitations](/docs/writing-rules/generic-pattern-matching/#caveats-and-limitations-of-generic-mode).
+
+In generic mode, a word token that can be matched by a metavariable is defined as a sequence of characters in the set `[A-z0-9_]`. So `ABC_DEF` is one token, and a metavariable such as `$VAR` captures the entire sequence. However, `ABC-DEF` is two tokens, and a metavariable such as `$VAR` does not capture the entire sequence.
 
 ## Capturing multiple tokens with ellipsis metavariables
 
-In `generic` mode, `ABC_DEF` is one token, and a metavariable such as `$VAR` captures the entire sequence. However, `ABC-DEF` is two tokens, and a metavariable such as `$VAR` does not capture the entire sequence.
+Not all languages you might match using generic mode share the same definition of word tokens. If you're matching patterns in one of these languages, your metavariables might not match as much of a word token as you expect. For example, in HTML, "ABC-DEF" is a single token (perhaps an `id` value).
 
 If the language you're working with allows other characters in tokens, using ellipsis metavariables can prevent problems with metavariables matching too little of the pattern.
 
-To match `ABC-DEF` in `generic` mode, use an ellipsis metavariable, like `$...VAR`. Here is an example rule:
+To match all of `ABC-DEF` in `generic` mode, use an ellipsis metavariable, like `$...VAR`. Here is an example rule:
 
-<iframe src="https://semgrep.dev/embed/editor?snippet=J6Ro" title="pattern-not rule for unverified transactions" width="100%" height="432px" frameBorder="0"></iframe>
+<iframe src="https://semgrep.dev/embed/editor?snippet=J6Ro" title="html-ellipsis-metavariable" width="100%" height="432px" frameBorder="0"></iframe>
 
 If you remove the ellipsis in the `$...ID` variable, the second example no longer matches.
 
 ## Alternative: try the Aliengrep experiment
 
-Semgrep's generic matching mode contains [caveats and limitations](/docs/writing-rules/generic-pattern-matching/#caveats-and-limitations-of-generic-mode). To address some of the limitations, the team is experimenting with a new mode called [Aliengrep](/docs/writing-rules/experiments/aliengrep/). 
+To address some of the limitations of generic mode, the team is experimenting with a new mode called [Aliengrep](/docs/writing-rules/experiments/aliengrep/).
 
-With Aliengrep, you can [configure what characters are allowed as part of a word token](/docs/writing-rules/experiments/aliengrep/#additional-word-characters-captured-by-metavariables) as well as [have even more fun with ellipses](/docs/writing-rules/experiments/aliengrep/#ellipsis-).
+With Aliengrep, you can [configure what characters are allowed as part of a word token](/docs/writing-rules/experiments/aliengrep/#additional-word-characters-captured-by-metavariables), so that you could match the HTML example with a single metavariable. You can also [have even more fun with ellipses](/docs/writing-rules/experiments/aliengrep/#ellipsis-).
 
 Give it a try and share your thoughts!
 

--- a/docs/kb/rules/ellipsis-metavariables.md
+++ b/docs/kb/rules/ellipsis-metavariables.md
@@ -7,25 +7,29 @@ tags:
 
 import MoreHelp from "/src/components/MoreHelp"
 
-# Using ellipsis metavariables to match multiple tokens
+# Matching multiple tokens with ellipsis metavariables
 
-Ellipses (`...`) to match a sequence of items are one of the most-used constructs in Semgrep rules, and they can even be used with metavariables ($VAR) to increase matching scope!
+## What are ellipsis metavariables?
 
-Most commonly, ellipsis metavariables like `$...ARGS` are used to match sequences of items, like multiple arguments to a function, [while capturing the values for later re-use](/docs/writing-rules/pattern-syntax/#ellipsis-metavariables).
+Using ellipsis (`...`) to match a sequence of items is one of the most common constructs in Semgrep rules, and ellipses can even be used with metavariables ($VAR) to increase matching scope!
+
+Most commonly, ellipsis metavariables like `$...ARGS` are used for purposes like matching multiple arguments to a function, [while capturing the values for later re-use](/docs/writing-rules/pattern-syntax/#ellipsis-metavariables).
 
 However, they can also be used to match multiple word tokens. This is especially handy in [Generic pattern matching mode](/docs/writing-rules/generic-pattern-matching/), where a token is defined as a sequence of characters in the set `[A-z0-9_]`. 
 
-In `generic` mode, `ABC_DEF` is one token, and a metavariable such as $VAR captures the entire sequence. However, `ABC-DEF` is two tokens, and a metavariable such as $VAR does not capture the entire sequence. If the language you're working with allows other characters in tokens, using ellipsis metavariables can prevent problems with matching too little of the pattern.
-
 ## Capturing multiple tokens with ellipsis metavariables
 
-To match `ABC-DEF` in `generic` mode, use an ellipsis metavariable, `$...VAR`. Here is an example rule:
+In `generic` mode, `ABC_DEF` is one token, and a metavariable such as `$VAR` captures the entire sequence. However, `ABC-DEF` is two tokens, and a metavariable such as `$VAR` does not capture the entire sequence. 
+
+If the language you're working with allows other characters in tokens, using ellipsis metavariables can prevent problems with matching too little of the pattern.
+
+To match `ABC-DEF` in `generic` mode, use an ellipsis metavariable, like `$...VAR`. Here is an example rule:
 
 <iframe src="https://semgrep.dev/embed/editor?snippet=J6Ro" title="pattern-not rule for unverified transactions" width="100%" height="432px" frameBorder="0"></iframe>
 
 If you remove the ellipsis in the `$...ID` variable, the second example no longer matches.
 
-## Alternative: try the aliengrep experiment
+## Alternative: try the Aliengrep experiment
 
 Semgrep's generic matching mode is [somewhat limited](/docs/writing-rules/generic-pattern-matching/#caveats-and-limitations-of-generic-mode). To address some of the limitations, the team is experimenting with a new mode called [Aliengrep](/docs/writing-rules/experiments/aliengrep/). 
 

--- a/docs/kb/rules/ellipsis-metavariables.md
+++ b/docs/kb/rules/ellipsis-metavariables.md
@@ -9,19 +9,19 @@ import MoreHelp from "/src/components/MoreHelp"
 
 # Matching multiple tokens with ellipsis metavariables
 
-## What are ellipsis metavariables?
+## Introduction to ellipsis metavariables
 
-Using ellipsis (`...`) to match a sequence of items is one of the most common constructs in Semgrep rules, and ellipses can even be used with metavariables ($VAR) to increase matching scope!
+Using ellipsis (`...`) to match a sequence of tokens (for example, items in an array) is one of the most common constructs in Semgrep rules, and ellipses can even be used with metavariables ($VAR) to increase matching scope!
 
 Most commonly, ellipsis metavariables like `$...ARGS` are used for purposes like matching multiple arguments to a function, [while capturing the values for later re-use](/docs/writing-rules/pattern-syntax/#ellipsis-metavariables).
 
-However, they can also be used to match multiple word tokens. This is especially handy in [Generic pattern matching mode](/docs/writing-rules/generic-pattern-matching/), where a token is defined as a sequence of characters in the set `[A-z0-9_]`, which is not a fit for all languages.
+However, they can also be used to match multiple word tokens. This is especially handy in [Generic pattern matching mode](/docs/writing-rules/generic-pattern-matching/), where a token is defined as a sequence of characters in the set `[A-z0-9_]`. Not all languages you might match with Generic mode share the same definition of word tokens. If you're matching patterns in one of these languages, your metavariables might not match as much of a word token as you expect.
 
 ## Capturing multiple tokens with ellipsis metavariables
 
 In `generic` mode, `ABC_DEF` is one token, and a metavariable such as `$VAR` captures the entire sequence. However, `ABC-DEF` is two tokens, and a metavariable such as `$VAR` does not capture the entire sequence.
 
-If the language you're working with allows other characters in tokens, using ellipsis metavariables can prevent problems with matching too little of the pattern.
+If the language you're working with allows other characters in tokens, using ellipsis metavariables can prevent problems with metavariables matching too little of the pattern.
 
 To match `ABC-DEF` in `generic` mode, use an ellipsis metavariable, like `$...VAR`. Here is an example rule:
 

--- a/docs/writing-rules/experiments/aliengrep.md
+++ b/docs/writing-rules/experiments/aliengrep.md
@@ -70,11 +70,11 @@ In Semgrep rule syntax, an ellipsis is a specific pattern written as three dots 
 
 Ellipses at the beginning or at the end of a pattern are anchored. For example, ellipses must match the beginning or the end of the target input, respectively. For example, `...` alone matches the whole input and `a ...` matches the whole input starting from the first occurrence of the word `a`.
 
-### Metavariable ellipsis (capturing ellipsis)
+### Ellipsis metavariable (capturing ellipsis)
 
-A metavariable ellipsis `$...X` matches the same contents as an ordinary ellipsis `...` but additionally captures the contents and assigns it to the metavariable `X`.
+An ellipsis metavariable `$...X` matches the same contents as an ordinary ellipsis `...` but additionally captures the contents and assigns them to the metavariable `X`.
 
-Repeating a metavariable ellipsis such as in `$...A, $...A` requires the same exact contents to be matched, including the same whitespace. This is an unfortunate limitation of the implementation. For example, `$...A, $...A` matches `1 2, 1 2` and `1   2, 1   2` but unfortunately, it doesn't match `1 2, 1   2`.
+Repeating a metavariable ellipsis such as in `$...A, $...A` requires the same contents to be matched by each repetition, including the same whitespace. This is an unfortunate limitation of the implementation. For example, `$...A, $...A` matches `1 2, 1 2` and `1   2, 1   2` but it doesn't match `1 2, 1   2`.
 
 ### Single-line mode
 
@@ -92,7 +92,7 @@ rules:
   pattern: "password: ..."
 ```
 
-Now instead of matching everything until the end of the target input file, the pattern `password: ...` will stop the match at the end of the line. In single-line mode, a regular ellipsis `...` or its named variant `$...X` cannot span multiple lines.
+Now instead of matching everything until the end of the target input file, the pattern `password: ...` stops the match at the end of the line. In single-line mode, a regular ellipsis `...` or its named variant `$...X` cannot span multiple lines.
 
 Another feature of the single-line mode is that newlines in rule patterns must match literally. For example, the following YAML rule contains a two-line pattern:
 
@@ -124,7 +124,7 @@ x a b x
 It does however match in the default multiline mode of Aliengrep.
 
 :::caution
-YAML syntax makes it easy to introduce significant newline characters in patterns without realizing it. In doubt and for better clarity, use the quoted string syntax `"a\nb"` as we did above. This ensures no trailing newline is added accidentally when using the single-line mode.
+YAML syntax makes it easy to introduce significant newline characters in patterns without realizing it. When in doubt and for better clarity, use the quoted string syntax `"a\nb"` as we did in the preceding example. This ensures no trailing newline is added accidentally when using the single-line mode.
 :::
 
 ### Long ellipsis (`....`)
@@ -153,7 +153,7 @@ rules:
   pattern: "data = $DATA;"
 ```
 
-The example above allows matching Base64-encoded data such as in the following target input:
+The preceding example allows matching Base64-encoded data such as in the following target input:
 
 ```
 data = bGlnaHQgd29yaw==;
@@ -199,7 +199,7 @@ rules:
   pattern: "x ... x"
 ```
 
-### Caseless matching
+### Case-insensitive matching
 
 Some languages are case-insensitive according to Unicode rules (UTF-8 encoding). To deal with this, Aliengrep offers an option for case-insensitive matching `options.generic_caseless: true`.
 
@@ -219,7 +219,7 @@ rules:
 This rule matches `Content-Type: text/html` but also `content-type: text/html` or `CONTENT-TyPe: text/HTML` among all the possible variants.
 
 :::caution
-Back-referencing a metavariable requires an exact repeat of the text captured by the metavariable, even in caseless mode. For example, `$X $X` will match `ab ab` and `AB AB` but not `ab AB`.
+Back-referencing a metavariable requires an exact repeat of the text captured by the metavariable, even in caseless mode. For example, `$X $X` matches `ab ab` and `AB AB` but not `ab AB`.
 :::
 
 <MoreHelp />


### PR DESCRIPTION
* Add a guide for using ellipsis metavariables to match multiple word tokens in generic mode (a relatively common question).
  * As part of this addition, I checked whether "ellipsis metavariable" is the desired standard, and brought the new/experimental Aliengrep mode document into that fold.
  * While I was editing the Aliengrep doc I also did some other light Vale style linting on it. I didn't attempt to change the first-person usages because they were extensive, but I fixed uses of will and other smaller suggestions.

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
