### PR TITLE
Fixed callout box formatting in public docs

### DIFF
--- a/docs/writing-rules/autofix.md
+++ b/docs/writing-rules/autofix.md
@@ -12,9 +12,9 @@ Semgrep's rule format supports a `fix:` key that supports the replacement of met
 
 You can apply the autofix directly to the file using the `--autofix` flag. To test the autofix before applying it, use both the `--autofix` and `--dryrun` flags.
 
-```tip
+:::tip
 Rule-based autofix is deterministic and separate from the [Semgrep Assistant autofix feature](/semgrep-assistant/overview#autofix). The Assistant autofix feature uses AI to generate a suggested code fix.
-```
+:::
 
 ## Example autofix snippet
 


### PR DESCRIPTION
Callout box was previously formatted as a code block

### Please ensure
- [x] A technical writer reviews the content or PR

