### PR TITLE
Fix help workflow no color

### DIFF
--- a/.github/workflows/update-help-command.yml
+++ b/.github/workflows/update-help-command.yml
@@ -34,17 +34,17 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: Run `semgrep --help` and update reference file with output
         run: |
-          docker run --rm -e TERM=dumb semgrep/semgrep:$LATEST_VERSION semgrep --help | tee src/components/reference/_cli-help-output.md
+          docker run --rm semgrep/semgrep:$LATEST_VERSION semgrep --help | sed -r 's/\x1B\[[0-9;]*[a-zA-Z]//g' | tee src/components/reference/_cli-help-output.md
           sed -i '1i```' src/components/reference/_cli-help-output.md
           echo '```' >> src/components/reference/_cli-help-output.md
       - name: Run `semgrep scan --help` and update reference file with output
         run: |
-          docker run --rm -e TERM=dumb semgrep/semgrep:$LATEST_VERSION semgrep scan --help | tee src/components/reference/_cli-help-scan-output.md
+          docker run --rm semgrep/semgrep:$LATEST_VERSION semgrep scan --help | sed -r 's/\x1B\[[0-9;]*[a-zA-Z]//g' | tee src/components/reference/_cli-help-scan-output.md
           sed -i '1i```' src/components/reference/_cli-help-scan-output.md
           echo '```' >> src/components/reference/_cli-help-scan-output.md
       - name: Run `semgrep ci --help` and update reference file with output
         run: |
-          docker run --rm -e TERM=dumb semgrep/semgrep:$LATEST_VERSION semgrep ci --help | tee src/components/reference/_cli-help-ci-output.md
+          docker run --rm semgrep/semgrep:$LATEST_VERSION semgrep ci --help | sed -r 's/\x1B\[[0-9;]*[a-zA-Z]//g' | tee src/components/reference/_cli-help-ci-output.md
           sed -i '1i```' src/components/reference/_cli-help-ci-output.md
           echo '```' >> src/components/reference/_cli-help-ci-output.md
       - name: Commit changes, if any

--- a/.github/workflows/update-help-command.yml
+++ b/.github/workflows/update-help-command.yml
@@ -34,17 +34,17 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: Run `semgrep --help` and update reference file with output
         run: |
-          docker run --rm -e NO_COLOR=1 semgrep/semgrep:$LATEST_VERSION semgrep --help | tee src/components/reference/_cli-help-output.md
+          docker run --rm -e TERM=dumb semgrep/semgrep:$LATEST_VERSION semgrep --help | tee src/components/reference/_cli-help-output.md
           sed -i '1i```' src/components/reference/_cli-help-output.md
           echo '```' >> src/components/reference/_cli-help-output.md
       - name: Run `semgrep scan --help` and update reference file with output
         run: |
-          docker run --rm -e NO_COLOR=1 semgrep/semgrep:$LATEST_VERSION semgrep scan --help | tee src/components/reference/_cli-help-scan-output.md
+          docker run --rm -e TERM=dumb semgrep/semgrep:$LATEST_VERSION semgrep scan --help | tee src/components/reference/_cli-help-scan-output.md
           sed -i '1i```' src/components/reference/_cli-help-scan-output.md
           echo '```' >> src/components/reference/_cli-help-scan-output.md
       - name: Run `semgrep ci --help` and update reference file with output
         run: |
-          docker run --rm -e NO_COLOR=1 semgrep/semgrep:$LATEST_VERSION semgrep ci --help | tee src/components/reference/_cli-help-ci-output.md
+          docker run --rm -e TERM=dumb semgrep/semgrep:$LATEST_VERSION semgrep ci --help | tee src/components/reference/_cli-help-ci-output.md
           sed -i '1i```' src/components/reference/_cli-help-ci-output.md
           echo '```' >> src/components/reference/_cli-help-ci-output.md
       - name: Commit changes, if any

--- a/.github/workflows/update-help-command.yml
+++ b/.github/workflows/update-help-command.yml
@@ -34,17 +34,17 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: Run `semgrep --help` and update reference file with output
         run: |
-          docker run --rm semgrep/semgrep:$LATEST_VERSION semgrep --help | tee src/components/reference/_cli-help-output.md
+          docker run --rm -e NO_COLOR=1 semgrep/semgrep:$LATEST_VERSION semgrep --help | tee src/components/reference/_cli-help-output.md
           sed -i '1i```' src/components/reference/_cli-help-output.md
           echo '```' >> src/components/reference/_cli-help-output.md
       - name: Run `semgrep scan --help` and update reference file with output
         run: |
-          docker run --rm semgrep/semgrep:$LATEST_VERSION semgrep scan --help | tee src/components/reference/_cli-help-scan-output.md
+          docker run --rm -e NO_COLOR=1 semgrep/semgrep:$LATEST_VERSION semgrep scan --help | tee src/components/reference/_cli-help-scan-output.md
           sed -i '1i```' src/components/reference/_cli-help-scan-output.md
           echo '```' >> src/components/reference/_cli-help-scan-output.md
       - name: Run `semgrep ci --help` and update reference file with output
         run: |
-          docker run --rm semgrep/semgrep:$LATEST_VERSION semgrep ci --help | tee src/components/reference/_cli-help-ci-output.md
+          docker run --rm -e NO_COLOR=1 semgrep/semgrep:$LATEST_VERSION semgrep ci --help | tee src/components/reference/_cli-help-ci-output.md
           sed -i '1i```' src/components/reference/_cli-help-ci-output.md
           echo '```' >> src/components/reference/_cli-help-ci-output.md
       - name: Commit changes, if any


### PR DESCRIPTION
While checking the output of https://github.com/semgrep/semgrep-docs/pull/2591, Claude noticed an unrelated issue where a newer version of Semgrep emits ANSI color escape codes, which produced the extra characters seen in [this diff
](https://github.com/semgrep/semgrep-docs/pull/2583/changes/97155bf2d99d1aac100924246b870f6ea239d32f)

Neither `NO_COLOR=1` or `TERM=dumb` worked, so Claude went with this character stripping approach