### PR TITLE
Add additional variables for Jenkins

### DIFF
--- a/docs/kb/semgrep-ci/bitbuket-jenkins-pipeline-projects.md
+++ b/docs/kb/semgrep-ci/bitbuket-jenkins-pipeline-projects.md
@@ -65,7 +65,11 @@ pipeline {
 
 :::note
 - Ensure that you have defined a `SEMGREP_APP_TOKEN` as a credential in Jenkins.
-- The variable SEMGREP_BASELINE_REF must be set to the main branch, in the example: `origin/master`.
+- The variable `SEMGREP_BASELINE_REF` must be set to the main branch, in the example: `origin/master`.
+- You may need to set additional variables, depending on your environment configuration, such as;
+    - `SEMGREP_REPO_NAME` -> An exact, case-sensitive match, to the repository name in Bitbucket
+    - `SEMGREP_REPO_URL` -> The web link to your repository (not the `.git` one)
+    - `SEMGREP_COMMIT` -> Specifically for PRs / diff scans, set this to the HEAD commit of the PR
 :::
 
 ## Test the new Jenkins pipeline project


### PR DESCRIPTION
As a result of the Linear [FS-2764](https://linear.app/semgrep/issue/FS-2764/bank-millennium-post-pov-bbdc-pr-comments-not-working-and-hyperlinks), we identified that customers using a Jenkins & Bitbucket combo meal may need to include these additional variables in their Jenkins Pipeline:

- `SEMGREP_REPO_NAME`
- `SEMGREP_REPO_URL`
- `SEMGREP_COMMIT`

Specifically the commit one, without this PR comments were failing for the customer, due to a [piece of logic](https://github.com/semgrep/semgrep-app/blob/372c1f2bbb172db4171e510a9c1a4a2dc12a38f5/server/semgrep_app/foundations/scm_comments/controllers/renderer.py#L132) we have in `renderer.py` that requires the `repo_name`, `pr_id` and `commit` to be able to post comments.

The definitions I've added (and the location of the addition) might need tweaking, definitely not a final version here.