### PR TITLE
chore: add dart to supported languages

### DIFF
--- a/src/components/reference/_supported-languages-table.mdx
+++ b/src/components/reference/_supported-languages-table.mdx
@@ -23,6 +23,7 @@
 | C++        | Experimental | -- | -- |  
 | Cairo      | Experimental | -- | -- | 
 | Clojure    | Experimental | -- | -- |  
+| Dart       | Experimental | -- | -- |   
 | Dockerfile | Experimental | -- | -- |   
 | Elixir     | Experimental | -- | -- |   
 | HTML       | Experimental | -- | -- |      


### PR DESCRIPTION
https://github.com/returntocorp/semgrep/pull/8704 will add Experimental support for Dart to Semgrep. This PR just updates the documentation.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [X] This change has no security implications or else you have pinged the security team
- [X] Redirects are added if the PR changes page URLs
- [X] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
