### PR TITLE
Include pattern is permitted in semgrepignore

### DIFF
--- a/docs/ignoring-files-folders-code.md.template
+++ b/docs/ignoring-files-folders-code.md.template
@@ -89,7 +89,6 @@ Semgrep provides several methods to customize ignore behavior. Refer to the foll
 
 `.semgrepignore` syntax mirrors `.gitignore` syntax, with the following modifications:
 
-* "Include" patterns (lines starting with `!`) are unsupported.
 * "Character range" patterns (lines including a collection of characters inside brackets) are unsupported.
 * An `:include ...` directive is added, which allows another file to be included in the ignore pattern list; typically this included file would be the project `.gitignore`. No attempt at cycle detection is made.
 * Any line that begins with a colon, but not `:include`, raises an error.


### PR DESCRIPTION
See https://github.com/semgrep/semgrep/pull/6919 and https://github.com/semgrep/semgrep/blob/2600e5338d4499a25d9c1c7db5011b7c600006cf/src/targeting/Semgrepignore.ml#L17
