### PR TITLE
To URL, not from URL

### DIFF
--- a/docs/semgrep-ci/network-broker.md
+++ b/docs/semgrep-ci/network-broker.md
@@ -352,7 +352,7 @@ The Semgrep Network Broker supports repository cloning with GitHub when `allowCo
 ```yaml
 inbound:
   allowlist:
-    # allow GET requests from https://git.example.com/*
+    # allow GET requests from Semgrep to https://git.example.com/*
     - url: https://git.example.com/*
       methods: [GET, POST]
 ```


### PR DESCRIPTION
Allowlisting gives Semgrep access to make requests _to_ the allowlisted URL patterns, not from.

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR