### PR TITLE
add instructions on running semgrep docker windows

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -79,7 +79,11 @@ To install and run Semgrep OSS Engine, use one of the following options:
 
 <TabItem value='Windows Subsystem for Linux (WSL)'>
 
-  1. Install:
+:::info Prerequisites
+You must have Windows Subsystem for Linux installed. To install WSL, refer to Microsoft's documentation on [Installing Linux on Windows with WSL](https://learn.microsoft.com/en-us/windows/wsl/install).
+:::
+
+  1. Within your WSL interface, install Semgrep:
       ```bash
       python3 -m pip install semgrep
       ```
@@ -109,12 +113,15 @@ To install and run Semgrep OSS Engine, use one of the following options:
       ```
 
   3. Run recommended Semgrep Registry rules:
-    ```bash
-    docker run --rm -v "${PWD}:/src" returntocorp/semgrep semgrep --config=auto
+    1. On macOS or Linux, in the directory to scan:
+      ```bash
+      docker run --rm -v "${PWD}:/src" returntocorp/semgrep semgrep --config=auto
+      ```
+      The provided `-v` option mounts the current directory into the container to be scanned. Change directories locally or provide a specific local directory in the command to scan a different directory.
+    2. On WSL, in the directory to scan:
     ```
-
-    The provided `-v` option mounts the current directory into the container to be scanned. Change directories locally or provide a specific local directory in the command to scan a different directory.
-
+    docker run --rm -v "%cd%:/src" returntocorp/semgrep semgrep --config=auto
+    ```
 
 </TabItem>
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -118,7 +118,7 @@ You must have Windows Subsystem for Linux installed. To install WSL, refer to Mi
         docker run --rm -v "${PWD}:/src" returntocorp/semgrep semgrep --config=auto
         ```
         The provided `-v` option mounts the current directory into the container to be scanned. Change directories locally or provide a specific local directory in the command to scan a different directory.
-      2. On **WSL**, in the directory to scan:
+      2. On **Windows**, in the directory to scan:
         ```bash
         docker run --rm -v "%cd%:/src" returntocorp/semgrep semgrep --config=auto
         ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -79,7 +79,7 @@ To install and run Semgrep OSS Engine, use one of the following options:
 
 <TabItem value='Windows Subsystem for Linux (WSL)'>
 
-:::info Prerequisites
+:::info Prerequisite
 You must have Windows Subsystem for Linux installed. To install WSL, refer to Microsoft's documentation on [Installing Linux on Windows with WSL](https://learn.microsoft.com/en-us/windows/wsl/install).
 :::
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -113,15 +113,15 @@ You must have Windows Subsystem for Linux installed. To install WSL, refer to Mi
       ```
 
   3. Run recommended Semgrep Registry rules:
-    1. On macOS or Linux, in the directory to scan:
-      ```bash
-      docker run --rm -v "${PWD}:/src" returntocorp/semgrep semgrep --config=auto
-      ```
-      The provided `-v` option mounts the current directory into the container to be scanned. Change directories locally or provide a specific local directory in the command to scan a different directory.
-    2. On WSL, in the directory to scan:
-    ```
-    docker run --rm -v "%cd%:/src" returntocorp/semgrep semgrep --config=auto
-    ```
+      1. On **macOS or Linux**, in the directory to scan:
+        ```bash
+        docker run --rm -v "${PWD}:/src" returntocorp/semgrep semgrep --config=auto
+        ```
+        The provided `-v` option mounts the current directory into the container to be scanned. Change directories locally or provide a specific local directory in the command to scan a different directory.
+      2. On **WSL**, in the directory to scan:
+        ```bash
+        docker run --rm -v "%cd%:/src" returntocorp/semgrep semgrep --config=auto
+        ```
 
 </TabItem>
 


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR

@sebasrevuelta This PR adds back some of your tips:

- Added prerequisite and link to install WSL in getting started docs
- Added helpful docker command specific to windows when running semgrep in docker in windows

There are several helpful commands you included (running env vars in docker, specifying target folder) that I haven't figured out yet where to place, namely "running semgrep with a specific target directory or module". I think they should go into a Semgrep Usage tips or Helpful Semgrep Command Combinations guide. I will find a place for them, maybe in Semgrep CLI, as an "Appendix" or "Common use cases for Semgrep CLI". I have opened a [linear ticket here](https://linear.app/semgrep/issue/MKT-713/common-uses-and-workflows-for-semgrep-cli) so that everything you wrote has a place in the docs.


