### PR TITLE
We should not tell people to use --output

### DIFF
--- a/docs/kb/integrations/defect-dojo-integration.md
+++ b/docs/kb/integrations/defect-dojo-integration.md
@@ -15,7 +15,7 @@ Follow these steps to prepare DefectDojo and generate Semgrep findings in the pr
 1. In DefectDojo:
     1. Create your [**product**](https://defectdojo.github.io/django-DefectDojo/usage/models/#products).
     2. In that DefectDojo product, create an [engagement](https://defectdojo.github.io/django-DefectDojo/usage/models/#engagement), called `semgrep`. This is a CI/CD engagement type and the name designates the CI/CD tool used.
-2. Run a semgrep scan with flags `--json --output report.json` to generate a JSON report.
+2. Run semgrep as `semgrep ... --json > report.json` to generate a JSON report.
 
 Now, you are ready to use the [DefectDojo API](https://demo.defectdojo.org/api/v2/oa3/swagger-ui/).
 

--- a/docs/kb/semgrep-ci/github-upload-findings-in-security-dashboard.md
+++ b/docs/kb/semgrep-ci/github-upload-findings-in-security-dashboard.md
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - run: semgrep ci --sarif --output=semgrep.sarif
+      - run: semgrep ci --sarif > semgrep.sarif
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
 

--- a/docs/semgrep-ci/running-semgrep-ci-with-semgrep-cloud-platform.md
+++ b/docs/semgrep-ci/running-semgrep-ci-with-semgrep-cloud-platform.md
@@ -142,7 +142,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - run: semgrep scan --sarif --output=semgrep.sarif --config=policy
+      - run: semgrep scan --sarif --config=policy > semgrep.sarif
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
       - name: Upload SARIF file for GitHub Advanced Security Dashboard

--- a/docs/semgrep-ci/running-semgrep-ci-without-semgrep-cloud-platform.md
+++ b/docs/semgrep-ci/running-semgrep-ci-without-semgrep-cloud-platform.md
@@ -177,9 +177,9 @@ To save or export findings, pass file format options and send the formatted find
 
 For example, to save to a JSON file:
 
-`semgrep ci --json --output findings.json`
+`semgrep ci --json > findings.json`
 
-You can also use output redirection (`>`):
+You can also use the SARIF format:
 
 `semgrep ci --sarif > findings.sarif`
 

--- a/src/components/code_snippets/_gha-semgrep-app-sast-dash.mdx
+++ b/src/components/code_snippets/_gha-semgrep-app-sast-dash.mdx
@@ -33,7 +33,7 @@ jobs:
       # Fetch project source with GitHub Actions Checkout.
       - uses: actions/checkout@v3
       # Run the "semgrep ci" command on the command line of the docker image.
-      - run: semgrep ci --sarif --output=semgrep.sarif
+      - run: semgrep ci --sarif > semgrep.sarif
         env:
           # Connect to Semgrep Cloud Platform through your SEMGREP_APP_TOKEN.
           # Generate a token from Semgrep Cloud Platform > Settings

--- a/src/components/code_snippets/_gha-semgrep-app-standalone-dash.mdx
+++ b/src/components/code_snippets/_gha-semgrep-app-standalone-dash.mdx
@@ -33,7 +33,7 @@ jobs:
       # Fetch project source with GitHub Actions Checkout.
       - uses: actions/checkout@v3
       # Run the "semgrep ci" command on the command line of the docker image.
-      - run: semgrep ci --code --sarif --output=semgrep.sarif
+      - run: semgrep ci --code --sarif > semgrep.sarif
 
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         uses: github/codeql-action/upload-sarif@v2


### PR DESCRIPTION
The --output is a bit redundant with shell redirection
so we should not advise it. It was added a long time ago
and we're not even sure anymore if it's that useful.
People in theory can use it to post the result to an URL
but even that I'm not sure it's used. In any case
when a user just want to save the output to a file, he
can simply use shell redirection.

test plan:
wait for green CI checks


# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link