### PR TITLE
Correct 404'ing workspace-admin-token bitbucket link

### DIFF
--- a/docs/deployment/managed-scanning/bitbucket.mdx
+++ b/docs/deployment/managed-scanning/bitbucket.mdx
@@ -13,7 +13,7 @@ Semgrep Managed Scans require one of the following plans:
 
 ### Bitbucket Cloud
 
-You must provide a Bitbucket [workspace access token](https://support.atlassian.com/bitbucket-cloud/workspace-access-tokens/) to Semgrep, which can be created by a user with the `Product Admin` role. Once you have Semgrep Managed Scans fully configured, you can update the token provided to Semgrep to one that's more restrictive. The scopes you must assign to the token include:
+You must provide a Bitbucket [workspace access token](https://support.atlassian.com/bitbucket-cloud/docs/create-a-workspace-access-token/) to Semgrep, which can be created by a user with the `Product Admin` role. Once you have Semgrep Managed Scans fully configured, you can update the token provided to Semgrep to one that's more restrictive. The scopes you must assign to the token include:
 
 - `webhook (read and write)`
 - `repository (read and write)`


### PR DESCRIPTION
Correct a 404ing workspace-acces-token link

### Thanks for improving Semgrep Docs

Please ensure:

- [ ] A subject matter expert reviews the content
- [ ] A technical writer reviews the PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Any redirects are in `docs/docs.json` if URLs changed
- [ ] If you edited `docs/extensions/pre-commit.md.template.mdx`, CI regenerates `pre-commit.mdx` on this PR (no manual `run-build-scripts` needed)
- [ ] Check the **Mintlify** bot preview link on this PR (requires PR to `main`)
