### PR TITLE
feat(rule syntax): add string in docs

### DIFF
--- a/docs/writing-rules/rule-syntax.md
+++ b/docs/writing-rules/rule-syntax.md
@@ -255,6 +255,7 @@ The `comparison` key accepts Python expression using:
 - Function `today()` that gets today's date as a float representing epoch time.
 - Function `strptime()` that converts strings in the format `"yyyy-mm-dd"` to a float representing the date in epoch time.
 - Lists, together with the `in`, and `not in` infix operators.
+- Strings, together with the `in` and `not in` infix operators, for substring containment.
 - Function `re.match()` to match a regular expression (without the optional `flags` argument).
 
 You can use Semgrep metavariables such as `$MVAR`, which Semgrep evaluates as follows:


### PR DESCRIPTION
As of https://github.com/returntocorp/semgrep/pull/8406, we now support `in` and `not in` for strings. This just changes the docs.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [X] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [X] This change has no security implications or else you have pinged the security team
- [X] Redirects are added if the PR changes page URLs
- [X] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
