### PR TITLE
docs: add Codex tab to Semgrep Plugin page

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -32,6 +32,7 @@ This guide covers setup for Cursor, Windsurf, and Claude Code, but the plugin wo
     {label: 'Claude Code', value: 'claude'},
     {label: 'Cursor', value: 'cursor'},
     {label: 'Windsurf', value: 'windsurf'},
+    {label: 'Codex', value: 'codex'},
     {label: 'Other IDEs', value: 'other'},
     ]}
 >
@@ -106,12 +107,10 @@ This guide covers setup for Cursor, Windsurf, and Claude Code, but the plugin wo
 <TabItem value='windsurf'>
 
 1. Install Semgrep:
-     ```bash
+    ```bash
     # install through homebrew
     brew install semgrep
-    ```
 
-     ```bash
     # install through pip
     python3 -m pip install semgrep
     ```
@@ -143,6 +142,39 @@ This guide covers setup for Cursor, Windsurf, and Claude Code, but the plugin wo
     ```
 
 1. Restart Windsurf to apply hook configuration.
+
+</TabItem>
+
+<TabItem value='codex'>
+
+1. Install Semgrep:
+     ```bash
+    # install through homebrew
+    brew install semgrep
+    ```
+
+     ```bash
+    # install through pip
+    python3 -m pip install semgrep
+    ```
+
+2. Verify that you've installed the [latest version](https://github.com/semgrep/semgrep/releases) of Semgrep by running the following:
+    ```bash
+    semgrep --version
+    ```
+
+3. Sign in to your Semgrep account. Running this command launches a browser window, but you can also use the link that's returned in the CLI to proceed:
+    ```bash
+    semgrep login
+    ```
+    In the **Semgrep CLI login**, click **Activate** to proceed.
+
+4. Return to the CLI, and install the Semgrep Pro engine:
+    ```bash
+    semgrep install-semgrep-pro
+    ```
+
+5. Add the Semgrep MCP Server to your IDE. Semgrep provides [sample configuration information](https://github.com/semgrep/semgrep/tree/develop/cli/src/semgrep/mcp#integrations) that you can use as a starting point for your configuration. Refer to your IDE's documentation for specific details on where to add the MCP server configuration information.
 
 </TabItem>
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -174,7 +174,20 @@ This guide covers setup for Cursor, Windsurf, and Claude Code, but the plugin wo
     semgrep install-semgrep-pro
     ```
 
-5. Add the Semgrep MCP Server to your IDE. Semgrep provides [sample configuration information](https://github.com/semgrep/semgrep/tree/develop/cli/src/semgrep/mcp#integrations) that you can use as a starting point for your configuration. Refer to your IDE's documentation for specific details on where to add the MCP server configuration information.
+5. Add the following configuration to your Codex MCP settings:
+
+    ```json
+    {
+      "mcp": {
+        "servers": {
+          "semgrep": {
+            "command": "semgrep",
+            "args": ["mcp"]
+          }
+        }
+      }
+    }
+    ```
 
 </TabItem>
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -174,19 +174,12 @@ This guide covers setup for Claude Code, Cursor, Windsurf, and Codex but the plu
     semgrep install-semgrep-pro
     ```
 
-5. Add the following configuration to your Codex MCP settings:
+5. Update your `config.toml` file and paste the following:
 
-    ```json
-    {
-      "mcp": {
-        "servers": {
-          "semgrep": {
-            "command": "semgrep",
-            "args": ["mcp"]
-          }
-        }
-      }
-    }
+    ```toml
+    [mcp_servers.semgrep]
+    command = "semgrep"
+    args = ["mcp"]
     ```
 
 </TabItem>

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -14,9 +14,9 @@ import TabItem from '@theme/TabItem';
 
 # Semgrep Plugin
 
-Semgrep's plugin integrates natively with AI coding agents like Cursor, Claude Code, and Windsurf to catch security issues before they ship. It bundles the Semgrep MCP server, Hooks, and Skills into a single install, and scans every file an agent generates using Semgrep Code, Supply Chain, and Secrets. When findings are detected, the agent is prompted to regenerate code until Semgrep returns clean results or you choose to dismiss them.
+Semgrep's plugin integrates natively with AI coding agents like Claude Code and Cursor to catch security issues before they ship. It bundles the Semgrep MCP server, Hooks, and Skills into a single install, and scans every file an agent generates using Semgrep Code, Supply Chain, and Secrets. When findings are detected, the agent is prompted to regenerate code until Semgrep returns clean results or you choose to dismiss them.
 
-This guide covers setup for Cursor, Windsurf, and Claude Code, but the plugin works with any MCP client.
+This guide covers setup for Claude Code, Cursor, Windsurf, and Codex but the plugin works with any MCP client.
 
 ## Prerequisites
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -174,7 +174,7 @@ This guide covers setup for Claude Code, Cursor, Windsurf, and Codex but the plu
     semgrep install-semgrep-pro
     ```
 
-5. Update your `config.toml` file and paste the following:
+5. Update your `~/.codex/config.toml` file and paste the following:
 
     ```toml
     [mcp_servers.semgrep]


### PR DESCRIPTION
## Summary

- Adds a **Codex** tab to the Semgrep Plugin (`docs/mcp.md`) installation section, positioned after Windsurf
- Codex tab uses the same generic MCP setup instructions as "Other IDEs"
- Also includes upstream changes from `main`: Claude Code tab reordered to first position, updated Claude Code install steps using the plugin marketplace UI (`/plugin` → Discover → Install → `/setup-semgrep-plugin`)

## Test plan

- [ ] Verify Codex tab renders correctly in the docs site
- [ ] Confirm tab order is: Claude Code, Cursor, Windsurf, Codex, Other IDEs
- [ ] Confirm Codex tab content matches Other IDEs instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)