### PR TITLE
`interfile: true` should be under `options`, not `metadata`

### DIFF
--- a/docs/semgrep-code/semgrep-pro-engine-examples.md
+++ b/docs/semgrep-code/semgrep-pro-engine-examples.md
@@ -14,7 +14,7 @@ This document provides an overview of Semgrep Pro Engine features through specif
 The following resources can help you to test the code in the sections below. As you work through the examples in this document, try the following:
 
 - Ensure that the <i class="fa-solid fa-toggle-large-on"></i> **Pro Engine beta** toggle is enabled on the [Playground](https://semgrep.dev/playground/new) page.
-    - Rules you use in Semgrep Pro Engine require `interfile: true` key included in the `metadata` key. See the following [example](https://semgrep.dev/s/3NZb).
+    - Rules you use in Semgrep Pro Engine require `interfile: true` key included in the `options` key. See the following [example](https://semgrep.dev/playground/s/lkPE).
 - The [Semgrep Pro Engine testing repository](https://github.com/returntocorp/semgrep-pro-tests) 
     - Clone the repository:
         ```sh

--- a/docs/semgrep-code/semgrep-pro-engine-intro.md
+++ b/docs/semgrep-code/semgrep-pro-engine-intro.md
@@ -146,13 +146,13 @@ To test Semgrep Pro Engine on a purposefully vulnerable repository, fork the [ju
 
 ### Creating rules that analyze across files
 
-Cross-file analysis (also called interfile analysis) rules you use in Semgrep Pro Engine require the `interfile: true` key included under the rule `metadata` key. See the following [example](https://semgrep.dev/s/3NZb). This key signals Semgrep Pro Engine to use the rule for cross-file analysis.
+Cross-file analysis (also called interfile analysis) rules you use in Semgrep Pro Engine require the `interfile: true` key included under the rule `options` key. See the following [example](https://semgrep.dev/playground/s/lkPE). This key signals Semgrep Pro Engine to use the rule for cross-file analysis.
 
 Example of `interfile: true` key:
 ```yaml
 rules:
   - id: dangerous-call-to-employees-pro-engine-example
-    metadata:
+    options:
       interfile: true
     patterns:
       - pattern: dangerous("Employees")


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
