### PR TITLE
updated based on pa team

### DIFF
--- a/src/components/reference/_supported-languages-table.mdx
+++ b/src/components/reference/_supported-languages-table.mdx
@@ -14,8 +14,8 @@
 | PHP        | GA | Beta | -- |                   
 | Python     | GA | Beta | -- |                        
 | Scala      | GA | Beta | -- |                       
-| Terraform  | GA | Beta | -- |      
-| Rust       | Beta | -- | -- |   
+| Terraform  | GA | -- | -- |      
+| Rust       | Beta | Experimental | -- |   
 | Bash       | Experimental | -- | -- |  
 | C          | Experimental | -- | -- |     
 | C++        | Experimental | -- | -- |  

--- a/src/components/reference/_supported-languages-table.mdx
+++ b/src/components/reference/_supported-languages-table.mdx
@@ -9,11 +9,11 @@
 | TypeScript | GA | Beta | Beta |
 | C#         | GA | Beta | -- |
 | Ruby       | GA | Beta | -- |                      
-| JSON       | GA | Beta | -- |                    
 | JSX        | GA | Beta | -- |                       
 | PHP        | GA | Beta | -- |                   
 | Python     | GA | Beta | -- |                        
 | Scala      | GA | Beta | -- |                       
+| JSON       | GA | -- | -- |                    
 | Terraform  | GA | -- | -- |      
 | Rust       | Beta | Experimental | -- |   
 | Bash       | Experimental | -- | -- |  


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
~~- [ ] A technical writer reviews the content or PR~~ XS size PR, not needed
- [x] This change has no security implications or else you have pinged the security team

I set Rust as experimental for intrafile because we have not extensively tested it.
Removed beta from terraform as discussed.