### PR TITLE
Update SAST standalone snippets with --code

### DIFF
--- a/src/components/code_snippets/_azure-semgrep-app-standalone.mdx
+++ b/src/components/code_snippets/_azure-semgrep-app-standalone.mdx
@@ -10,7 +10,5 @@ steps:
 - script: |
     python -m pip install --upgrade pip
     pip install semgrep
-    semgrep ci
-  env: 
-    SEMGREP_RULES: p/default
+    semgrep ci --code
 ```

--- a/src/components/code_snippets/_bitbucket-semgrep-app-standalone.mdx
+++ b/src/components/code_snippets/_bitbucket-semgrep-app-standalone.mdx
@@ -9,11 +9,9 @@ pipelines:
           deployment: dev
           image: returntocorp/semgrep
           script:
-            - export SEMGREP_RULES = "p/default"
-
             # Uncomment the following line to scan changed 
             # files in PRs or MRs (diff-aware scanning): 
             # - export SEMGREP_BASELINE_REF = "main"
 
-            - semgrep ci
+            - semgrep ci --code
 ```

--- a/src/components/code_snippets/_buildkite-semgrep-app-standalone.mdx
+++ b/src/components/code_snippets/_buildkite-semgrep-app-standalone.mdx
@@ -1,13 +1,10 @@
 ```yaml
 - label: ":semgrep: Semgrep"
   commands:
-    # Define rules to scan with by setting the SEMGREP_RULES environment variable. 
-    - export SEMGREP_RULES="p/default"
-
     # To scan changed files in PRs or MRs (diff-aware scanning):
     # - export SEMGREP_BASELINE_REF=${BUILDKITE_BRANCH}
 
-    - semgrep ci 
+    - semgrep ci --code
   
   plugins:
     - docker#v3.7.0:

--- a/src/components/code_snippets/_circleci-semgrep-app-standalone.mdx
+++ b/src/components/code_snippets/_circleci-semgrep-app-standalone.mdx
@@ -7,8 +7,6 @@ jobs:
         type: string
         default: main
     environment:
-      SEMGREP_RULES: p/default
-
       # Uncomment the following line to scan changed 
       # files in PRs or MRs (diff-aware scanning): 
       # - export SEMGREP_BASELINE_REF = "origin/main"
@@ -21,7 +19,7 @@ jobs:
       - checkout
       - run:
           name: "Semgrep scan"
-          command: semgrep ci
+          command: semgrep ci --code
 workflows:
   main:
     jobs:

--- a/src/components/code_snippets/_gha-semgrep-app-standalone-dash.mdx
+++ b/src/components/code_snippets/_gha-semgrep-app-standalone-dash.mdx
@@ -33,10 +33,7 @@ jobs:
       # Fetch project source with GitHub Actions Checkout.
       - uses: actions/checkout@v3
       # Run the "semgrep ci" command on the command line of the docker image.
-      - run: semgrep ci --sarif --output=semgrep.sarif
-        env:
-           # Add the rules that Semgrep uses by setting the SEMGREP_RULES environment variable. 
-           SEMGREP_RULES: p/default # more at semgrep.dev/explore
+      - run: semgrep ci --code --sarif --output=semgrep.sarif
 
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         uses: github/codeql-action/upload-sarif@v2

--- a/src/components/code_snippets/_gha-semgrep-app-standalone.mdx
+++ b/src/components/code_snippets/_gha-semgrep-app-standalone.mdx
@@ -33,8 +33,5 @@ jobs:
       # Fetch project source with GitHub Actions Checkout.
       - uses: actions/checkout@v3
       # Run the "semgrep ci" command on the command line of the docker image.
-      - run: semgrep ci
-        env:
-           # Add the rules that Semgrep uses by setting the SEMGREP_RULES environment variable. 
-           SEMGREP_RULES: p/default # more at semgrep.dev/explore
+      - run: semgrep ci --code
 ```

--- a/src/components/code_snippets/_glcicd-semgrep-app-standalone-dash.mdx
+++ b/src/components/code_snippets/_glcicd-semgrep-app-standalone-dash.mdx
@@ -11,9 +11,6 @@ semgrep:
   - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 
   variables:
-    # Add the rules that Semgrep uses by setting the SEMGREP_RULES environment variable.
-    SEMGREP_RULES: p/default # See more at semgrep.dev/explore.
-
     # Upload findings to GitLab SAST Dashboard:
     SEMGREP_GITLAB_JSON: "1"
 
@@ -21,7 +18,7 @@ semgrep:
 
   # Run the "semgrep ci" command on the command line of the docker image and send findings
   # to GitLab SAST.
-  script: semgrep ci --gitlab-sast > gl-sast-report.json || true
+  script: semgrep ci --code --gitlab-sast > gl-sast-report.json || true
   artifacts:
     reports:
       sast: gl-sast-report.json

--- a/src/components/code_snippets/_glcicd-semgrep-app-standalone.mdx
+++ b/src/components/code_snippets/_glcicd-semgrep-app-standalone.mdx
@@ -3,7 +3,7 @@ semgrep:
   # A Docker image with Semgrep installed.
   image: returntocorp/semgrep
   # Run the "semgrep ci" command on the command line of the docker image.
-  script: semgrep ci
+  script: semgrep ci --code
 
   rules:
   # Scan changed files in MRs, (diff-aware scanning):
@@ -11,8 +11,4 @@ semgrep:
 
   # Scan mainline (default) branches and report all findings.
   - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-
-  variables:
-    # Add the rules that Semgrep uses by setting the SEMGREP_RULES environment variable.
-    SEMGREP_RULES: p/default # See more at semgrep.dev/explore.
 ```

--- a/src/components/code_snippets/_jenkins-semgrep-app-standalone.mdx
+++ b/src/components/code_snippets/_jenkins-semgrep-app-standalone.mdx
@@ -4,7 +4,6 @@ This code snippet uses Jenkins declarative syntax.
 pipeline {
   agent any
     environment {
-      SEMGREP_RULES = "p/default" 
       SEMGREP_BRANCH = "${GIT_BRANCH}"
 
       // Uncomment the following line to scan changed 
@@ -15,7 +14,7 @@ pipeline {
       stage('Semgrep-Scan') {
         steps {
           sh 'pip3 install semgrep'
-          sh 'semgrep ci'
+          sh 'semgrep ci --code'
       }
     }
   }


### PR DESCRIPTION
At the moment this change won't have any effect in the user-facing docs, since we removed these snippets from the CI configuration reference earlier, but this prepares us for adding them to the KB in the future.

The change is to remove reference to SEMGREP_RULES which is not compatible with `semgrep ci`, and instead execute with the `--code` argument, which was added in [1.40.0](https://github.com/returntocorp/semgrep/releases/tag/v1.40.0).

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR