### PR TITLE
Triage by comment for GL is still in beta

### DIFF
--- a/docs/semgrep-code/triage-remediation.md
+++ b/docs/semgrep-code/triage-remediation.md
@@ -210,8 +210,9 @@ Triaging a finding as **Ignored** through a comment in GitHub changes the status
 <TabItem value='gl'>
 
 ### Prerequisites
-- A repository hosted by GitLab. Semgrep supports the use of both GitLab.com and GitLab self-managed plans.
+- A repository hosted by GitLab. Semgrep supports the use of both GitLab.com and GitLab self-managed plans. A Premium or Ultimate plan is required.
 - You have completed a [Semgrep core deployment](/deployment/core-deployment).
+- This feature is in beta. Please [reach out to support](/docs/support) to have it added for your organization.
 
 ### Enable triage through GitLab MR comments:
 


### PR DESCRIPTION
This feature is still in beta, so it requires the additional step indicated in order to work for an org.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
