### PR TITLE
Closed is not actually a status

### DIFF
--- a/docs/semgrep-supply-chain/getting-started.md
+++ b/docs/semgrep-supply-chain/getting-started.md
@@ -88,7 +88,7 @@ You can configure your CI/CD system to trigger a Semgrep Supply Chain scan whene
 This feature is currently in beta. Please contact [Semgrep Support](/support) for more information.
 :::
 
-Semgrep Supply Chain can use **Dynamic Dependency Resolution** to scan projects without requiring lockfiles. This simplifies the configuration of Supply Chain scans. See [Feature support](docs/semgrep-supply-chain/sca-feature-support) for more information.
+Semgrep Supply Chain can use **Dynamic Dependency Resolution** to scan projects without requiring lockfiles. This simplifies the configuration of Supply Chain scans. See [Feature support](/semgrep-supply-chain/sca-feature-support) for more information.
 
 ### CLI Scans, including self-managed CI systems
 1. Ensure that the environment where you run Semgrep scans has installed all of the dependencies required to build your project, such as Java and Maven or Python and pip.

--- a/src/components/reference/_triage-states.mdx
+++ b/src/components/reference/_triage-states.mdx
@@ -4,9 +4,8 @@
 | **Reviewing** | Indicates that the finding requires investigation to determine what the next steps in the triage process should be. |
 | **Provisionally ignored** | Findings that Semgrep Multimodal has flagged as false positives. You can change the status to **Ignored** if you agree with Multimodal's assement. Otherwise, you can change the status to **To fix** if you disagree. |
 | **To fix** | Findings that you have decided to fix. Commonly used to indicate that these findings are tracked in Jira or assigned to developers for further work. |
-| **Fixed** | Fixed findings were detected in a previous scan but are no longer detected in the most recent scan of that same branch due to changes in the code. |
+| **Fixed** | Fixed findings were detected in a previous scan but are no longer detected in the most recent scan of that same branch. |
 | **Ignored** | Findings marked as ignored are present in the code but have been labeled unimportant. Ignore false positives or deprioritized issues. Mark findings as [ignored through Semgrep AppSec Platform](/semgrep-code/triage-remediation) or by adding a [nosemgrep code comment](/ignoring-files-folders-code/#reference-summary). You can also provide a reason for ignoring a finding: **False positive**, **Acceptable risk**, **No time to fix**. |
-| **Closed** | Vulnerabilities that are no longer detected after a scan. This can be due to changes in the underlying rule or the code. |
 
 ### Removed findings
 


### PR DESCRIPTION
We were using "Closed" in some places in the UI for a while, but I believe that was reverted, and it's not actually a distinct status from Fixed. (Perhaps ideally it would or will be, but we must live in the present in our docs.)

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR