### PR TITLE
Add references to enabling comments docs

### DIFF
--- a/docs/kb/semgrep-cloud-platform/inline-pr-comments.md
+++ b/docs/kb/semgrep-cloud-platform/inline-pr-comments.md
@@ -24,4 +24,10 @@ GitHub only allows PR comments to be posted on lines of code that are shown in t
 
 GitLab allows comments to be posted on lines of code outside the default file-diff view, but the comments don't appear in the file-diff (Changes) view. However, they do appear as diff-related comments on the Overview.
 
+## Additional references
+
+* [Enabling GitHub pull request comments](/docs/semgrep-cloud-platform/github-pr-comments/)
+* [Enabling GitLab merge request comments](/docs/semgrep-cloud-platform/gitlab-mr-comments/)
+* [Enabling Bitbucket pull request comments](/docs/semgrep-cloud-platform/bitbucket-pr-comments/)
+
 <MoreHelp />


### PR DESCRIPTION
I found my own KB in a search today (lol) and realized it was weird from that perspective that it doesn't link to the docs for enabling comments. 

Logically speaking, for this KB to be useful, you need to already have them enabled, but you might still land on it in other circumstances. 😄

### Please ensure

- [ ] ~A subject matter expert (SME) reviews the content~ small change
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications