### PR TITLE
Put the thank-you note within a markdown comment

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-# Thanks for improving Semgrep Docs 😀
+<!-- Thanks for improving Semgrep Docs 😀 -->
 
 ### Please ensure
 


### PR DESCRIPTION
I assume this message was intended as a comment. If not, nevermind.

```
# Thanks for improving Semgrep Docs 😀
```

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
