### PR TITLE
Adjust CI/CD code snippets for OSS

### DIFF
--- a/src/components/code_snippets/_gha-semgrep-oss-sast.mdx
+++ b/src/components/code_snippets/_gha-semgrep-oss-sast.mdx
@@ -9,7 +9,7 @@ Semgrep CE in CI code snippet for GitHub Actions
 name: Semgrep CE scan
 
 on:
-  # Scan changed files in PRs (diff-aware scanning):
+  # Scan in PRs:
   pull_request: {}
   # Scan on-demand through GitHub Actions interface:
   workflow_dispatch: {}

--- a/src/components/code_snippets/_glcicd-semgrep-oss-sast.mdx
+++ b/src/components/code_snippets/_glcicd-semgrep-oss-sast.mdx
@@ -6,7 +6,7 @@ semgrep:
   script: semgrep scan --config auto .
 
   rules:
-  # Scan changed files in MRs, (diff-aware scanning):
+  # Scan in MRs.
   - if: $CI_MERGE_REQUEST_IID
 
   # Scan mainline (default) branches and report all findings.


### PR DESCRIPTION
When reading the CI/CD snippets in the docs regarding the OSS version, I noticed two things:
- The Gitlab CI/CD snippet refers to `semgrep ci --config auto`, which does not work like this. Changed it to `semgrep scan --config auto` similar to the other examples
- The pull/merge request comments mention that they would offer 'diff-based' scanning. However, diff-based scanning would require `semgrep ci` (which is a non-OSS feature), so with `semgrep scan` they would scan the full repository. Hence, I remove the mentions of diff-based scanning from the OSS snippets.

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
