### PR TITLE
Use latest version for docker image instead of `latest`

### DIFF
--- a/.github/workflows/update-help-command.yml
+++ b/.github/workflows/update-help-command.yml
@@ -32,16 +32,16 @@ jobs:
           echo '```' >> src/components/reference/_cli-help-scan-output.md
       - name: Commit changes, if any
         run: |
-            if $(git diff --quiet); then
-              echo "No changes made, exiting."
-            else
-              echo "Committing changes."
-              git config user.name github-actions
-              git config user.email github-actions@github.com
-              git add .
-              git commit -m "Updated help command output based on latest Semgrep release"
-              git push --set-upstream origin update_help_commands_$LATEST_VERSION
-              gh pr create --title "Update help command output for Semgrep $LATEST_VERSION" --body "This is an automatically generated PR"
-            fi
+          if $(git diff --quiet); then
+            echo "No changes made, exiting."
+          else
+            echo "Committing changes."
+            git config user.name github-actions
+            git config user.email github-actions@github.com
+            git add .
+            git commit -m "Updated help command output based on latest Semgrep release"
+            git push --set-upstream origin update_help_commands_$LATEST_VERSION
+            gh pr create --title "Update help command output for Semgrep $LATEST_VERSION" --body "This is an automatically generated PR"
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-help-command.yml
+++ b/.github/workflows/update-help-command.yml
@@ -9,6 +9,9 @@ jobs:
   update-output:
     name: Update `--help` and `--help scan` command output 
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       # Fetch project source with GitHub Actions Checkout.

--- a/.github/workflows/update-help-command.yml
+++ b/.github/workflows/update-help-command.yml
@@ -15,19 +15,19 @@ jobs:
       - uses: actions/checkout@v4
       - name: Checkout new branch named based on latest tag
         run: |
-          LATEST_TAG=$(gh release view -R returntocorp/semgrep --json tagName -q .tagName)
-          echo "LATEST_TAG=$(gh release view -R returntocorp/semgrep --json tagName -q .tagName)" >> $GITHUB_ENV
-          git checkout -b update_help_commands_$LATEST_TAG
+          LATEST_VERSION=$(gh release view -R returntocorp/semgrep --json tagName -q .tagName | sed 's/^v//g')
+          echo "LATEST_VERSION=$(gh release view -R returntocorp/semgrep --json tagName -q .tagName | sed 's/^v//g')" >> $GITHUB_ENV
+          git checkout -b update_help_commands_$LATEST_VERSION
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run `semgrep --help` and update reference file with output
         run: |
-          docker run --rm returntocorp/semgrep:latest semgrep --help | tee src/components/reference/_cli-help-output.md
+          docker run --rm returntocorp/semgrep:$LATEST_VERSION semgrep --help | tee src/components/reference/_cli-help-output.md
           sed -i '1i```' src/components/reference/_cli-help-output.md
           echo '```' >> src/components/reference/_cli-help-output.md
       - name: Run `semgrep scan --help` and update reference file with output
         run: |
-          docker run --rm returntocorp/semgrep:latest semgrep scan --help | tee src/components/reference/_cli-help-scan-output.md
+          docker run --rm returntocorp/semgrep:$LATEST_VERSION semgrep scan --help | tee src/components/reference/_cli-help-scan-output.md
           sed -i '1i```' src/components/reference/_cli-help-scan-output.md
           echo '```' >> src/components/reference/_cli-help-scan-output.md
       - name: Commit changes, if any
@@ -40,8 +40,8 @@ jobs:
               git config user.email github-actions@github.com
               git add .
               git commit -m "Updated help command output based on latest Semgrep release"
-              git push --set-upstream origin update_help_commands_$LATEST_TAG
-              gh pr create --title "Update help command output for Semgrep $LATEST_TAG" --body "This is an automatically generated PR"
+              git push --set-upstream origin update_help_commands_$LATEST_VERSION
+              gh pr create --title "Update help command output for Semgrep $LATEST_VERSION" --body "This is an automatically generated PR"
             fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Now that we are running the canary release, it makes more sense to just explicitly use the latest version of semgrep in the docker tag instead of `latest` which will always be 1 version behind.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
