### PR TITLE
Clarify tag setting

### DIFF
--- a/docs/semgrep-cloud-platform/tags.md
+++ b/docs/semgrep-cloud-platform/tags.md
@@ -23,13 +23,14 @@ import MoreHelp from "/src/components/MoreHelp"
 
 Add tags for specific projects in the Semgrep Cloud Platform through the following methods:
 
+* Set tags through the Semgrep Cloud Platform > Project page.
+* Set tags using the Semgrep Cloud Platform API (for Team and Enterprise Tier users).
 * Set tags in your repository's `.semgrepconfig.yml` file.
-* Set tags through Semgrep Cloud Platform > Project page or Semgrep Cloud Platform API (for Team and Enterprise Tier users).
 
-:::tip Best practices
-*  Choose either Semgrep Cloud Platform (and API) or `.semgrepconfig.yml` to manage tags. **Do not use a mix of the two.**
-* Semgrep Cloud Platform and its API **never** overwrite your `.semgrepconfig.yml` file. If you choose to use `.semgrepconfig.yml` to manage your tags, use it **exclusively**. Do not use Semgrep Cloud Platform or the API to manage any tags. Any changes to your tags through Semgrep Cloud Platform will be overwritten after a CI scan due to values present in `.semgrepconfig.yml`.
-* Semgrep always prioritizes values in `.semgrepconfig.yml` as the source of truth.
+:::caution Setting tags
+* Keep in mind, when setting tags via the `.semgrepconfig.yml` file or Semgrep Cloud Platform API, that these actions **overwrite** any tags previously set.
+* For example, if you set tags via API and subsequently run a CI scan, then the previous tags set by the API will be overwritten by any tag definitions in the `.semgrepconfig.yml` file of the repo.
+* For this reason, we recommend exclusively choosing either the API or `.semgrepconfig.yml` file to manage and set tags. **Do not use a mix of the two.**
 :::
 
 ## Set tags through Semgrep Cloud Platform and Semgrep Cloud Platform API

--- a/docs/semgrep-cloud-platform/tags.md
+++ b/docs/semgrep-cloud-platform/tags.md
@@ -28,7 +28,7 @@ Add tags for specific projects in the Semgrep Cloud Platform through the followi
 * Set tags in your repository's `.semgrepconfig.yml` file.
 
 :::caution Setting tags
-* Keep in mind, when setting tags via the `.semgrepconfig.yml` file or Semgrep Cloud Platform API, that these actions **overwrite** any tags previously set.
+* Keep in mind, when setting tags via the `.semgrepconfig.yml` file or Semgrep Cloud Platform API, that these actions **supersede** any tags previously set.
 * For example, if you set tags through the API and subsequently run a CI scan, then the previous tags set by the API will be overwritten by any tag definitions in the `.semgrepconfig.yml` file of the repository.
 * For this reason, we recommend exclusively choosing either the API or `.semgrepconfig.yml` file to manage and set tags. **Do not use a mix of the two.**
 :::

--- a/docs/semgrep-cloud-platform/tags.md
+++ b/docs/semgrep-cloud-platform/tags.md
@@ -29,7 +29,7 @@ Add tags for specific projects in the Semgrep Cloud Platform through the followi
 
 :::caution Setting tags
 * Keep in mind, when setting tags via the `.semgrepconfig.yml` file or Semgrep Cloud Platform API, that these actions **overwrite** any tags previously set.
-* For example, if you set tags via API and subsequently run a CI scan, then the previous tags set by the API will be overwritten by any tag definitions in the `.semgrepconfig.yml` file of the repo.
+* For example, if you set tags through the API and subsequently run a CI scan, then the previous tags set by the API will be overwritten by any tag definitions in the `.semgrepconfig.yml` file of the repository.
 * For this reason, we recommend exclusively choosing either the API or `.semgrepconfig.yml` file to manage and set tags. **Do not use a mix of the two.**
 :::
 


### PR DESCRIPTION
Updated the verbiage to explain how tag setting works via API and settings file. Also changed the docusaurus admonition to type "caution" to better reflect the tone of the message

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
