### PR TITLE
Update lockfileless docs for SMS Gradle/Maven public beta

### DIFF
--- a/docs/semgrep-supply-chain/feature-support.md
+++ b/docs/semgrep-supply-chain/feature-support.md
@@ -22,11 +22,11 @@ For some languages, a lockfile or manifest file is parsed to determine %%transit
 
 Additionally, Semgrep offers beta support for the scanning of projects written in the following languages **without lockfiles**:
 
-- C#
+- C# (CI only)
 - Java
 - Kotlin
-- Python
-- Ruby
+- Python (CI only)
+- Ruby (CI only)
 
 ## Supply Chain features for each language
 <!-- *************************************************************************

--- a/docs/semgrep-supply-chain/feature-support.md
+++ b/docs/semgrep-supply-chain/feature-support.md
@@ -22,11 +22,11 @@ For some languages, a lockfile or manifest file is parsed to determine %%transit
 
 Additionally, Semgrep offers beta support for the scanning of projects written in the following languages **without lockfiles**:
 
-- C# (CI only)
+- C# (CI and CLI only)
 - Java
 - Kotlin
-- Python (CI only)
-- Ruby (CI only)
+- Python (CI and CLI only)
+- Ruby (CI and CLI only)
 
 ## Supply Chain features for each language
 <!-- *************************************************************************

--- a/docs/semgrep-supply-chain/getting-started.md
+++ b/docs/semgrep-supply-chain/getting-started.md
@@ -100,7 +100,7 @@ Semgrep Supply Chain can use **Dynamic Dependency Resolution** to scan projects 
 
 ### CLI Scans, including self-managed CI systems
 1. Ensure that the environment where you run Semgrep scans has installed all of the dependencies required to build your project, such as Java and Maven or Python and pip.
-2. Initiate a Semgrep scan, ensuring that you include the `--allow-local-builds` flag:
+2. Initiate a Semgrep scan, ensuring that you include the `--allow-local-builds` flag to enable Semgrep to invoke package managers on the system:
     ```console
     semgrep ci --allow-local-builds
     ```

--- a/docs/semgrep-supply-chain/getting-started.md
+++ b/docs/semgrep-supply-chain/getting-started.md
@@ -91,14 +91,14 @@ You can configure your CI/CD system to trigger a Semgrep Supply Chain scan whene
 This feature is currently in beta. Please contact [Semgrep Support](/support) for more information.
 :::
 
-Semgrep Supply Chain can use **Dynamic Dependency Resolution** scan projects without the need for lockfiles. This simplifies the configuration of Supply Chain scans. This feature is available in both CLI scans and Semgrep Managed Scans for the following languages:
+Semgrep Supply Chain can use **Dynamic Dependency Resolution** to scan projects without requiring lockfiles. This simplifies the configuration of Supply Chain scans. This feature is available for the following languages:
 
 - C# (CLI scans only)
 - Java projects built using Maven or Gradle (Gradle Wrapper required)
 - Kotlin projects built using Maven or Gradle (Gradle Wrapper required)
 - Python (CLI scans only)
 
-### CLI Scans (including self-managed CI)
+### CLI Scans, including self-managed CI systems
 1. Ensure that the environment where you run Semgrep scans has installed all of the dependencies required to build your project, such as Java and Maven or Python and pip.
 2. Initiate a Semgrep scan, ensuring that you include the `--allow-local-builds` flag:
     ```console
@@ -109,7 +109,7 @@ Semgrep Supply Chain can use **Dynamic Dependency Resolution** scan projects wit
 
 ### Semgrep Managed Scans
 1. [Configure private
-   registry credentials](https://semgrep.dev/docs/semgrep-supply-chain/triage-and-remediation#connect-a-private-registry-to-semgrep) in **Settings > Integrations**. Note that only Maven registries are currently supported for Managed Scans.
+   registry credentials](/semgrep-supply-chain/triage-and-remediation#connect-a-private-registry-to-semgrep) in **Settings > Integrations**. Note that only Maven registries are currently supported for Managed Scans.
 2. Contact [Semgrep Support](/support) to enable Dynamic Dependency resolution
    for the necessary repositories.
 

--- a/docs/semgrep-supply-chain/getting-started.md
+++ b/docs/semgrep-supply-chain/getting-started.md
@@ -88,16 +88,17 @@ You can configure your CI/CD system to trigger a Semgrep Supply Chain scan whene
 ## Scan a project without lockfiles (beta)
 
 :::info
-This feature is currently in invite-only beta. Please contact [Semgrep Support](/support) for more information.
+This feature is currently in beta. Please contact [Semgrep Support](/support) for more information.
 :::
 
-Semgrep Supply Chain can scan projects without the need for lockfiles. This simplifies the configuration of Supply Chain scans. This feature is available for the following languages:
+Semgrep Supply Chain can use **Dynamic Dependency Resolution** scan projects without the need for lockfiles. This simplifies the configuration of Supply Chain scans. This feature is available in both CLI scans and Semgrep Managed Scans for the following languages:
 
-- C#
-- Java projects built using Maven or Gradle Wrapper
-- Kotlin
-- Python
+- C# (CLI scans only)
+- Java projects built using Maven or Gradle (Gradle Wrapper required)
+- Kotlin projects built using Maven or Gradle (Gradle Wrapper required)
+- Python (CLI scans only)
 
+### CLI Scans (including self-managed CI)
 1. Ensure that the environment where you run Semgrep scans has installed all of the dependencies required to build your project, such as Java and Maven or Python and pip.
 2. Initiate a Semgrep scan, ensuring that you include the `--allow-local-builds` flag:
     ```console
@@ -106,13 +107,12 @@ Semgrep Supply Chain can scan projects without the need for lockfiles. This simp
     For existing CI jobs, you may have to edit your configuration file to include this flag.
     Semgrep builds the project, using the build information included in the `pom.xml` or `build.gradle` file to determine the set of dependencies used by the project. 
 
-:::info
-- Semgrep Managed Scans can't determine the dependencies in a project when there is no manifest file or lockfile, so Supply Chain scans don't return any findings.
-- By default, Semgrep doesn't surface errors generated during a scan. To view errors in the CLI output, include the `--verbose` when initiating your scan:
-    ```console
-    semgrep ci --allow-local-builds --verbose
-    ```
-:::
+### Semgrep Managed Scans
+1. [Configure private
+   registry credentials](https://semgrep.dev/docs/semgrep-supply-chain/triage-and-remediation#connect-a-private-registry-to-semgrep) in **Settings > Integrations**. Note that only Maven registries are currently supported for Managed Scans.
+2. Contact [Semgrep Support](/support) to enable Dynamic Dependency resolution
+   for the necessary repositories.
+
 ## Run a scan using the CLI
 
 You can start a stand-alone Semgrep Supply Chain scan by running the following command in the CLI:

--- a/docs/semgrep-supply-chain/package-manager-support.md
+++ b/docs/semgrep-supply-chain/package-manager-support.md
@@ -43,7 +43,7 @@ The following table lists all Semgrep-supported package managers for each langua
    <td rowspan="2">Java</td>
    <td>Gradle</td>
    <td><code>gradle.lockfile</code> or with only <code>build.gradle</code> or
-   <code>build.gradle.kts</code> via <a
+   <code>build.gradle.kts</code> through <a
    href="/docs/semgrep-supply-chain/getting-started#scan-a-project-without-lockfiles-beta">Dynamic
    Dependency Resolution</a>.</td>
   </tr>

--- a/docs/semgrep-supply-chain/package-manager-support.md
+++ b/docs/semgrep-supply-chain/package-manager-support.md
@@ -44,13 +44,13 @@ The following table lists all Semgrep-supported package managers for each langua
    <td>Gradle</td>
    <td><code>gradle.lockfile</code> or with only <code>build.gradle</code> or
    <code>build.gradle.kts</code> via <a
-   href="docs/semgrep-supply-chain/getting-started#scan-a-project-without-lockfiles-beta">Dynamic
+   href="/docs/semgrep-supply-chain/getting-started#scan-a-project-without-lockfiles-beta">Dynamic
    Dependency Resolution</a>.</td>
   </tr>
   <tr>
    <td>Maven</td>
    <td>Maven-generated dependency tree (See <a href="/docs/semgrep-supply-chain/setup-maven/">Setting up SSC scans for Apache Maven</a> for instructions.), or with only <code>pom.xml</code> via <a
-   href="docs/semgrep-supply-chain/getting-started#scan-a-project-without-lockfiles-beta">Dynamic
+   href="/docs/semgrep-supply-chain/getting-started#scan-a-project-without-lockfiles-beta">Dynamic
    Dependency Resolution</a>.</td>
   </tr>
   <tr>

--- a/docs/semgrep-supply-chain/package-manager-support.md
+++ b/docs/semgrep-supply-chain/package-manager-support.md
@@ -42,11 +42,16 @@ The following table lists all Semgrep-supported package managers for each langua
 <tr rowspan="2">
    <td rowspan="2">Java</td>
    <td>Gradle</td>
-   <td><code>gradle.lockfile</code></td>
+   <td><code>gradle.lockfile</code> or with only <code>build.gradle</code> or
+   <code>build.gradle.kts</code> via <a
+   href="docs/semgrep-supply-chain/getting-started#scan-a-project-without-lockfiles-beta">Dynamic
+   Dependency Resolution</a>.</td>
   </tr>
   <tr>
    <td>Maven</td>
-   <td>Maven-generated dependency tree (See <a href="/docs/semgrep-supply-chain/setup-maven/">Setting up SSC scans for Apache Maven</a> for instructions.)</td>
+   <td>Maven-generated dependency tree (See <a href="/docs/semgrep-supply-chain/setup-maven/">Setting up SSC scans for Apache Maven</a> for instructions.), or with only <code>pom.xml</code> via <a
+   href="docs/semgrep-supply-chain/getting-started#scan-a-project-without-lockfiles-beta">Dynamic
+   Dependency Resolution</a>.</td>
   </tr>
   <tr>
    <td rowspan="3">JavaScript or TypeScript</td>

--- a/docs/semgrep-supply-chain/package-manager-support.md
+++ b/docs/semgrep-supply-chain/package-manager-support.md
@@ -49,7 +49,7 @@ The following table lists all Semgrep-supported package managers for each langua
   </tr>
   <tr>
    <td>Maven</td>
-   <td>Maven-generated dependency tree (See <a href="/docs/semgrep-supply-chain/setup-maven/">Setting up SSC scans for Apache Maven</a> for instructions.), or with only <code>pom.xml</code> via <a
+   <td>Maven-generated dependency tree (See <a href="/docs/semgrep-supply-chain/setup-maven/">Setting up SSC scans for Apache Maven</a> for instructions.), or with only <code>pom.xml</code> through <a
    href="/docs/semgrep-supply-chain/getting-started#scan-a-project-without-lockfiles-beta">Dynamic
    Dependency Resolution</a>.</td>
   </tr>


### PR DESCRIPTION
SMS Lockfileless is entering public beta for Gradle and Maven. This updates the relevant portions of the docs.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link

---

<details>
<summary>Adding a new documentation page? Click to expand the checklist </summary>

- [ ] Create `.md` or `.mdx` file in `/docs/[section]/` with frontmatter: `slug`, `title`, `description`, `displayed_sidebar`, `tags`
- [ ] Add page to appropriate sidebar in `/sidebars.js` (shows in side nav)
- [ ] **If adding the doc in a new directory:** Update `/src/theme/Navbar/Content/index.tsx` → add path to `getCurrentSection()` (highlights top nav)

Sidebars fields for `displayed_sidebar`:
`scanSidebar` | `rulewritingSidebar` | `devSidebar` | `learnSidebar` | `aboutSidebar` | `kbSidebar` | `whatsSemgrepSidebar`

Top nav fields for `getCurrentSection()`:
`'scan'` | `'write-rules'` | `'learning-guides'` | `'help'` | `'explore'`

</details>
