### PR TITLE
Lockfileless does surface some errors by default

### DIFF
--- a/docs/semgrep-supply-chain/getting-started.md
+++ b/docs/semgrep-supply-chain/getting-started.md
@@ -108,7 +108,7 @@ Semgrep Supply Chain can scan projects without the need for lockfiles. This simp
 
 :::info
 - Semgrep Managed Scans can't determine the dependencies in a project when there is no manifest file or lockfile, so Supply Chain scans don't return any findings.
-- By default, Semgrep doesn't surface errors generated during a scan. To view errors in the CLI output, include the `--verbose` when initiating your scan:
+- By default, Semgrep doesn't surface all errors generated during a scan. To view more detailed errors in the CLI output, include the `--verbose` when initiating your scan:
     ```console
     semgrep ci --allow-local-builds --verbose
     ```


### PR DESCRIPTION
Lockfileless scanning actually does surface certain errors at info level logging, so I modified the wording to explain that more detail is available at verbose.

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
