### PR TITLE
fix all next links not working

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -197,7 +197,6 @@ module.exports = {
                 id: 'extensions/overview'
               },
               items: [
-                'extensions/overview',
                 'extensions/semgrep-vs-code'
               ]
             },
@@ -207,7 +206,6 @@ module.exports = {
             collapsible: true,
             link: {type: 'doc', id: 'writing-rules/overview'},
             items: [
-                'writing-rules/overview',
                 'writing-rules/pattern-examples',
                 'writing-rules/pattern-syntax',
                 'writing-rules/rule-ideas',
@@ -230,11 +228,6 @@ module.exports = {
                           label: 'Join mode',
                           link: {type: 'doc', id: 'writing-rules/experiments/join-mode/overview'},
                           items: [
-                              {
-                                  type: 'doc',
-                                  label: 'Overview',
-                                  id: 'writing-rules/experiments/join-mode/overview'
-                              },
                               'writing-rules/experiments/join-mode/recursive-joins'
                           ]
                       },
@@ -255,7 +248,6 @@ module.exports = {
             label: 'Data-flow analysis',
             link: {type: 'doc', id: 'writing-rules/data-flow/data-flow-overview'},
             items: [
-                'writing-rules/data-flow/data-flow-overview',
                 'writing-rules/data-flow/constant-propagation',
                 'writing-rules/data-flow/taint-mode',
                 'writing-rules/data-flow/status'
@@ -397,7 +389,6 @@ module.exports = {
           collapsible: true,
           link: {type: 'doc', id: 'semgrep-code/semgrep-pro-engine-intro'},
           items: [
-            'semgrep-code/semgrep-pro-engine-intro',
             'semgrep-code/semgrep-pro-engine-examples',
             'semgrep-code/semgrep-pro-engine-data-flow'
           ]
@@ -497,7 +488,10 @@ module.exports = {
               type: 'category',
               label: '2023',
               collapsible: true,
-              link: {type: 'doc', id: 'release-notes/latest'},
+                link: {
+                    type: 'generated-index',
+                    title: '2023 Release notes'
+                },
               items: [
                 'release-notes/september-2023',
                 'release-notes/august-2023',
@@ -514,7 +508,10 @@ module.exports = {
               type: 'category',
               label: '2022',
               collapsible: true,
-              link: {type: 'doc', id: 'release-notes/december-2022'},
+                link: {
+                    type: 'generated-index',
+                    title: '2022 Release notes'
+                },
               items: [
                 'release-notes/december-2022',
                 'release-notes/november-2022',
@@ -534,7 +531,10 @@ module.exports = {
                 type: 'category',
                 label: '2021',
                 collapsible: true,
-                link: {type: 'doc', id: 'release-notes/december-2021'},
+                link: {
+                    type: 'generated-index',
+                    title: '2021 Release notes'
+                },
                 items: [
                   'release-notes/december-2021',
                   'release-notes/november-2021',


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] Pablo-from-Infra approves

The following issue:
![Snag_ec231c](https://github.com/returntocorp/semgrep-docs/assets/20766840/92e83289-6bff-4e74-ac94-cfc2e39d6392)

arises when a higher-level category in the sidebar is a link to DocumentA, which is then re-referenced as the first item. Therefore:
```
Document A
└╴ Document A
```
It looks like this in sidebars.js:

![2023-10-21_03-40-08](https://github.com/returntocorp/semgrep-docs/assets/20766840/99e91077-e6e3-48c5-b3e1-eb88dbc2f300)

To correct this, we should not duplicate DocumentA as the first item. There are some examples of the correct behavior CURRENTLY - try clicking on Ticketing or Notifications in the [semgrep.dev/docs](https://github.com/returntocorp/semgrep-docs/pull/1235) and you'll see that the Next button correctly moves to the next document. 

The other correction is to use a generated index instead of a link to a document as the higher-level category. I applied that fix for the release notes fixes.






