### PR TITLE
Better visibility for DDR options for Maven/Gradle

### DIFF
--- a/docs/semgrep-supply-chain/package-manager-support.md
+++ b/docs/semgrep-supply-chain/package-manager-support.md
@@ -49,7 +49,7 @@ The following table lists all Semgrep-supported package managers for each langua
   </tr>
   <tr>
    <td>Maven</td>
-   <td>Maven-generated dependency tree (See <a href="/docs/semgrep-supply-chain/setup-maven/">Setting up SSC scans for Apache Maven</a> for instructions.), <b>or</b> <br /><code>pom.xml</code> through <a
+   <td>Maven-generated dependency tree (see <a href="/docs/semgrep-supply-chain/setup-maven/">Setting up SSC scans for Apache Maven</a> for instructions) <b>or</b> <br /><code>pom.xml</code> through <a
    href="/docs/semgrep-supply-chain/getting-started#scan-a-project-without-lockfiles-beta">Dynamic
    Dependency Resolution</a>.</td>
   </tr>

--- a/docs/semgrep-supply-chain/package-manager-support.md
+++ b/docs/semgrep-supply-chain/package-manager-support.md
@@ -42,14 +42,14 @@ The following table lists all Semgrep-supported package managers for each langua
 <tr rowspan="2">
    <td rowspan="2">Java</td>
    <td>Gradle</td>
-   <td><code>gradle.lockfile</code> <b>or</b> <br />with <code>build.gradle</code> or
+   <td><code>gradle.lockfile</code> <b>or</b> <br /><code>build.gradle</code> or
    <code>build.gradle.kts</code> through <a
    href="/docs/semgrep-supply-chain/getting-started#scan-a-project-without-lockfiles-beta">Dynamic
    Dependency Resolution</a>.</td>
   </tr>
   <tr>
    <td>Maven</td>
-   <td>Maven-generated dependency tree (See <a href="/docs/semgrep-supply-chain/setup-maven/">Setting up SSC scans for Apache Maven</a> for instructions.), <b>or</b> <br /> with <code>pom.xml</code> through <a
+   <td>Maven-generated dependency tree (See <a href="/docs/semgrep-supply-chain/setup-maven/">Setting up SSC scans for Apache Maven</a> for instructions.), <b>or</b> <br /><code>pom.xml</code> through <a
    href="/docs/semgrep-supply-chain/getting-started#scan-a-project-without-lockfiles-beta">Dynamic
    Dependency Resolution</a>.</td>
   </tr>

--- a/docs/semgrep-supply-chain/package-manager-support.md
+++ b/docs/semgrep-supply-chain/package-manager-support.md
@@ -42,14 +42,14 @@ The following table lists all Semgrep-supported package managers for each langua
 <tr rowspan="2">
    <td rowspan="2">Java</td>
    <td>Gradle</td>
-   <td><code>gradle.lockfile</code> or with only <code>build.gradle</code> or
+   <td><code>gradle.lockfile</code> <b>or</b> <br />with <code>build.gradle</code> or
    <code>build.gradle.kts</code> through <a
    href="/docs/semgrep-supply-chain/getting-started#scan-a-project-without-lockfiles-beta">Dynamic
    Dependency Resolution</a>.</td>
   </tr>
   <tr>
    <td>Maven</td>
-   <td>Maven-generated dependency tree (See <a href="/docs/semgrep-supply-chain/setup-maven/">Setting up SSC scans for Apache Maven</a> for instructions.), or with only <code>pom.xml</code> through <a
+   <td>Maven-generated dependency tree (See <a href="/docs/semgrep-supply-chain/setup-maven/">Setting up SSC scans for Apache Maven</a> for instructions.), <b>or</b> <br /> with <code>pom.xml</code> through <a
    href="/docs/semgrep-supply-chain/getting-started#scan-a-project-without-lockfiles-beta">Dynamic
    Dependency Resolution</a>.</td>
   </tr>


### PR DESCRIPTION
A few folks including me managed to read past the fact that we do specify exactly which manifests are supported for Maven and Gradle for DDR/SWOL, so I humbly submit this change to make the presence of that information more obvious. Open to discussion on alternatives!

<img width="1776" height="416" alt="CleanShot 2026-05-07 at 11 52 35@2x" src="https://github.com/user-attachments/assets/7cc5e628-0f6b-4968-9ab3-a72841b4c0a8" />

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR