### PR TITLE
Clarify ISO 27001 certification status

### DIFF
--- a/docs/compliance/iso27001.md
+++ b/docs/compliance/iso27001.md
@@ -29,5 +29,4 @@ Semgrep helps address multiple ISO 27001:2022 Annex A controls:
 
 ### Deployment and certification
 
-Semgrep Inc. is ISO 27001 certified. For CLI deployments, scans run on customer infrastructure. For on-premises CI/CD, scans run on customer-controlled infrastructure. Cloud CI/CD providers (GitHub, GitLab, Azure DevOps, Bitbucket) maintain ISO 27001 certification. For Semgrep Multimodal, the default provider (OpenAI) maintains ISO 27001 certification. For Semgrep Managed Scans, AWS infrastructure is ISO 27001 certified.
-
+Semgrep Inc. is **not** itself ISO 27001 certified, but the product can be used in deployment models that support an organization's ISO 27001 certification efforts. For CLI and customer-managed CI/CD deployments, scans run on customer-controlled infrastructure. For Semgrep Multimodal, the default provider (OpenAI) maintains ISO 27001 certification. For Semgrep Managed Scans (SMS), AWS infrastructure is ISO 27001 certified.


### PR DESCRIPTION
Clarify that Semgrep does not currently hold ISO 27001 and to avoid speculation about the certification status of CI/CD providers. Best that we speak directly to the services we use to deliver our own.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [N/A] Redirects are added if the PR changes page URLs
- [N/A] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link

