### PR TITLE
docs: list pipx and uv before homebrew in quickstart install

### DIFF
--- a/docs/extensions/pre-commit.mdx
+++ b/docs/extensions/pre-commit.mdx
@@ -18,7 +18,7 @@ Add the following to your `.pre-commit-config.yaml` file:
 ```yaml
 repos:
 - repo: https://github.com/semgrep/pre-commit
-  rev: 'v1.165.0'
+  rev: 'v1.166.0'
   hooks:
     - id: semgrep
       entry: semgrep
@@ -51,7 +51,7 @@ Add the following to your `.pre-commit-config.yaml` file:
 ```yaml
 repos:
 - repo: https://github.com/semgrep/pre-commit
-  rev: 'v1.165.0'
+  rev: 'v1.166.0'
   hooks:
     - id: semgrep-ci
 ```

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -34,7 +34,7 @@ You must have Python 3.10 or later installed on the machine where the Semgrep CL
         # preferred: install through uv (https://docs.astral.sh/uv/)
         uv tool install semgrep
 
-        # best-effort: install through homebrew (maintained on a best-effort basis; may lag behind the latest release)
+        # best-effort: install through homebrew (maintained on a best-effort basis; often lags behind the latest release)
         brew install semgrep
 
         # confirm installation succeeded by printing the currently installed version
@@ -44,7 +44,7 @@ You must have Python 3.10 or later installed on the machine where the Semgrep CL
         <Info>
         **NOTE**
 
-        `pipx` and `uv` are the preferred installation methods. The Homebrew formula is maintained on a best-effort basis and may lag behind the latest release.
+        `pipx` and `uv` are the preferred installation methods. The Homebrew formula is maintained on a best-effort basis and often lags behind the latest release.
 
         **Homebrew users:** ensure that you've [added Homebrew to your PATH](https://docs.brew.sh/FAQ#my-mac-apps-dont-find-homebrew-utilities).
         </Info>

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -28,14 +28,14 @@ You must have Python 3.10 or later installed on the machine where the Semgrep CL
         i. Install the Semgrep CLI and confirm the installation:
 
         ```bash
-        # install through homebrew
-        brew install semgrep
-
-        # or, install through pipx (https://pipx.pypa.io/stable/how-to/install-pipx/)
+        # install through pipx (https://pipx.pypa.io/stable/how-to/install-pipx/)
         pipx install semgrep
 
         # or, install through uv (https://docs.astral.sh/uv/)
         uv tool install semgrep
+
+        # or, install through homebrew
+        brew install semgrep
 
         # confirm installation succeeded by printing the currently installed version
         semgrep --version

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -28,13 +28,13 @@ You must have Python 3.10 or later installed on the machine where the Semgrep CL
         i. Install the Semgrep CLI and confirm the installation:
 
         ```bash
-        # install through pipx (https://pipx.pypa.io/stable/how-to/install-pipx/)
+        # preferred: install through pipx (https://pipx.pypa.io/stable/how-to/install-pipx/)
         pipx install semgrep
 
-        # or, install through uv (https://docs.astral.sh/uv/)
+        # preferred: install through uv (https://docs.astral.sh/uv/)
         uv tool install semgrep
 
-        # or, install through homebrew
+        # best-effort: install through homebrew (maintained on a best-effort basis; may lag behind the latest release)
         brew install semgrep
 
         # confirm installation succeeded by printing the currently installed version
@@ -43,6 +43,8 @@ You must have Python 3.10 or later installed on the machine where the Semgrep CL
 
         <Info>
         **NOTE**
+
+        `pipx` and `uv` are the preferred installation methods. The Homebrew formula is maintained on a best-effort basis and may lag behind the latest release.
 
         **Homebrew users:** ensure that you've [added Homebrew to your PATH](https://docs.brew.sh/FAQ#my-mac-apps-dont-find-homebrew-utilities).
         </Info>


### PR DESCRIPTION
## Summary
Marks `pipx` and `uv` as the preferred installation methods, and homebrew as best effort.

New copy: 
```
# preferred: install through pipx (https://pipx.pypa.io/stable/how-to/install-pipx/)
pipx install semgrep

# preferred: install through uv (https://docs.astral.sh/uv/)
uv tool install semgrep

# best-effort: install through homebrew (maintained on a best-effort basis; may lag behind the latest release)
brew install semgrep

# confirm installation succeeded by printing the currently installed version
semgrep --version
```


🤖 Generated with [Claude Code](https://claude.com/claude-code)