### PR TITLE
Use IAM role instead of IAM user

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -11,6 +11,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -24,8 +27,9 @@ jobs:
       - name: Set AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::338683922796:role/semgrep-docs-deploy-role
+          role-duration-seconds: 900
+          role-session-name: deploy
           aws-region: us-west-2
       - name: Deploy to staging
         if: github.ref == 'refs/heads/develop'


### PR DESCRIPTION
IAM users have static credentials that need periodic rotation (the key for this user is over 200 days old!). Use the IAM role introduced in https://github.com/returntocorp/semgrep-app-terraform/pull/1140 instead to enable the workflow to use temporary creds using OIDC like in most other workflows.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
