### PR TITLE
Correct role requirements for GitLab

### DIFF
--- a/docs/deployment/managed-scanning/gitlab.mdx
+++ b/docs/deployment/managed-scanning/gitlab.mdx
@@ -16,11 +16,10 @@ You must provide a GitLab group access token or personal access token to Semgrep
 
 During SMS onboarding, the group or user to which the token is assigned must have one of the following roles: 
 
-- `Maintainer`
 - `Owner`
 - `Admin`
 
-This is because managed scans of GitLab repositories require the enablement of webhooks to facilitate diff-aware scans and the creation of pull request comments by Semgrep. The webhooks are enabled by default when you set up Managed Scans and add GitLab as a source code manager. Once onboarding is complete, you can downgrade the role assigned to the token to `Developer`.
+`Owner` or `Admin` role is required because managed scans of GitLab repositories require the configuration of group webhooks to facilitate diff-aware scans and the creation of pull request comments by Semgrep. The webhooks are enabled by default when you set up Managed Scans and add GitLab as a source code manager. Once onboarding is complete, you can downgrade the role assigned to the token to `Developer`.
 
 See [Pre-deployment checklist > Permissions](/deployment/checklist#permissions) for more information about the permissions used by Semgrep.
 

--- a/docs/deployment/managed-scanning/gitlab.mdx
+++ b/docs/deployment/managed-scanning/gitlab.mdx
@@ -6,7 +6,7 @@ description: "Add GitLab repositories to your Semgrep organization in bulk witho
 
 ## Prerequisites and permissions
 
-Semgrep Managed Scanning (SMS) requires one of the following plans:
+Semgrep Managed Scans requires one of the following plans:
 
 - GitLab Premium
 - GitLab Ultimate
@@ -14,12 +14,8 @@ Semgrep Managed Scanning (SMS) requires one of the following plans:
 
 You must provide a GitLab group access token or personal access token to Semgrep. The token must have the `api` scope assigned to it.
 
-During SMS onboarding, the group or user to which the token is assigned must have one of the following roles: 
 
-- `Owner`
-- `Admin`
-
-`Owner` or `Admin` role is required because managed scans of GitLab repositories require the configuration of group webhooks to facilitate diff-aware scans and the creation of pull request comments by Semgrep. The webhooks are enabled by default when you set up Managed Scans and add GitLab as a source code manager. Once onboarding is complete, you can downgrade the role assigned to the token to `Developer`.
+When onboarding to Semgrep Managed Scanning, the group or user assigned to the token must have the **`Owner`** or **`Admin`** role. The `Owner` or `Admin` role is required because Managed Scans of GitLab repositories require group webhooks. Semgrep uses these webhooks to facilitate diff-aware scans and create pull request (PR) comments. Webhooks are enabled by default when you set up Managed Scans and add GitLab as a source code manager. After onboarding is complete, you can downgrade the token’s role to `Developer`.
 
 See [Pre-deployment checklist > Permissions](/deployment/checklist#permissions) for more information about the permissions used by Semgrep.
 
@@ -319,7 +315,7 @@ Click **Remove** to confirm.
 Sign in to Semgrep AppSec Platform.
 </Step>
 <Step>
-Go to Projects and find the project you no longer want scanned with Semgrep Managed Scanning. Click the project's **Details** page > **Settings** tab. 
+Go to Projects and find the project you no longer want scanned with Semgrep Managed Scans. Click the project's **Details** page > **Settings** tab. 
 </Step>
 <Step>
 Toggle the switch for **Managed diff scans** to turn off scans of new pull requests and merge requests and **Managed full scans** to turn off full scans of the base branch.

--- a/docs/deployment/managed-scanning/gitlab.mdx
+++ b/docs/deployment/managed-scanning/gitlab.mdx
@@ -15,7 +15,7 @@ Semgrep Managed Scans requires one of the following plans:
 You must provide a GitLab group access token or personal access token to Semgrep. The token must have the `api` scope assigned to it.
 
 
-When onboarding to Semgrep Managed Scanning, the group or user assigned to the token must have the **`Owner`** or **`Admin`** role. The `Owner` or `Admin` role is required because Managed Scans of GitLab repositories require group webhooks. Semgrep uses these webhooks to facilitate diff-aware scans and create pull request (PR) comments. Webhooks are enabled by default when you set up Managed Scans and add GitLab as a source code manager. After onboarding is complete, you can downgrade the token’s role to `Developer`.
+When onboarding to Semgrep Managed Scans, the group or user assigned to the token must have the **`Owner`** or **`Admin`** role. The `Owner` or `Admin` role is required because Managed Scans of GitLab repositories require group webhooks. Semgrep uses these webhooks to facilitate diff-aware scans and create pull request (PR) comments. Webhooks are enabled by default when you set up Managed Scans and add GitLab as a source code manager. After onboarding is complete, you can downgrade the token’s role to `Developer`.
 
 See [Pre-deployment checklist > Permissions](/deployment/checklist#permissions) for more information about the permissions used by Semgrep.
 

--- a/docs/deployment/managed-scanning/gitlab.mdx
+++ b/docs/deployment/managed-scanning/gitlab.mdx
@@ -15,7 +15,9 @@ Semgrep Managed Scans requires one of the following plans:
 You must provide a GitLab group access token or personal access token to Semgrep. The token must have the `api` scope assigned to it.
 
 
-When onboarding to Semgrep Managed Scans, the group or user assigned to the token must have the **`Owner`** or **`Admin`** role. The `Owner` or `Admin` role is required because Managed Scans of GitLab repositories require group webhooks. Semgrep uses these webhooks to facilitate diff-aware scans and create pull request (PR) comments. Webhooks are enabled by default when you set up Managed Scans and add GitLab as a source code manager. After onboarding is complete, you can downgrade the token’s role to `Developer`.
+When onboarding to Semgrep Managed Scans, the group or user assigned to the token must have the **`Owner`** or **`Admin`** role. The `Owner` or `Admin` role is required because Managed Scans of GitLab repositories require group webhooks. Semgrep uses these webhooks to facilitate diff-aware scans and create pull request (PR) comments. 
+
+Webhooks are enabled by default when you set up Managed Scans and add GitLab as a source code manager. After onboarding is complete, you can downgrade the token’s role to `Developer`.
 
 See [Pre-deployment checklist > Permissions](/deployment/checklist#permissions) for more information about the permissions used by Semgrep.
 


### PR DESCRIPTION
It is not intuitive based on the [permission matrix](https://docs.gitlab.com/user/permissions/) GitLab's docs have, but **group webhooks** require Owner+ role in order to be configured. [Source](https://docs.gitlab.com/user/project/integrations/webhooks/#create-a-webhook)

we need to be super crisp about this.

### Thanks for improving Semgrep Docs

Please ensure:

- [ ] A subject matter expert reviews the content
- [x] A technical writer reviews the PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Any redirects are in `docs/docs.json` if URLs changed
- [ ] If you edited `docs/extensions/pre-commit.md.template.mdx`, CI regenerates `pre-commit.mdx` on this PR (no manual `run-build-scripts` needed)
- [ ] Check the **Mintlify** bot preview link on this PR (requires PR to `main`)
