### PR TITLE
manually run build scripts

### DIFF
--- a/docs/extensions/pre-commit.mdx
+++ b/docs/extensions/pre-commit.mdx
@@ -18,7 +18,7 @@ Add the following to your `.pre-commit-config.yaml` file:
 ```yaml
 repos:
 - repo: https://github.com/semgrep/pre-commit
-  rev: 'v1.164.0'
+  rev: 'v1.165.0'
   hooks:
     - id: semgrep
       entry: semgrep
@@ -51,7 +51,7 @@ Add the following to your `.pre-commit-config.yaml` file:
 ```yaml
 repos:
 - repo: https://github.com/semgrep/pre-commit
-  rev: 'v1.164.0'
+  rev: 'v1.165.0'
   hooks:
     - id:  semgrep-ci
 ```


### PR DESCRIPTION
Manually running `run-build-scripts` to fix the warnings while I figure out what to do about the unsigned commits pushed by Mintlify workflows