### PR TITLE
CircleCI snippet fix: SAST snippet was running SSC instead

### DIFF
--- a/src/components/code_snippets/_circleci-semgrep-app-standalone.mdx
+++ b/src/components/code_snippets/_circleci-semgrep-app-standalone.mdx
@@ -21,7 +21,7 @@ jobs:
       - checkout
       - run:
           name: "Semgrep scan"
-          command: semgrep ci --supply-chain
+          command: semgrep ci
 workflows:
   main:
     jobs:


### PR DESCRIPTION
SAST standalone snippets should not use the `--supply-chain` argument :)
There are some more complex issues with this snippet but I've raised those in a separate internal issue for discussion - this fix at least gets us running the right product.

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
