### PR TITLE
ci: use semgrep-autoapprover app token instead of default GITHUB_TOKEN [SEC-2024]

### DIFF
--- a/.github/workflows/update-help-command.yml
+++ b/.github/workflows/update-help-command.yml
@@ -15,15 +15,23 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Authenticate as semgrep-autoapprover
+        id: generate-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        with:
+          app-id: ${{ secrets.SEMGREP_AUTOAPPROVER_APP_ID }}
+          private-key: ${{ secrets.SEMGREP_AUTOAPPROVER_PRIVATE_KEY }}
       # Fetch project source with GitHub Actions Checkout.
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
       - name: Checkout new branch named based on latest tag
         run: |
           LATEST_VERSION=$(gh release view -R semgrep/semgrep --json tagName -q .tagName | sed 's/^v//g')
           echo "LATEST_VERSION=$(gh release view -R semgrep/semgrep --json tagName -q .tagName | sed 's/^v//g')" >> $GITHUB_ENV
           git checkout -b update_help_commands_$LATEST_VERSION
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: Run `semgrep --help` and update reference file with output
         run: |
           docker run --rm semgrep/semgrep:$LATEST_VERSION semgrep --help | tee src/components/reference/_cli-help-output.md
@@ -53,4 +61,4 @@ jobs:
             gh pr create --title "Update help command output for Semgrep $LATEST_VERSION" --body "This is an automatically generated PR"
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## Problem

The default `secrets.GITHUB_TOKEN` runs as `github-actions[bot]`, which can't bypass ruleset checks like "Require Signed Commits".

## Solution

Mint a token from `semgrep-autoapprover` via `actions/create-github-app-token` and use it in place of `secrets.GITHUB_TOKEN` in `.github/workflows/update-help-command.yml`. The token is passed to `actions/checkout` so the subsequent `git push` uses the app identity, and to the `GITHUB_TOKEN` env on the steps that call `gh`.

Linear: [SEC-2024](https://linear.app/semgrep/issue/SEC-2024/semgrep-docs-replace-github-actionsbot-with-semgrep)