### PR TITLE
Update --error flag description in exit codes section

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -92,8 +92,8 @@ export HTTPS_PROXY="http://10.10.1.10:1080"
 
 Semgrep can finish with the following exit codes:
 
-- **0**: Semgrep ran successfully and found no errors (or did find errors, but the `--error` flag is **not** set).
-- **1**: Semgrep ran successfully and found issues in your code (and the `--error` flag is set).
+- **0**: Semgrep ran successfully and found no errors (or did find errors, but the `--error` flag is **not** being used).
+- **1**: Semgrep ran successfully and found issues in your code (while using the `--error` flag).
 - **2**: Semgrep failed.
 - **3**: Invalid syntax of the scanned language. This error occurs only while using the `--strict` flag.
 - **4**: Semgrep encountered an invalid pattern in the rule schema.


### PR DESCRIPTION
This is mostly a nitpick, but the current language might have two interpretations:

1. The `--error` flag needs to be used
2. An `--error` flag is set when issues are detect

This is an attempt to make the language clear that the `--error` flag must be used for Semgrep to exhibit this behaviour.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [X] This change has no security implications or else you have pinged the security team
- [X] Redirects are added if the PR changes page URLs
- [X] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
