### PR TITLE
Add language maturity definitions for Pro Engine

### DIFF
--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -44,9 +44,21 @@ Semgrep Code supports over 30 languages and counting! 🚀
 
 ### Maturity levels
 
-#### Language maturity factors
+#### Language maturity factors (Pro Engine)
+Semgrep Pro Engine has two maturity levels:
+* Generally available (GA) 
+* Beta
 
-Semgrep OSS Engine has three maturity levels. Semgrep Code has the same maturity level as Semgrep OSS Engine for any supported language. The maturity levels are the following:
+
+**Generally Available**: Receives highest quality support from the Semgrep team. Reported issues are resolved promptly and timelines for fixes are communicated to customers within 2 weeks.
+
+**Beta**: Supported by the Semgrep team. Reported issues are tracked and prioritized to be fixed after GA languages.
+
+
+
+#### Language maturity factors (OSS Engine)
+
+Semgrep OSS Engine has three maturity levels:
 * Generally available (GA) 
 * Beta
 * Experimental 

--- a/src/components/reference/_supported-languages-table.mdx
+++ b/src/components/reference/_supported-languages-table.mdx
@@ -17,6 +17,7 @@
 | Terraform  | GA | -- | -- |      
 | Rust       | GA | Experimental | -- |
 | Swift      | Beta | -- | -- |     
+| Apex       | _Pro Engine Only_   | Experimental | -- |
 | Bash       | Experimental | -- | -- |  
 | C          | Experimental | -- | -- |     
 | C++        | Experimental | -- | -- |  

--- a/src/components/reference/_supported-languages-table.mdx
+++ b/src/components/reference/_supported-languages-table.mdx
@@ -2,22 +2,22 @@
 
 | Language | Semgrep OSS Engine | Semgrep Pro Engine (cross-function) | Semgrep Pro Engine (cross-file)
 |:---------- |:----------------------------|:---------------------------|:---------------------------|
-| Go         | GA | Beta | Beta |                         
-| Java       | GA | Beta | Beta |      
-| Kotlin     | GA | Beta | Beta |                
-| JavaScript | GA | Beta | Beta | 
-| TypeScript | GA | Beta | Beta |
-| C#         | GA | Beta | -- |
-| Ruby       | GA | Beta | -- |                      
-| JSX        | GA | Beta | -- |                       
-| PHP        | GA | Beta | -- |                   
-| Python     | GA | Beta | -- |                        
-| Scala      | GA | Beta | -- |                       
+| Go         | GA | GA | GA |                         
+| Java       | GA | GA | GA |                   
+| JavaScript | GA | GA | GA | 
+| TypeScript | GA | GA | GA |
+| Kotlin     | GA | GA | Beta |   
+| C#         | GA | GA | -- |
+| Ruby       | GA | GA | -- |                      
+| JSX        | GA | GA | -- |                       
+| PHP        | GA | GA | -- |                   
+| Python     | GA | GA | -- |                        
+| Scala      | GA | GA | -- |     
 | JSON       | GA | -- | -- |                    
 | Terraform  | GA | -- | -- |      
+| Apex       | _Pro Engine Only_   | Beta | -- |
 | Rust       | GA | Experimental | -- |
 | Swift      | Beta | -- | -- |     
-| Apex       | _Pro Engine Only_   | Experimental | -- |
 | Bash       | Experimental | -- | -- |  
 | C          | Experimental | -- | -- |     
 | C++        | Experimental | -- | -- |  


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
