### PR TITLE
Update _gha-semgrep-app-sast-dash.mdx

### DIFF
--- a/src/components/code_snippets/_gha-semgrep-app-sast-dash.mdx
+++ b/src/components/code_snippets/_gha-semgrep-app-sast-dash.mdx
@@ -16,7 +16,11 @@ on:
     # It is recommended to change the schedule to a random time.
 
 permissions:
+  # This permission is required when uploading sarifs to any repository at GitHub
+  security-events: write
+  # These permissions are only required when uploading sarifs to private and internal repositories at GitHub
   contents: read
+  actions: read
 
 jobs:
   semgrep:
@@ -44,7 +48,7 @@ jobs:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
 
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: semgrep.sarif
         if: always()


### PR DESCRIPTION
Updates github/codeql-action/upload-sarif to the latest supported version and adds new permission requirements as per [official GitHub documentation](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github#example-workflow-for-sarif-files-generated-outside-of-a-repository)

This fixes deprecation notices and resource integration errors when attempting to run the example GitHub Actions workflow

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR