### PR TITLE
New KB article: Failed to run a git command during a pull or merge request scan

### DIFF
--- a/docs/kb/semgrep-ci/git-command-errors.md
+++ b/docs/kb/semgrep-ci/git-command-errors.md
@@ -8,7 +8,7 @@ import MoreHelp from "/src/components/MoreHelp"
 
 # Failed to run a git command during a pull or merge request scan
 
-When running Semgrep in CI with a pull or merge request as the triggering event, Semgrep runs some additional `git` commands in order to determine the behavior for the scan. The scan will exit with an error if these commands fail. A message like the following will show in the output:
+When running Semgrep in CI with a pull or merge request as the triggering event, Semgrep runs some additional `git` commands to determine the behavior for the scan. The scan exits with an error if these commands fail. A message like the following shows in the output:
 
 ```
 [ERROR] Command failed with exit code: 128
@@ -31,9 +31,9 @@ In addition to the potential reasons included in the message, there are two othe
 
 ## Clone depth is too shallow
 
-If a shallow git clone of the repository is used to fetch code, and the branch to be scanned has had many commits added since it was branched off the base branch, Semgrep may not be able to identify the base branch commit to compare the current pull or merge request branch with. In this case, the command that failed will usually look like:
+If a shallow git clone of the repository is used to fetch code, and the branch to be scanned has had many commits added since it was branched off the base branch, Semgrep may not be able to identify the base branch commit to compare the current pull or merge request branch with. In this case, the command that failed is typically:
 
-`git merge-base --all SHA FETCH_HEAD`
+<pre class="language-bash"><code>git merge-base --all <span className="placeholder">SHA</span> FETCH_HEAD</code></pre>
 
 Semgrep uses the merge-base command to compare the tip of the pull or merge request branch with the base branch and determine where it branched off, so that it can accurately scan for changes made in the merge request rather than in the base branch. 
 
@@ -43,15 +43,18 @@ To resolve this issue, increase the clone depth to a larger value. A value such 
 
 For GitLab CI, see [Limit the number of changes fetched during clone](https://docs.gitlab.com/ee/ci/pipelines/settings.html#limit-the-number-of-changes-fetched-during-clone) for instructions on configuring this value.
 
-## Commit or branch is not included in the checkout
+## Commit or branch not included in the checkout
 
-As with clone depth, which refs are checked out can vary with the environment. If the branch or ref to scan is not cloned or not checked out, the failed command will usually look like:
+As with clone depth, which refs are checked out can vary depending on the CI environment and configuration. If the branch or ref to scan or the related baseline ref is not cloned or not checked out, the command that failed is typically:
 
-`git cat-file -e REF`
+<pre class="language-bash"><code>git cat-file -e <span className="placeholder">REF</span></code></pre>
 
-with the message `Not a valid object name test-branch`. This is more common if you are using a standalone CI service, or if you have manually set `--baseline-commit` or `SEMGREP_BASELINE_REF` to a commit hash or branch name.
+with the message `Not a valid object name REF`. This is more common when:
 
-To resolve this issue, ensure that you have set the baseline ref to a valid ref, and that the ref is checked out in the CI environment.
+* You are using a standalone CI service, rather than one connected to your SCM.
+* You have manually set `--baseline-commit` or `SEMGREP_BASELINE_REF` to a commit hash or branch name.
+
+To resolve this issue, ensure that you have set the baseline ref to a valid ref, and that the ref to scan is checked out in the CI environment.
 
 <MoreHelp />
 

--- a/docs/kb/semgrep-ci/git-command-errors.md
+++ b/docs/kb/semgrep-ci/git-command-errors.md
@@ -43,6 +43,12 @@ To resolve this issue, increase the clone depth to a larger value. A value such 
 
 For GitLab CI, see [Limit the number of changes fetched during clone](https://docs.gitlab.com/ee/ci/pipelines/settings.html#limit-the-number-of-changes-fetched-during-clone) for instructions on configuring this value.
 
+### GitHub Actions clone behavior
+
+Semgrep has built-in behavior in GitHub Actions to fetch additional commits if the initial clone does not provide sufficient information, so GitHub Actions rarely encounter failures of the `git merge-base` command. 
+
+However, if Semgrep is showing findings in GitHub pull requests that were not introduced by the pull request, you can set the variable [`SEMGREP_GHA_MIN_FETCH_DEPTH`](https://semgrep.dev/docs/semgrep-ci/ci-environment-variables/#semgrep_gha_min_fetch_depth) to a higher value to improve the accuracy of the merge-base calculation. This value is the starting value used for fetching additional commits. The default is 0.
+
 ## Commit or branch not included in the checkout
 
 As with clone depth, which refs are checked out can vary depending on the CI environment and configuration. If the branch or ref to scan or the related baseline ref is not cloned or not checked out, the command that failed is typically:

--- a/docs/kb/semgrep-ci/git-command-errors.md
+++ b/docs/kb/semgrep-ci/git-command-errors.md
@@ -8,7 +8,7 @@ import MoreHelp from "/src/components/MoreHelp"
 
 # Failed to run a git command during a pull or merge request scan
 
-When running Semgrep in CI with a pull or merge request as the triggering event, Semgrep runs some `git` commands in order to determine the behavior for the scan. The scan will exit with an error if these commands fail. A message like the following will show in the output:
+When running Semgrep in CI with a pull or merge request as the triggering event, Semgrep runs some additional `git` commands in order to determine the behavior for the scan. The scan will exit with an error if these commands fail. A message like the following will show in the output:
 
 ```
 [ERROR] Command failed with exit code: 128
@@ -33,15 +33,23 @@ In addition to the potential reasons included in the message, there are two othe
 
 If a shallow git clone of the repository is used to fetch code, and the branch to be scanned has had many commits added since it was branched off the base branch, Semgrep may not be able to identify the base branch commit to compare the current pull or merge request branch with. In this case, the command that failed will usually look like:
 
-`git merge-base --all 606...57587 FETCH_HEAD`
+`git merge-base --all SHA FETCH_HEAD`
 
-Semgrep uses the merge-base command to compare the tip of the pull or merge request branch with the base branch and determine where it branched off, so that it can accurately scan for changes made in the merge request rather than in the base branch. If there isn't enough history for the base branch, this comparison can fail. This is most common if the git clone performed is shallow by default (as is the case in GitLab CI) or if the depth has been set via command line argument `--depth` or environment variable `GIT_DEPTH`.
+Semgrep uses the merge-base command to compare the tip of the pull or merge request branch with the base branch and determine where it branched off, so that it can accurately scan for changes made in the merge request rather than in the base branch. 
 
-To resolve this issue, increase the clone depth to a larger value. Typically, a value such as 20 or 50 is sufficient to capture the information needed for most merge-base calculations.
+If there isn't enough history to identify the branch point, this comparison can fail. This is most common if the git clone performed is shallow by default, or if the depth has been set to a small value via command line argument `--depth` or environment variable `GIT_DEPTH`.
+
+To resolve this issue, increase the clone depth to a larger value. A value such as 20 or 50 is sufficient to capture the information needed for most merge-base calculations.
+
+For GitLab CI, see [Limit the number of changes fetched during clone](https://docs.gitlab.com/ee/ci/pipelines/settings.html#limit-the-number-of-changes-fetched-during-clone) for instructions on configuring this value.
 
 ## Commit or branch is not included in the checkout
 
-As with clone depth, which refs are checked out can vary with the environment. Seeing a message such as `Not a valid object name test-branch` indicates that the branch is not present or is not properly checked out. This is more common if you are using a standalone CI service, or if you have manually set `--baseline-commit` or `SEMGREP_BASELINE_REF` to a commit hash or branch.
+As with clone depth, which refs are checked out can vary with the environment. If the branch or ref to scan is not cloned or not checked out, the failed command will usually look like:
+
+`git cat-file -e REF`
+
+with the message `Not a valid object name test-branch`. This is more common if you are using a standalone CI service, or if you have manually set `--baseline-commit` or `SEMGREP_BASELINE_REF` to a commit hash or branch name.
 
 To resolve this issue, ensure that you have set the baseline ref to a valid ref, and that the ref is checked out in the CI environment.
 

--- a/docs/kb/semgrep-ci/git-command-errors.md
+++ b/docs/kb/semgrep-ci/git-command-errors.md
@@ -1,0 +1,50 @@
+---
+tags:
+  - Git
+  - Semgrep in CI
+---
+
+import MoreHelp from "/src/components/MoreHelp"
+
+# Failed to run a git command during a pull or merge request scan
+
+When running Semgrep in CI with a pull or merge request as the triggering event, Semgrep runs some `git` commands in order to determine the behavior for the scan. The scan will exit with an error if these commands fail. A message like the following will show in the output:
+
+```
+[ERROR] Command failed with exit code: 128
+-----
+Command failed with output:
+fatal: Not a valid object name master
+
+
+Failed to run 'git <command-details>'. Possible reasons:
+
+- the git binary is not available
+- the current working directory is not a git repository
+- the current working directory is not marked as safe
+    (fix with `git config --global --add safe.directory $(pwd)`)
+
+Try running the command yourself to debug the issue.
+```
+
+In addition to the potential reasons included in the message, there are two other common reasons for git command failure:
+
+## Clone depth is too shallow
+
+If a shallow git clone of the repository is used to fetch code, and the branch to be scanned has had many commits added since it was branched off the base branch, Semgrep may not be able to identify the base branch commit to compare the current pull or merge request branch with. In this case, the command that failed will usually look like:
+
+`git merge-base --all 606...57587 FETCH_HEAD`
+
+Semgrep uses the merge-base command to compare the tip of the pull or merge request branch with the base branch and determine where it branched off, so that it can accurately scan for changes made in the merge request rather than in the base branch. If there isn't enough history for the base branch, this comparison can fail. This is most common if the git clone performed is shallow by default (as is the case in GitLab CI) or if the depth has been set via command line argument `--depth` or environment variable `GIT_DEPTH`.
+
+To resolve this issue, increase the clone depth to a larger value. Typically, a value such as 20 or 50 is sufficient to capture the information needed for most merge-base calculations.
+
+## Commit or branch is not included in the checkout
+
+As with clone depth, which refs are checked out can vary with the environment. Seeing a message such as `Not a valid object name test-branch` indicates that the branch is not present or is not properly checked out. This is more common if you are using a standalone CI service, or if you have manually set `--baseline-commit` or `SEMGREP_BASELINE_REF` to a commit hash or branch.
+
+To resolve this issue, ensure that you have set the baseline ref to a valid ref, and that the ref is checked out in the CI environment.
+
+<MoreHelp />
+
+


### PR DESCRIPTION
We get occasional reports of folks who see git commands failing during a Semgrep scan and aren't sure why. The current error suggests a few common fixes, but there are a couple that are a bit more complicated and for now are more suitable for a KB - hence this article.

(It's possible that after the osemgrep port is complete we can improve the errors in Semgrep directly.)

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
