### PR TITLE
Link directly to Maven instructions

### DIFF
--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -161,7 +161,7 @@ Semgrep Supply Chain parses **lockfiles** for dependencies, then scans your code
   </tr>
   <tr>
    <td>Maven</td>
-   <td>Maven-generated dependency tree (See <a href="/docs/semgrep-supply-chain/getting-started/#apache-maven-java">Setting up SSC scans for Apache Maven</a> for instructions.)</td>
+   <td>Maven-generated dependency tree (See <a href="/docs/semgrep-supply-chain/setup-maven/">Setting up SSC scans for Apache Maven</a> for instructions.)</td>
    <td style={{"text-align": "center"}}>GA</td>
    <td>✔️</td>
   </tr>


### PR DESCRIPTION
Probably we used to have this as part of a page but now it's its own page so let's link there
### Please ensure

- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
