### PR TITLE
chore: call out the number of uploads per day limitation for Wiz integration

### DIFF
--- a/docs/semgrep-appsec-platform/wiz.md
+++ b/docs/semgrep-appsec-platform/wiz.md
@@ -53,7 +53,7 @@ By default, the Code findings that Semgrep sends are:
 
 Semgrep sends findings from all repositories on supported SCMs in your organization. Findings previously sent but not included in submissions are marked as fixed in Wiz.
 
-Wiz allows a maximum of 3 uploads per repository per day. If more than 3 full scans complete on the primary branch in a single day, subsequent uploads will fail.
+Wiz allows up to **three uploads per repository per day**. If more than three full scans complete on the primary branch in a single day, subsequent uploads will fail.
 
 Currently, findings from repositories on SCMs other than GitHub and GitLab are not supported, as indicated in [Prerequisites](#prerequisites).
 

--- a/docs/semgrep-appsec-platform/wiz.md
+++ b/docs/semgrep-appsec-platform/wiz.md
@@ -53,6 +53,8 @@ By default, the Code findings that Semgrep sends are:
 
 Semgrep sends findings from all repositories on supported SCMs in your organization. Findings previously sent but not included in submissions are marked as fixed in Wiz.
 
+Wiz allows up to 3 uploads per repository per day. If more than 3 full scans complete on the primary branch in a single day, subsequent uploads will fail.
+
 Currently, findings from repositories on SCMs other than GitHub and GitLab are not supported, as indicated in [Prerequisites](#prerequisites).
 
 :::caution

--- a/docs/semgrep-appsec-platform/wiz.md
+++ b/docs/semgrep-appsec-platform/wiz.md
@@ -53,7 +53,7 @@ By default, the Code findings that Semgrep sends are:
 
 Semgrep sends findings from all repositories on supported SCMs in your organization. Findings previously sent but not included in submissions are marked as fixed in Wiz.
 
-Wiz allows up to 3 uploads per repository per day. If more than 3 full scans complete on the primary branch in a single day, subsequent uploads will fail.
+Wiz allows a maximum of 3 uploads per repository per day. If more than 3 full scans complete on the primary branch in a single day, subsequent uploads will fail.
 
 Currently, findings from repositories on SCMs other than GitHub and GitLab are not supported, as indicated in [Prerequisites](#prerequisites).
 


### PR DESCRIPTION
Wiz has a limit on the number of uploads per repository per day. Updating the limitations section in the Wiz integration page to include this limitation.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link

---

<details>
<summary>Adding a new documentation page? Click to expand the checklist </summary>

- [ ] Create `.md` or `.mdx` file in `/docs/[section]/` with frontmatter: `slug`, `title`, `description`, `displayed_sidebar`, `tags`
- [ ] Add page to appropriate sidebar in `/sidebars.js` (shows in side nav)
- [ ] **If adding the doc in a new directory:** Update `/src/theme/Navbar/Content/index.tsx` → add path to `getCurrentSection()` (highlights top nav)

Sidebars fields for `displayed_sidebar`:
`scanSidebar` | `rulewritingSidebar` | `devSidebar` | `learnSidebar` | `aboutSidebar` | `kbSidebar` | `whatsSemgrepSidebar`

Top nav fields for `getCurrentSection()`:
`'scan'` | `'write-rules'` | `'learning-guides'` | `'help'` | `'explore'`

</details>
