### PR TITLE
[TEC-554] Document GitHub permissions required by code autofix

### DIFF
--- a/docs/deployment/checklist.mdx
+++ b/docs/deployment/checklist.mdx
@@ -240,6 +240,10 @@ Lets Semgrep configure itself to run in CI by writing to .github/workflows/semgr
 Allows Semgrep Multimodal to fetch source code files on-demand to construct AI prompts.
 </Accordion>
 
+<Tip>
+**Autofix** (Semgrep Code and Semgrep Supply Chain upgrade PRs) needs **Contents: Read and write** on the private app, plus other permissions, so Semgrep can clone and push branches and open draft PRs. For a breakdown of Git operations versus REST endpoints, see [GitHub permissions and API usage for Autofix](/semgrep-code/triage-remediation/autofix#github-permissions-and-api-usage-for-autofix).
+</Tip>
+
 </Tab>
 
 <Tab title="Permissions for GitLab">

--- a/docs/semgrep-code/triage-remediation/autofix.mdx
+++ b/docs/semgrep-code/triage-remediation/autofix.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Autofix for Semgrep Code (beta)"
 sidebarTitle: "Autofix (beta)"
-description: "Semgrep’s Autofix feature uses AI to generate proposed code changes for Semgrep Code findings."
+description: "Semgrep’s Autofix feature uses AI to generate proposed code changes for Semgrep Code findings, including required GitHub App permissions and how Semgrep accesses your repository."
 ---
 
 
@@ -144,3 +144,20 @@ Because the code changes displayed on findings and PRs are generated separately,
 At this time, Semgrep Memories do not directly influence Autofix PR generation.
 
 Memories may affect PRs indirectly through remediation guidance. If general remediation guidance has been generated and includes information derived from memories, that guidance is passed into the PR generation process. However, memories themselves are not currently sent as direct input when generating the PR.
+
+## GitHub permissions and API usage for Autofix
+
+Autofix uses your **private Semgrep GitHub App** with the permissions below. Use this section for security reviews (for example, which GitHub operations require **Contents: Read and write**).
+
+### Repository permissions
+
+| GitHub App permission | Why Autofix needs it |
+| :--- | :--- |
+| **Contents: Read** | Clone the repository over HTTPS (shallow, single-branch) so Semgrep can analyze the code and generate a fix. This uses GitHub's Smart HTTP Git protocol (`git-upload-pack`). |
+| **Contents: Write** | Push the Autofix branch back to the repository. This uses GitHub's Smart HTTP Git protocol (`git-receive-pack`). |
+| **Metadata: Read** | Read repository metadata, including the default branch, using `GET /repos/{owner}/{repo}`. |
+| **Pull requests: Write** | Open a **draft** pull request using `POST /repos/{owner}/{repo}/pulls`. |
+
+### How repository contents are accessed
+
+Semgrep does **not** read or write file contents through the REST Contents API (`GET` or `PUT` `/repos/{owner}/{repo}/contents/{path}`). Autofix reads and writes code only through the **Git transport layer** (clone and push), which still requires the GitHub **Contents** permissions above.

--- a/docs/semgrep-code/triage-remediation/autofix.mdx
+++ b/docs/semgrep-code/triage-remediation/autofix.mdx
@@ -153,11 +153,12 @@ Autofix uses your **private Semgrep GitHub App** with the permissions below. Use
 
 | GitHub App permission | Why Autofix needs it |
 | :--- | :--- |
-| **Contents: Read** | Clone the repository over HTTPS (shallow, single-branch) so Semgrep can analyze the code and generate a fix. This uses GitHub's Smart HTTP Git protocol (`git-upload-pack`). |
-| **Contents: Write** | Push the Autofix branch back to the repository. This uses GitHub's Smart HTTP Git protocol (`git-receive-pack`). |
+| **Contents: Read** | Clone the repository using git+https (shallow, single-branch) so Semgrep can analyze the code and generate a fix. |
+| **Contents: Write** | Push the Autofix branch back to the repository using git+https. |
 | **Metadata: Read** | Read repository metadata, including the default branch, using `GET /repos/{owner}/{repo}`. |
 | **Pull requests: Write** | Open a **draft** pull request using `POST /repos/{owner}/{repo}/pulls`. |
 
 ### How repository contents are accessed
 
 Semgrep does **not** read or write file contents through the REST Contents API (`GET` or `PUT` `/repos/{owner}/{repo}/contents/{path}`). Autofix reads and writes code only through the **Git transport layer** (clone and push), which still requires the GitHub **Contents** permissions above.
+

--- a/docs/semgrep-code/triage-remediation/autofix.mdx
+++ b/docs/semgrep-code/triage-remediation/autofix.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Autofix for Semgrep Code (beta)"
 sidebarTitle: "Autofix (beta)"
-description: "Semgrep’s Autofix feature uses AI to generate proposed code changes for Semgrep Code findings, including required GitHub App permissions and how Semgrep accesses your repository."
+description: "Semgrep’s Autofix feature uses AI to generate proposed code changes for Semgrep Code findings. This page also describes required GitHub App permissions and how Semgrep accesses your repository."
 ---
 
 

--- a/docs/semgrep-supply-chain/triage-and-remediation.mdx
+++ b/docs/semgrep-supply-chain/triage-and-remediation.mdx
@@ -78,9 +78,7 @@ To access all upgrade guidance and Autofix features, you must have:
 - Enabled upgrade guidance Semgrep AppSec Platform by going to **Settings > General > Supply Chain**
 - At least one repository with full [scans with Semgrep Supply Chain](/semgrep-supply-chain/getting-started).
 - Semgrep Multimodal [enabled](/semgrep-multimodal/getting-started).
-- The **private** GitHub app for Semgrep installed.
-  - The app must have [**Read and write** access on the **Contents** permission](#grant-read-and-write-access-to-a-private-github-semgrep-app) to open Autofix PRs. Current customers must manually enable this if they haven't already.
-  - For which GitHub operations and endpoints that entails (Git clone and push versus REST), see [GitHub permissions and API usage for Autofix](/semgrep-code/triage-remediation/autofix#github-permissions-and-api-usage-for-autofix).
+- The **private** GitHub app for Semgrep installed. The app must have [**Read and write** access on the **Contents** permission](#grant-read-and-write-access-to-a-private-github-semgrep-app) to open Autofix PRs. Current customers must manually enable this if they haven't already.
 - Optionally: if you have [a private registry, connect it to Semgrep](#connect-a-private-registry-to-semgrep) to improve results.
 
 ### Features and permissions required

--- a/docs/semgrep-supply-chain/triage-and-remediation.mdx
+++ b/docs/semgrep-supply-chain/triage-and-remediation.mdx
@@ -80,6 +80,7 @@ To access all upgrade guidance and Autofix features, you must have:
 - Semgrep Multimodal [enabled](/semgrep-multimodal/getting-started).
 - The **private** GitHub app for Semgrep installed.
   - The app must have [**Read and write** access on the **Contents** permission](#grant-read-and-write-access-to-a-private-github-semgrep-app) to open Autofix PRs. Current customers must manually enable this if they haven't already.
+  - For which GitHub operations and endpoints that entails (Git clone and push versus REST), see [GitHub permissions and API usage for Autofix](/semgrep-code/triage-remediation/autofix#github-permissions-and-api-usage-for-autofix).
 - Optionally: if you have [a private registry, connect it to Semgrep](#connect-a-private-registry-to-semgrep) to improve results.
 
 ### Features and permissions required
@@ -191,6 +192,7 @@ To prevent security vulnerabilities from being merged into your codebase, see [S
 
 ### Grant **Read and write** access to a private GitHub Semgrep app
 
+Autofix PRs for Supply Chain use the same private GitHub App permissions and GitHub access patterns as [Autofix for Semgrep Code](/semgrep-code/triage-remediation/autofix#github-permissions-and-api-usage-for-autofix).
 
 <Accordion title={"Expand for instructions on granting read and write access to a private GitHub Semgrep app"}>
 If you are an **existing** Semgrep user and you need to change 


### PR DESCRIPTION
[Preview](https://semgrep-ee9d73d8-abhijna-autofix-github-perm.mintlify.app/semgrep-code/triage-remediation/autofix#github-permissions-and-api-usage-for-autofix)

To do:
- [ ] Break up appendix (in different PR)

Reviews:
- [ ] A subject matter expert reviews the content
- [ ] A technical writer reviews the PR
- [ ] Check the **Mintlify** bot preview link on this PR (requires PR to `main`)
