### PR TITLE
docs: add hosted remote server alternative to Claude Code tab

### DIFF
--- a/docs/guardian.mdx
+++ b/docs/guardian.mdx
@@ -84,7 +84,7 @@ semgrep login && semgrep install-semgrep-pro
     </Steps>
     The plugin registers a post-tool hook so Claude Code scans every file it writes. Learn more about [Claude Code plugins](https://code.claude.com/docs/en/plugins) and [hooks](https://code.claude.com/docs/en/hooks).
 
-    <Accordion title="Alternative: hosted remote server (early access beta)">
+    <Accordion title="Alternative: Use Semgrep’s hosted remote server (beta)">
       <Note>Early access beta.</Note>
 
       If you can't install the Semgrep CLI locally, you can use Semgrep's hosted remote server instead.

--- a/docs/guardian.mdx
+++ b/docs/guardian.mdx
@@ -84,8 +84,8 @@ semgrep login && semgrep install-semgrep-pro
     </Steps>
     The plugin registers a post-tool hook so Claude Code scans every file it writes. Learn more about [Claude Code plugins](https://code.claude.com/docs/en/plugins) and [hooks](https://code.claude.com/docs/en/hooks).
 
-    <Accordion title="Alternative: hosted remote server (early access beta — internal demo only)">
-      <Warning>Early access beta. Internal demo only.</Warning>
+    <Accordion title="Alternative: hosted remote server (early access beta)">
+      <Note>Early access beta.</Note>
 
       If you can't install the Semgrep CLI locally, you can use Semgrep's hosted remote server instead.
 

--- a/docs/guardian.mdx
+++ b/docs/guardian.mdx
@@ -83,6 +83,52 @@ semgrep login && semgrep install-semgrep-pro
       </Step>
     </Steps>
     The plugin registers a post-tool hook so Claude Code scans every file it writes. Learn more about [Claude Code plugins](https://code.claude.com/docs/en/plugins) and [hooks](https://code.claude.com/docs/en/hooks).
+
+    <Accordion title="Alternative: hosted remote server (early access beta — internal demo only)">
+      <Warning>Early access beta. Internal demo only.</Warning>
+
+      If you can't install the Semgrep CLI locally, you can use Semgrep's hosted remote server instead.
+
+      <Steps>
+        <Step>
+          Start a Claude Code instance:
+
+          ```bash
+          claude
+          ```
+        </Step>
+        <Step>
+          Add the Semgrep marketplace:
+
+          ```bash
+          /plugin marketplace add semgrep/guardian-claude
+          ```
+        </Step>
+        <Step>
+          Install the plugin from the marketplace:
+
+          ```bash
+          /plugin install semgrep-plugin@semgrep-guardian-claude
+          ```
+        </Step>
+        <Step>
+          Tell Claude to load the plugin:
+
+          ```bash
+          /reload-plugins
+          ```
+        </Step>
+        <Step>
+          Start a new session in Claude to begin the Semgrep login flow:
+
+          ```bash
+          /clear
+          ```
+
+          Alternatively, exit and relaunch Claude Code.
+        </Step>
+      </Steps>
+    </Accordion>
   </Tab>
   <Tab title="Codex">
     <Steps>

--- a/docs/guardian.mdx
+++ b/docs/guardian.mdx
@@ -85,7 +85,7 @@ semgrep login && semgrep install-semgrep-pro
     The plugin registers a post-tool hook so Claude Code scans every file it writes. Learn more about [Claude Code plugins](https://code.claude.com/docs/en/plugins) and [hooks](https://code.claude.com/docs/en/hooks).
 
     <Accordion title="Alternative: Use Semgrep’s hosted remote server (beta)">
-      <Note>Early access beta.</Note>
+      <Note>Beta.</Note>
 
       If you can't install the Semgrep CLI locally, you can use Semgrep's hosted remote server instead.
 


### PR DESCRIPTION
## Summary
- Add an Accordion under the Claude Code tab on the Guardian page with steps to use Semgrep's hosted remote server as an alternative when the Semgrep CLI can't be installed locally
- Flagged as early access beta / internal demo only via a Warning callout

## Test plan
- [ ] Preview the Guardian page and verify the accordion renders inside the Claude Code tab
- [ ] Verify the warning callout displays
- [ ] Confirm the listed plugin commands match what's expected for the demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)