### PR TITLE
GROW-920: Update AI scan credit copy

### DIFF
--- a/docs/usage-and-billing/overview.md
+++ b/docs/usage-and-billing/overview.md
@@ -75,9 +75,11 @@ The following table lists the credits required for AI-powered features:
 | AI-powered pull request or merge request comments | 0 credits |
 | AI analysis<sup>*</sup> | 1 credit per finding |
 | AI autofix | 20 credits per finding |
-| AI-powered detection scanning | 30 credits per scan |
+| AI-powered detection scanning | Variable per scan |
 
 <sup>*</sup>Includes autotriage, remediation guidance, and component tagging
+
+AI-powered detection scans use a variable number of credits per scan. Credit use depends on scan size and complexity, so larger or more complex scans may use more credits.
 
 ## How to determine your plan needs
 

--- a/docs/usage-and-billing/overview.md
+++ b/docs/usage-and-billing/overview.md
@@ -75,11 +75,11 @@ The following table lists the credits required for AI-powered features:
 | AI-powered pull request or merge request comments | 0 credits |
 | AI analysis<sup>*</sup> | 1 credit per finding |
 | AI autofix | 20 credits per finding |
-| AI-powered detection scanning | Variable per scan |
+| AI-powered detection scanning<sup>**</sup> | Variable per scan |
 
 <sup>*</sup>Includes autotriage, remediation guidance, and component tagging
 
-AI-powered detection scans use a variable number of credits per scan. Credit use depends on scan size and complexity, so larger or more complex scans may use more credits.
+<sup>**</sup>AI-powered detection scans use a variable number of credits per scan. Credit use depends on scan size and complexity, so larger or more complex scans may use more credits.
 
 ## How to determine your plan needs
 


### PR DESCRIPTION
## Summary
- Replace the fixed 30-credit AI-powered detection scan cost with variable-per-scan copy.
- Add a short explanation that scan credit use depends on scan size and complexity.

## Validation
- `npm run build` completed successfully.
- Build emitted existing Docusaurus warnings about duplicate routes, broken anchors, and SVG image-size parsing unrelated to this billing copy change.