### PR TITLE
Use updated actions/checkout

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -15,7 +15,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v3
         with:
           node-version: 22

--- a/.github/workflows/meilisearch-scrape.yml.old
+++ b/.github/workflows/meilisearch-scrape.yml.old
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Wait for deployment
         run: sleep 480s

--- a/.github/workflows/update-help-command.yml
+++ b/.github/workflows/update-help-command.yml
@@ -22,7 +22,7 @@ jobs:
           app-id: ${{ vars.SEMGREP_DOCS_RELEASE_APP_ID }}
           private-key: ${{ secrets.SEMGREP_DOCS_RELEASE_PRIVATE_KEY }}
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.generate-token.outputs.token }}
 

--- a/src/components/code_snippets/_gha-semgrep-app-sast.mdx
+++ b/src/components/code_snippets/_gha-semgrep-app-sast.mdx
@@ -43,7 +43,7 @@ jobs:
     if: (github.actor != 'dependabot[bot]')
 
     steps:
-      # Fetch project source with GitHub Actions Checkout. Use either v3 or v4.
+      # Fetch project source with GitHub Actions Checkout.
       - uses: actions/checkout@v6
       # Run the "semgrep ci" command on the command line of the docker image.
       - run: semgrep ci

--- a/src/components/code_snippets/_gha-semgrep-oss-sast.mdx
+++ b/src/components/code_snippets/_gha-semgrep-oss-sast.mdx
@@ -39,7 +39,7 @@ jobs:
     if: (github.actor != 'dependabot[bot]')
 
     steps:
-      # Fetch project source with GitHub Actions Checkout. Use either v3 or v4.
+      # Fetch project source with GitHub Actions Checkout.
       - uses: actions/checkout@v6
       # Run the "semgrep scan" command on the command line of the docker image.
       - run: semgrep scan --config auto


### PR DESCRIPTION
Checkout latest version is v6, generally compatible with v3 afaik, and v3 runs on a deprecated Node version.
This both removes outdated references in the docs where the version was already updated, and actually updates the version for some Actions.

The current failure in this PR is unrelated to my changes and is addressed in https://github.com/semgrep/semgrep-docs/pull/2616.

If additional tests are required for some actions that don't always run, happy to work with y'all to figure that out.