### PR TITLE
Add callout to clarify that transitive can be unreachable if not reachable by inclusion

### DIFF
--- a/docs/semgrep-supply-chain/overview.md
+++ b/docs/semgrep-supply-chain/overview.md
@@ -122,7 +122,10 @@ See [SSC glossary > Transitivity](/docs/semgrep-supply-chain/glossary/#transitiv
 * Semgrep Supply Chain does **not** perform reachability analysis for transitive dependencies. This means we do not scan the source code of your dependencies to determine if their dependencies may produce a reachable finding in the code.
 * Semgrep Supply Chain supports scanning for transitive or indirect dependencies for all of its [supported languages](/docs/supported-languages#semgrep-supply-chain). Findings are collected and displayed in **Semgrep Cloud Platform** > **Supply Chain**.
 * In most cases, Semgrep Supply Chain generates **reachable findings** for **direct dependencies**. However, there are certain dependencies that are vulnerable simply through their inclusion in a codebase. Semgrep Supply Chain generates reachable findings for these types of dependencies even if they are transitive dependencies.
-  - Semgrep Supply Chain shows transitive dependencies that are not vulnerable through inclusion as **unreachable**.
+
+:::info
+In some ecosystems, it's possible to use a transitive dependency in your code as if it were a direct dependency. This is very uncommon, but Semgrep does scan for these usages with reachability rules if they are available, and will mark transitive dependencies as "unreachable" if they are not directly used.
+:::
 
 ## Next steps: Scanning your codebase
 

--- a/docs/semgrep-supply-chain/overview.md
+++ b/docs/semgrep-supply-chain/overview.md
@@ -122,6 +122,7 @@ See [SSC glossary > Transitivity](/docs/semgrep-supply-chain/glossary/#transitiv
 * Semgrep Supply Chain does **not** perform reachability analysis for transitive dependencies. This means we do not scan the source code of your dependencies to determine if their dependencies may produce a reachable finding in the code.
 * Semgrep Supply Chain supports scanning for transitive or indirect dependencies for all of its [supported languages](/docs/supported-languages#semgrep-supply-chain). Findings are collected and displayed in **Semgrep Cloud Platform** > **Supply Chain**.
 * In most cases, Semgrep Supply Chain generates **reachable findings** for **direct dependencies**. However, there are certain dependencies that are vulnerable simply through their inclusion in a codebase. Semgrep Supply Chain generates reachable findings for these types of dependencies even if they are transitive dependencies.
+  - Semgrep Supply Chain shows transitive dependencies that are not vulnerable through inclusion as **unreachable**.
 
 ## Next steps: Scanning your codebase
 


### PR DESCRIPTION
Add a callout box mentioning that it's possible for transitive dependencies to show as unreachable if they have a reachability rule, but aren't used directly in the first-party codebase (which would be the case for the vast majority of transitive dependencies).

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
