### PR TITLE
ci: use peter-evans/create-pull-request in update-help-command workflow

### DIFF
--- a/.github/workflows/update-help-command.yml
+++ b/.github/workflows/update-help-command.yml
@@ -52,7 +52,7 @@ jobs:
           echo '```' >> src/components/reference/_cli-help-ci-output.md
 
       - name: Create pull request
-        uses: step-security/create-pull-request@e604d57b37b404d8bb34d152fa905e45d003a895 # v8.1.0
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.generate-token.outputs.token }}
           branch: update_help_commands_${{ env.LATEST_VERSION }}

--- a/.github/workflows/update-help-command.yml
+++ b/.github/workflows/update-help-command.yml
@@ -21,44 +21,42 @@ jobs:
         with:
           app-id: ${{ vars.SEMGREP_DOCS_RELEASE_APP_ID }}
           private-key: ${{ secrets.SEMGREP_DOCS_RELEASE_PRIVATE_KEY }}
-      # Fetch project source with GitHub Actions Checkout.
-      - uses: actions/checkout@v4
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ steps.generate-token.outputs.token }}
-      - name: Checkout new branch named based on latest tag
+
+      - name: Resolve latest Semgrep release tag
         run: |
           LATEST_VERSION=$(gh release view -R semgrep/semgrep --json tagName -q .tagName | sed 's/^v//g')
-          echo "LATEST_VERSION=$(gh release view -R semgrep/semgrep --json tagName -q .tagName | sed 's/^v//g')" >> $GITHUB_ENV
-          git checkout -b update_help_commands_$LATEST_VERSION
+          echo "LATEST_VERSION=$LATEST_VERSION" >> $GITHUB_ENV
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+
       - name: Run `semgrep --help` and update reference file with output
         run: |
           docker run --rm semgrep/semgrep:$LATEST_VERSION semgrep --help | sed -r 's/\x1B\[[0-9;]*[a-zA-Z]//g' | tee src/components/reference/_cli-help-output.md
           sed -i '1i```' src/components/reference/_cli-help-output.md
           echo '```' >> src/components/reference/_cli-help-output.md
+
       - name: Run `semgrep scan --help` and update reference file with output
         run: |
           docker run --rm semgrep/semgrep:$LATEST_VERSION semgrep scan --help | sed -r 's/\x1B\[[0-9;]*[a-zA-Z]//g' | tee src/components/reference/_cli-help-scan-output.md
           sed -i '1i```' src/components/reference/_cli-help-scan-output.md
           echo '```' >> src/components/reference/_cli-help-scan-output.md
+
       - name: Run `semgrep ci --help` and update reference file with output
         run: |
           docker run --rm semgrep/semgrep:$LATEST_VERSION semgrep ci --help | sed -r 's/\x1B\[[0-9;]*[a-zA-Z]//g' | tee src/components/reference/_cli-help-ci-output.md
           sed -i '1i```' src/components/reference/_cli-help-ci-output.md
           echo '```' >> src/components/reference/_cli-help-ci-output.md
-      - name: Commit changes, if any
-        run: |
-          if $(git diff --quiet); then
-            echo "No changes made, exiting."
-          else
-            echo "Committing changes."
-            git config user.name github-actions
-            git config user.email github-actions@github.com
-            git add .
-            git commit -m "Updated help command output based on latest Semgrep release"
-            git push --set-upstream origin update_help_commands_$LATEST_VERSION
-            gh pr create --title "Update help command output for Semgrep $LATEST_VERSION" --body "This is an automatically generated PR"
-          fi
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+
+      - name: Create pull request
+        uses: step-security/create-pull-request@e604d57b37b404d8bb34d152fa905e45d003a895 # v8.1.0
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          branch: update_help_commands_${{ env.LATEST_VERSION }}
+          commit-message: Updated help command output based on latest Semgrep release
+          title: Update help command output for Semgrep ${{ env.LATEST_VERSION }}
+          body: This is an automatically generated PR
+          delete-branch: true


### PR DESCRIPTION
## Summary

- Replace the manual `git checkout -b` / `git config` / `git commit` / `git push` / `gh pr create` block in `.github/workflows/update-help-command.yml` with a single `peter-evans/create-pull-request` step that handles branch creation, staging, commit, push, and PR open-or-update.
- Pin `actions/checkout` and `peter-evans/create-pull-request` to commit SHAs per the supply-chain policy.

## Test plan

- [x] Trigger the workflow via `workflow_dispatch` and confirm it opens (or updates) a PR titled `Update help command output for Semgrep <version>` with the expected file changes.
- [x] Re-run with no upstream changes and confirm the action exits cleanly (no PR / no-op) instead of failing.