### PR TITLE
Update `update-help-command.yml` to auto-create a PR

### DIFF
--- a/.github/workflows/update-help-command.yml
+++ b/.github/workflows/update-help-command.yml
@@ -13,6 +13,13 @@ jobs:
     steps:
       # Fetch project source with GitHub Actions Checkout.
       - uses: actions/checkout@v4
+      - name: Checkout new branch named based on latest tag
+        run: |
+          LATEST_TAG=$(gh release view -R returntocorp/semgrep --json tagName -q .tagName)
+          echo "LATEST_TAG=$(gh release view -R returntocorp/semgrep --json tagName -q .tagName)" >> $GITHUB_ENV
+          git checkout -b update_help_commands_$LATEST_TAG
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run `semgrep --help` and update reference file with output
         run: |
           docker run --rm returntocorp/semgrep:latest semgrep --help | tee src/components/reference/_cli-help-output.md
@@ -23,11 +30,18 @@ jobs:
           docker run --rm returntocorp/semgrep:latest semgrep scan --help | tee src/components/reference/_cli-help-scan-output.md
           sed -i '1i```' src/components/reference/_cli-help-scan-output.md
           echo '```' >> src/components/reference/_cli-help-scan-output.md
-      - name: Commit changed reference files to repo
+      - name: Commit changes, if any
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git add .
-          git diff-index --quiet HEAD || \
-          git commit -m "Updated help command output based on latest Semgrep release"
-          git push
+            if $(git diff --quiet); then
+              echo "No changes made, exiting."
+            else
+              echo "Committing changes."
+              git config user.name github-actions
+              git config user.email github-actions@github.com
+              git add .
+              git commit -m "Updated help command output based on latest Semgrep release"
+              git push --set-upstream origin update_help_commands_$LATEST_TAG
+              gh pr create --title "Update help command output for Semgrep $LATEST_TAG" --body "This is an automatically generated PR"
+            fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Instead of committing directly to `main`, which would fail because it's a protected branch, we generate a PR, with a PR branch named based on the latest semgrep release tag, so the branch name is always unique.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
