### PR TITLE
Update installation commands to Google style (describe result/effect of command)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,7 +47,7 @@ To install and run Semgrep OSS Engine, use one of the following options:
       python3 -m pip install semgrep
       ```
 
-  2. Confirm installation by the following command:
+  2. Confirm installation:
       ```sh
       semgrep --version
       ```
@@ -65,7 +65,7 @@ To install and run Semgrep OSS Engine, use one of the following options:
       python3 -m pip install semgrep
       ```
 
-  2. Confirm installation by the following command:
+  2. Confirm installation:
       ```sh
       semgrep --version
       ```
@@ -84,7 +84,7 @@ To install and run Semgrep OSS Engine, use one of the following options:
       python3 -m pip install semgrep
       ```
 
-  2. Confirm installation by the following command:
+  2. Confirm installation:
       ```sh
       semgrep --version
       ```
@@ -103,7 +103,7 @@ To install and run Semgrep OSS Engine, use one of the following options:
      docker pull returntocorp/semgrep
      ```
    
-  2. Confirm version by the following command:
+  2. Confirm version:
       ```sh
       docker run --rm returntocorp/semgrep semgrep --version
       ```

--- a/docs/kb/semgrep-code/run-specific-version.md
+++ b/docs/kb/semgrep-code/run-specific-version.md
@@ -19,11 +19,11 @@ Installation with Homebrew does not support multiple versions of Semgrep, but yo
 
 ## Running different versions using pip
 
-You can install a specific Semgrep version using pip's version syntax.
+Install a specific Semgrep version using pip's version syntax:
 
 <pre class="language-bash"><code>python3 -m pip install semgrep==<span className="placeholder">x.y.z</span></code></pre>
 
-Confirm installation by running the following command:
+Confirm installation:
 
 ```
 semgrep --version
@@ -39,11 +39,11 @@ To pull:
 
 <pre class="language-bash"><code>docker pull returntocorp/semgrep:<span className="placeholder">x.y.z</span></code></pre>
 
-Example for a local run, mounting the desired source directory (`/PATH/TO/SRC`) for scanning:
+To run locally, mounting the desired source directory (`/PATH/TO/SRC`) for scanning:
 
 <pre class="language-bash"><code>docker run --rm -v "<span className="placeholder">/PATH/TO/SRC</span>:/src" returntocorp/semgrep:<span className="placeholder">x.y.z</span> semgrep --config=auto</code></pre>
 
-Example for a GitHub Actions CI configuration:
+To run in GitHub Actions CI:
 
 ```yaml
 jobs:


### PR DESCRIPTION
This came up when I did a copy-pasta of the Getting Started doc into a KB and @s-santillan pointed out that the sentence sounded a bit strange without a verb for running the command. It turns out Google prefers if you just describe the effect or result of the command so simplifying to that.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
