### PR TITLE
Update 'AWS Bedrock' to 'Amazon Bedrock'

### DIFF
--- a/docs/release-notes/april-2026.mdx
+++ b/docs/release-notes/april-2026.mdx
@@ -87,7 +87,7 @@ The following updates were made to Semgrep in April 2026.
 
 ### Added
 
-* Added IAM role-assumption authentication mode for AWS Bedrock BYOK. In addition to static access keys, users can now configure an IAM role ARN and grant Semgrep cross-account access using the generated external ID.
+* Added IAM role-assumption authentication mode for Amazon Bedrock BYOK. In addition to static access keys, users can now configure an IAM role ARN and grant Semgrep cross-account access using the generated external ID.
 
 ### Changed
 

--- a/docs/release-notes/august-2025.mdx
+++ b/docs/release-notes/august-2025.mdx
@@ -59,7 +59,7 @@ ensure keys for match-based IDs are stable.
 
 ### Added
 
-- Added support for the use of custom AWS Bedrock keys.
+- Added support for the use of custom Amazon Bedrock keys.
 
 ## 🔐 Semgrep Secrets
 

--- a/docs/release-notes/october-2024.mdx
+++ b/docs/release-notes/october-2024.mdx
@@ -84,7 +84,7 @@ description: "October 30, 2024 · 4 min read"
 - Users can now use Semgrep Assistant with their own OpenAI API key.
   - Enterprise users can also use the following API providers:
     - Azure OpenAI
-    - AWS Bedrock
+    - Amazon Bedrock
     - Google Gemini
  See the [AI provider documentation](/semgrep-multimodal/customize#select-your-ai-provider) for more details.
 - PR comments made by Semgrep Assistant now reference the Git commits that it used to generate the fix.

--- a/docs/semgrep-code/ai-powered-detection-concepts.mdx
+++ b/docs/semgrep-code/ai-powered-detection-concepts.mdx
@@ -34,7 +34,7 @@ AI-powered detection findings are inherently non-deterministic. Because AI scans
 
 AI-powered detection builds on Semgrep's existing integration framework, such as GitHub, GitLab, and Bitbucket. 
 
-During beta, you can choose between OpenAI, Anthropic, and Bedrock AI providers.
+During beta, you can choose between OpenAI, Anthropic, and Amazon Bedrock AI providers.
 
 ### Credits required for AI actions
 

--- a/docs/semgrep-code/triage-remediation/autofix.mdx
+++ b/docs/semgrep-code/triage-remediation/autofix.mdx
@@ -24,7 +24,7 @@ Autofix is available only for GitHub Cloud repositories.
 To use Autofix, you must meet the following requirements:
 
 * [Enable Semgrep Multimodal](/semgrep-multimodal/getting-started).  
-* Accept AWS Bedrock or Anthropic's Claude models.  
+* Accept Amazon Bedrock or Anthropic's Claude models.
   * During beta, Semgrep Code does not respect AI model selection.
 * Have at least one GitHub Cloud repository with new or existing Semgrep Code findings.  
 * Ensure the Semgrep private GitHub App is installed.

--- a/docs/semgrep-multimodal/customize.mdx
+++ b/docs/semgrep-multimodal/customize.mdx
@@ -173,14 +173,14 @@ Only users assigned the `admin` role in Semgrep can activate suggested memories.
 
 ## Select your AI provider
 
-By default, Semgrep Multimodal uses OpenAI and AWS Bedrock with Semgrep's API keys. 
+By default, Semgrep Multimodal uses OpenAI and Amazon Bedrock with Semgrep's API keys.
 
-Semgrep evaluates available models from multiple providers and selects the most performant option for each Multimodal feature, based on the providers enabled for your organization. For optimal results, keep both OpenAI and AWS Bedrock enabled. Enabling additional model providers can further improve performance.
+Semgrep evaluates available models from multiple providers and selects the most performant option for each Multimodal feature, based on the providers enabled for your organization. For optimal results, keep both OpenAI and Amazon Bedrock enabled. Enabling additional model providers can further improve performance.
 
 You can opt to:
 
 - Use OpenAI with your own API key
-- Use your own AWS Bedrock account
+- Use your own Amazon Bedrock account
 - Use Azure OpenAI
 - Use Google Gemini.
 - Use xAI.
@@ -209,9 +209,9 @@ By switching from Semgrep's key to your key, note that you lose access to the fo
 - Semgrep's [Zero Data Retention agreement](/semgrep-multimodal/privacy) that prevents OpenAI from saving input or output data.
 - Semgrep paying for the cost of your AI usage.
 
-### Your own AWS Bedrock account
+### Your own Amazon Bedrock account
 
-If you want to keep all data within your AWS account, you can use your own AWS Bedrock instance:
+If you want to keep all data within your AWS account, you can use your own Amazon Bedrock instance:
 
 <Steps>
   <Step>
@@ -221,7 +221,7 @@ If you want to keep all data within your AWS account, you can use your own AWS B
   Click the <Icon icon="gear" iconType="solid"/> **icon** next to **AI provider**.
   </Step>
   <Step>
-  Select **AWS Bedrock** then **Your AWS account**
+  Select **Amazon Bedrock** then **Your AWS account**
   </Step>
   <Step>
   Provide your AWS IAM role details.

--- a/docs/semgrep-multimodal/overview.mdx
+++ b/docs/semgrep-multimodal/overview.mdx
@@ -128,6 +128,6 @@ Read more about [Upgrade guidance and Autofix](/semgrep-supply-chain/triage-and-
 
 ## Reliability
 
-Multimodal supports fallback between model providers to ensure optimal performance and reliability. OpenAI is the primary provider in most cases, with automatic fallback to AWS Bedrock as needed. Semgrep's fallback decisions are based on an internal ranking system informed by ongoing research. Semgrep ranks models by performance and dynamically selects the best available from [your enabled options](/semgrep-multimodal/customize#select-your-ai-provider).
+Multimodal supports fallback between model providers to ensure optimal performance and reliability. OpenAI is the primary provider in most cases, with automatic fallback to Amazon Bedrock as needed. Semgrep's fallback decisions are based on an internal ranking system informed by ongoing research. Semgrep ranks models by performance and dynamically selects the best available from [your enabled options](/semgrep-multimodal/customize#select-your-ai-provider).
 
 Enabling additional model providers for your Semgrep organization can improve performance in some scenarios, while removing them could result in reduced performance.


### PR DESCRIPTION
Amazon is persnickety about which products are named 'Amazon' and which are named 'AWS'. This update fixes Bedrock mentions to comply with their branding. This is required before we submit a partner certification to AWS.

See https://aws.amazon.com/bedrock/ to confirm how the service is named.

### Thanks for improving Semgrep Docs

Please ensure:

- [ ] A subject matter expert reviews the content
- [ ] A technical writer reviews the PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Any redirects are in `docs/docs.json` if URLs changed
- [ ] If you edited `docs/extensions/pre-commit.md.template.mdx`, CI regenerates `pre-commit.mdx` on this PR (no manual `run-build-scripts` needed)
- [ ] Check the **Mintlify** bot preview link on this PR (requires PR to `main`)
