### PR TITLE
Add GPG key import step to CI workflow

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -34,10 +34,22 @@ jobs:
       - name: Run build scripts
         run: bash run-build-scripts
 
+      - name: Import GPG key
+        id: import-gpg
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
       - name: Commit generated files
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "chore: regenerate docs from build scripts"
+          commit_user_name: ${{ steps.import-gpg.outputs.name }}
+          commit_user_email: ${{ steps.import-gpg.outputs.email }}
+          commit_author: "${{ steps.import-gpg.outputs.name }} <${{ steps.import-gpg.outputs.email }}>"
           file_pattern: |
             docs/extensions/pre-commit.mdx
             docs/snippets/metrics.mdx


### PR DESCRIPTION
[Import GPG key for signing commits in CI workflow](https://github.com/stefanzweifel/git-auto-commit-action/blob/master/EXAMPLES.md#sign-automated-commits-with-gpg).

Please ensure:

- [ ] A technical writer reviews the PR
