### PR TITLE
removing dart from experimental

### DIFF
--- a/src/components/reference/_supported-languages-table.mdx
+++ b/src/components/reference/_supported-languages-table.mdx
@@ -20,7 +20,7 @@
 All generally available (GA) Semgrep OSS languages also have support for Semgrep Pro Engine's cross-functional analysis. 
 
 Semgrep OSS Engine also has experimental language support for the following languages:
-* Bash, C, C++, Cairo, Clojure, Dart, Dockerfile, Elixir, HTML, Jsonnet, Julia, Lisp, Lua, Ocaml, R, Scheme, Solidity, Swift, YAML, XML, Generic (ERB, Jinja, etc.).
+* Bash, C, C++, Cairo, Clojure, Dockerfile, Elixir, HTML, Jsonnet, Julia, Lisp, Lua, Ocaml, R, Scheme, Solidity, Swift, YAML, XML, Generic (ERB, Jinja, etc.).
 
 If you'd like to request a language not shown here, please [create an issue on the Semgrep GitHub repo](https://github.com/returntocorp/semgrep/issues). 
 


### PR DESCRIPTION
removing dart from experimental, while we fix it's parsing issues

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
