### PR TITLE
docs(sca): document private registry access via network broker

### DIFF
--- a/docs/semgrep-ci/network-broker.mdx
+++ b/docs/semgrep-ci/network-broker.mdx
@@ -376,6 +376,23 @@ inbound:
 
 In Network Broker `v0.31.0` and later, this URL is part of the default allowlist.
 
+## Use Semgrep Network Broker for private registry access
+
+Semgrep Supply Chain can route [private registry](/semgrep-supply-chain/triage-and-remediation#registry-support) traffic through the Network Broker, allowing Semgrep to reach registries that aren't publicly accessible on the internet. This is useful when your package registry is hosted inside your private network and can't be accessed directly from the Semgrep backend.
+
+To enable this, select **Use network broker for registry access** when you [connect the registry to Semgrep](/semgrep-supply-chain/triage-and-remediation#connect-a-private-registry-to-semgrep).
+
+For the broker to reach your registry, add the registry URL to the `allowlist` and permit `GET` and `HEAD` requests:
+
+```yaml
+inbound:
+  allowlist:
+    - url: "https://<registry-host>/*"
+      methods: ["GET", "HEAD"]
+```
+
+Replace `<registry-host>` with the host of your registry.
+
 ## Run multiple instances of the Semgrep Network Broker
 
 Do not attempt to run multiple instances of the Semgrep Network Broker to increase availability. Running multiple instances can result in contention and is less reliable than running a single instance.

--- a/docs/semgrep-supply-chain/triage-and-remediation.mdx
+++ b/docs/semgrep-supply-chain/triage-and-remediation.mdx
@@ -66,10 +66,9 @@ Semgrep's dependency upgrade guidance can determine if the package upgrade neede
 
 ### Registry support
 
-- Registries other than the public pypi and npm registry are not supported.
-- Private registries are not supported.
+Public npm and PyPI registries are supported. Private PyPI registries are also supported.
 
-This **includes** projects added to Semgrep through Semgrep Managed Scans.
+See [Connect a private registry to Semgrep](#connect-a-private-registry-to-semgrep).
 
 ### Prerequisites
 
@@ -229,7 +228,6 @@ Click **Review request** next to the **Permission updates requested** message, t
 
 ### Connect a private registry to Semgrep
 
-
 <Accordion title={"Expand to learn how to connect a private registry to Semgrep"}>
 <Steps>
 <Step>
@@ -244,27 +242,25 @@ Click **Add**, then select **Registry**.
 <Step>
 In the dialog that appears, provide the following information:
 
-   i. The **Name** of your registry.
+1. The **Name** of your registry.
+2. The <Tooltip tip="Software that interacts with a package registry to download, upload, or search for dependencies. Package managers typically generate manifest files or lockfiles." cta="See full definition." href="/semgrep-supply-chain/glossary#package-manager">**Package manager**</Tooltip>.
+3. The **Authentication method**. If none is required, select **None (public registry)**.
+    - **Username and password**: provide the required **Username** and **Password**.
+    - **API token**: provide the required token value.
+</Step>
+<Step>
+Optional: if your registry is only accessible from your private network, select **Use network broker for registry access**. This option requires a [Semgrep Network Broker](/semgrep-ci/network-broker) deployed within your network.
 
-   ii. Select the **%%Package manager|package_manager%%**.
+When enabled, Semgrep routes registry traffic through the broker, allowing Semgrep to access registries that aren't publicly accessible on the internet.
 
-   iii. Select the **Authentication method**. If none is required, select **None (public registry)**.
-
-      &emsp;&emsp;a. If you select **Username and password**, provide the required **Username** and **Password**.
-
-      &emsp;&emsp;b. If you select **API token**, provide the required token value.
+<Note>
+For the broker to reach your registry, its allowlist must include the registry URL. See [Use Semgrep Network Broker for private registry access](/semgrep-ci/network-broker#use-semgrep-network-broker-for-private-registry-access).
+</Note>
 </Step>
 <Step>
 Click **Connect** to save your changes and proceed.
 </Step>
 </Steps>
-
-<Note>
-**INFO**
-
-Semgrep currently supports integrations with private Maven package registries for [scans without lockfiles](/semgrep-supply-chain/getting-started#scan-a-project-without-lockfiles-beta).
-
-</Note>
 </Accordion>
 
 ### Troubleshooting: Semgrep is not displaying Upgrade guidance or Autofix functionality


### PR DESCRIPTION
## Context

Supply Chain recently added a **Use network broker for registry access**
checkbox when connecting a private registry, letting Semgrep reach registries
that are only accessible from a customer's private network. The docs didn't
cover this option, and the existing **Registry support** section incorrectly
stated private registries weren't supported.

## Solution

<img width="754" height="941" alt="CleanShot 2026-06-01 at 14 55 54" src="https://github.com/user-attachments/assets/d828dc5b-d397-4882-8392-d14f56c633cd" />

<img width="752" height="543" alt="CleanShot 2026-06-01 at 14 55 50" src="https://github.com/user-attachments/assets/3dd81bc3-2a6e-478e-a6d3-36a27065cbe6" />

- Correct the **Registry support** section: public npm/PyPI and private PyPI
  registries are supported, with a link to the connect flow.
- Add an optional step to the **Connect a private registry** flow documenting
  the **Use network broker for registry access** checkbox, calling out that it
  requires a deployed Network Broker and that the broker `allowlist` must
  include the registry URL.
- Add a **Use Semgrep Network Broker for private registry access** section to
  the Network Broker page with the required `allowlist` config (`GET`/`HEAD`
  on the registry host). Cross-linked both directions.

## Testing plan

- Verified internal links resolve to real anchors (`#registry-support`,
  `#connect-a-private-registry-to-semgrep`,
  `#use-semgrep-network-broker-for-private-registry-access`).
- Visual check of the nested list and tooltip rendering in local preview.