### PR TITLE
docs: default Guardian for Claude Code to the hosted remote server

### DIFF
--- a/docs/guardian.mdx
+++ b/docs/guardian.mdx
@@ -254,7 +254,7 @@ See [Kiro docs](https://kiro.dev/docs/mcp/) for more info.
 
 ## Install the Semgrep CLI
 
-Every IDE except Claude Code runs Semgrep from a locally installed CLI. (Claude Code uses Semgrep's hosted remote server by default and doesn't need a local CLI; its legacy local plugin installs the CLI for you.)
+Every IDE except Claude Code runs Semgrep from a locally installed CLI. (Claude Code uses Semgrep's hosted remote server by default and doesn't need a local CLI.)
 
 <Steps>
 <Step>

--- a/docs/guardian.mdx
+++ b/docs/guardian.mdx
@@ -282,22 +282,6 @@ semgrep login && semgrep install-semgrep-pro
 </Step>
 </Steps>
 
-## Scan your code
-
-<Steps>
-  <Step>
-    Open up your IDE's AI chat window.
-  </Step>
-  <Step>
-    Ensure that you're in the correct context to use Semgrep.
-  </Step>
-  <Step>
-    Prompt your IDE to scan with Semgrep.
-  </Step>
-</Steps>
-
-By default, the Semgrep Guardian runs all three Semgrep products: Code, Supply Chain, and Secrets.
-
 ## Additional resources
 
 * Semgrep's `#mcp` [Slack community](https://go.semgrep.dev/slack)

--- a/docs/guardian.mdx
+++ b/docs/guardian.mdx
@@ -67,6 +67,9 @@ This guide covers setup for each of the preceding products listed, but the plugi
 
       <Steps>
         <Step>
+          [Install the Semgrep CLI](#install-the-semgrep-cli).
+        </Step>
+        <Step>
           Start a Claude Code instance:
 
           ```bash
@@ -95,7 +98,7 @@ This guide covers setup for each of the preceding products listed, but the plugi
           ```
         </Step>
         <Step>
-          Set up the plugin. This also installs the Semgrep CLI:
+          Set up the plugin:
 
           ```bash
           /setup-semgrep-plugin

--- a/docs/guardian.mdx
+++ b/docs/guardian.mdx
@@ -19,17 +19,227 @@ This guide covers setup for each of the preceding products listed, but the plugi
 
 ## Prerequisites
 
-* Python 3.10 or later (the Semgrep CLI requires it at runtime regardless of how it was installed)
-* Homebrew, [`pipx`](https://pipx.pypa.io/stable/how-to/install-pipx/), or [`uv`](https://docs.astral.sh/uv/) to install Semgrep
 * A Semgrep account
+
+Claude Code uses Semgrep's hosted remote server by default, so no local install is required. Every other IDE runs Semgrep from your locally installed CLI; the steps for those IDEs link to [Install the Semgrep CLI](#install-the-semgrep-cli).
+
+## Connect to your IDE
+
+<Tabs>
+  <Tab title="Claude Code">
+    Claude Code uses Semgrep's hosted remote server by default, so you don't need to install the Semgrep CLI locally.
+
+    <Steps>
+      <Step>
+        Start a Claude Code instance:
+
+        ```bash
+        claude
+        ```
+      </Step>
+      <Step>
+        Open the plugin marketplace, search for **Semgrep**, and install it.
+      </Step>
+    </Steps>
+    The plugin registers a post-tool hook so Claude Code scans every file it writes. Learn more about [Claude Code plugins](https://code.claude.com/docs/en/plugins) and [hooks](https://code.claude.com/docs/en/hooks).
+
+    <Accordion title="Legacy: run Semgrep from a local plugin">
+      The remote server is the recommended default. If you need to run Semgrep locally instead, you can install the legacy local plugin from the [`semgrep/guardian-local`](https://github.com/semgrep/guardian-local) repo.
+
+      <Steps>
+        <Step>
+          Start a Claude Code instance:
+
+          ```bash
+          claude
+          ```
+        </Step>
+        <Step>
+          Add the Semgrep marketplace:
+
+          ```bash
+          /plugin marketplace add semgrep/guardian-local
+          ```
+        </Step>
+        <Step>
+          Install the plugin from the marketplace:
+
+          ```bash
+          /plugin install semgrep@semgrep-marketplace
+          ```
+        </Step>
+        <Step>
+          Tell Claude to load the plugin:
+
+          ```bash
+          /reload-plugins
+          ```
+        </Step>
+        <Step>
+          Set up the plugin. This also installs the Semgrep CLI:
+
+          ```bash
+          /setup-semgrep-plugin
+          ```
+        </Step>
+      </Steps>
+    </Accordion>
+  </Tab>
+  <Tab title="Codex">
+    <Steps>
+      <Step>
+        [Install the Semgrep CLI](#install-the-semgrep-cli).
+      </Step>
+      <Step>
+        Update your `~/.codex/config.toml` file and paste the following:
+
+        ```bash
+        [mcp_servers.semgrep]
+        command = "semgrep"
+        args = ["mcp"]
+        ```
+      </Step>
+    </Steps>
+    Codex does not expose a post-write hook, so Semgrep tools are surfaced through MCP and invoked when the agent calls them. Learn more about [Codex MCP configuration](https://developers.openai.com/codex/mcp).
+  </Tab>
+  <Tab title="Cursor">
+    <Steps>
+      <Step>
+        [Install the Semgrep CLI](#install-the-semgrep-cli).
+      </Step>
+      <Step>
+        Find Semgrep in the [Cursor Plugin Marketplace](https://cursor.com/marketplace/semgrep), or open **Cursor > ⌘⇧J > Plugins**. Search "Semgrep" and click **Add to Cursor**.
+      </Step>
+      <Step>
+        Restart Cursor to apply configuration.
+      </Step>
+      <Step>
+        In Cursor's chat, run the `/setup-semgrep-plugin` skill to finish wiring up the plugin.
+
+        The plugin uses [Cursor hooks](https://cursor.com/docs/hooks) (`afterFileEdit` and `stop`) to scan code as the agent writes it, and exposes Semgrep tools through [Cursor MCP](https://cursor.com/docs/mcp).
+      </Step>
+    </Steps>
+  </Tab>
+  <Tab title="GitHub Copilot">
+  Use this tab for GitHub Copilot in Visual Studio, JetBrains IDEs, Xcode, or Eclipse. (For Copilot in VS Code, use the **VS Code** tab.)
+    <Steps>
+      <Step>
+        [Install the Semgrep CLI](#install-the-semgrep-cli).
+      </Step>
+      <Step>
+        Register the Semgrep MCP server with your IDE's Copilot configuration. The JSON shape is the same across IDEs:
+
+        ```json
+          {
+            "servers": {
+              "semgrep": {
+                  "command": "semgrep",
+                  "args": ["mcp"]
+              }
+            }
+          }
+          ```
+        Follow your IDE's instructions for *where* to put this entry: [Extending Copilot Chat with MCP servers](https://docs.github.com/en/copilot/how-tos/provide-context/use-mcp-in-your-ide/extend-copilot-chat-with-mcp) covers Visual Studio, JetBrains, Xcode, and Eclipse.
+      </Step>
+      <Step>
+        Restart your IDE and open Copilot Chat. Semgrep tools become available in **Agent** mode.
+      </Step>
+    </Steps>
+    Copilot does not expose a post-write hook, so Semgrep tools are invoked when the agent calls them through MCP.
+  </Tab>
+
+  <Tab title="VS Code">
+    <Steps>
+      <Step>
+        [Install the Semgrep CLI](#install-the-semgrep-cli).
+      </Step>
+      <Step>
+        Add the Semgrep MCP server to VS Code. Create `.vscode/mcp.json` in your workspace (or run the **MCP: Open User Configuration** command from the Command Palette for a user-wide entry) and paste the following:
+
+        ```json
+          {
+            "servers": {
+              "semgrep": {
+                  "command": "semgrep",
+                  "args": ["mcp"]
+              }
+            }
+          }
+          ```
+      </Step>
+      <Step>
+        Reload VS Code. Semgrep tools become available in the Copilot Chat **Agent** mode.
+      </Step>
+    </Steps>
+    VS Code does not expose a post-write hook today, so Semgrep tools are invoked when the agent calls them through MCP. Learn more about [adding and managing MCP servers in VS Code](https://code.visualstudio.com/docs/copilot/customization/mcp-servers).
+  </Tab>
+
+  <Tab title="Windsurf">
+    <Steps>
+      <Step>
+        [Install the Semgrep CLI](#install-the-semgrep-cli).
+      </Step>
+      <Step>
+        Create a `hooks.json` file at `~/.codeium/windsurf/hooks.json` and paste the following configuration:
+
+        ```json
+        {
+          "hooks": {
+            "post_write_code": [
+              {
+                "command": "semgrep mcp -k post-tool-cli-scan -a windsurf",
+                "show_output": true
+              }
+            ]
+          }
+        }
+        ```
+      </Step>
+      <Step>
+      Restart Windsurf to apply hook configuration.
+    </Step>
+    </Steps>
+      The `post_write_code` event fires after Cascade writes or modifies any file. Learn more about [Windsurf Cascade hooks](https://docs.windsurf.com/windsurf/cascade/hooks).
+  </Tab>
+
+  <Tab title="Kiro">
+Kiro uses your locally installed Semgrep CLI to run Semgrep on your machine, so [install the Semgrep CLI](#install-the-semgrep-cli) first. Clicking the box below opens Kiro directly so you can add the server; it won’t open a new browser tab.
+
+[![Add to Kiro](https://kiro.dev/images/add-to-kiro.svg)](https://kiro.dev/launch/mcp/add?name=semgrep&config=%7B%22command%22%3A%22semgrep%22%2C%22args%22%3A%5B%22mcp%22%5D%2C%22env%22%3A%7B%22SEMGREP_APP_TOKEN%22%3A%22%24%7BSEMGREP_TOKEN%7D%22%7D%7D)
+
+Alternatively, follow the [Kiro MCP docs](https://kiro.dev/docs/mcp/) and add this file to your `.kiro/settings/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "semgrep": {
+      "command": "semgrep",
+      "args": ["mcp"],
+      "env": {
+        "SEMGREP_APP_TOKEN": "${SEMGREP_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+See [Kiro docs](https://kiro.dev/docs/mcp/) for more info.
+  </Tab>
+
+  <Tab title="Other IDEs">
+  [Install the Semgrep CLI](#install-the-semgrep-cli), then add the Semgrep MCP Server to your IDE. Semgrep provides [sample configuration information](https://github.com/semgrep/semgrep/tree/develop/cli/src/semgrep/mcp#integrations) that you can use as a starting point. Refer to your IDE's documentation for specific details on where to add the MCP server configuration.
+
+  If your IDE supports a post-write or post-tool hook, point it at `semgrep mcp -k post-tool-cli-scan -a <ide-name>` to scan generated code automatically. The Windsurf tab above shows this pattern.
+  </Tab>
+</Tabs>
 
 ## Install the Semgrep CLI
 
-These steps are the same regardless of which IDE you use.
+Every IDE except Claude Code runs Semgrep from a locally installed CLI. (Claude Code uses Semgrep's hosted remote server by default and doesn't need a local CLI; its legacy local plugin installs the CLI for you.)
 
 <Steps>
 <Step>
-Install Semgrep using Homebrew, pipx, or uv:
+Install the Semgrep CLI using Homebrew, pipx, or uv. This requires Python 3.10 or later (the Semgrep CLI needs it at runtime regardless of how it was installed):
 
 ```bash
 # install using Homebrew
@@ -59,223 +269,6 @@ semgrep login && semgrep install-semgrep-pro
 `semgrep login` launches a browser window. You can also use the activation link printed in the terminal.
 </Step>
 </Steps>
-## Connect to your IDE
-
-<Tabs>
-  <Tab title="Claude Code">
-    <Steps>
-      <Step>
-        Start a new Claude Code instance in the terminal:
-
-        ```bash
-        claude
-        ```
-      </Step>
-      <Step>
-        Open the plugin manager:
-
-        ```bash
-        /plugin
-        ```
-      </Step>
-      <Step>
-         Go to **Discover**, search for **Semgrep**, and click **Install**.
-      </Step>
-      <Step>
-      Set up the Guardian:
-
-        ```bash
-        /setup-semgrep-plugin
-        ```
-      </Step>
-    </Steps>
-    The plugin registers a post-tool hook so Claude Code scans every file it writes. Learn more about [Claude Code plugins](https://code.claude.com/docs/en/plugins) and [hooks](https://code.claude.com/docs/en/hooks).
-
-    <Accordion title="Alternative: Use Semgrep’s hosted remote server (beta)">
-      <Note>Beta.</Note>
-
-      If you can't install the Semgrep CLI locally, you can use Semgrep's hosted remote server instead.
-
-      <Steps>
-        <Step>
-          Start a Claude Code instance:
-
-          ```bash
-          claude
-          ```
-        </Step>
-        <Step>
-          Add the Semgrep marketplace:
-
-          ```bash
-          /plugin marketplace add semgrep/guardian-claude
-          ```
-        </Step>
-        <Step>
-          Install the plugin from the marketplace:
-
-          ```bash
-          /plugin install semgrep-plugin@semgrep-guardian-claude
-          ```
-        </Step>
-        <Step>
-          Tell Claude to load the plugin:
-
-          ```bash
-          /reload-plugins
-          ```
-        </Step>
-        <Step>
-          Start a new session in Claude to begin the Semgrep login flow:
-
-          ```bash
-          /clear
-          ```
-
-          Alternatively, exit and relaunch Claude Code.
-        </Step>
-      </Steps>
-    </Accordion>
-  </Tab>
-  <Tab title="Codex">
-    <Steps>
-      <Step>
-        Update your `~/.codex/config.toml` file and paste the following:
-
-        ```bash
-        [mcp_servers.semgrep]
-        command = "semgrep"
-        args = ["mcp"]
-        ```
-      </Step>
-    </Steps>
-    Codex does not expose a post-write hook, so Semgrep tools are surfaced through MCP and invoked when the agent calls them. Learn more about [Codex MCP configuration](https://developers.openai.com/codex/mcp).
-  </Tab>
-  <Tab title="Cursor">
-    <Steps>
-      <Step>
-        Find Semgrep in the [Cursor Plugin Marketplace](https://cursor.com/marketplace/semgrep), or open **Cursor > ⌘⇧J > Plugins**. Search "Semgrep" and click **Add to Cursor**.
-      </Step>
-      <Step>
-        Restart Cursor to apply configuration.
-      </Step>
-      <Step>
-        In Cursor's chat, run the `/setup-semgrep-plugin` skill to finish wiring up the plugin.
-
-        The plugin uses [Cursor hooks](https://cursor.com/docs/hooks) (`afterFileEdit` and `stop`) to scan code as the agent writes it, and exposes Semgrep tools through [Cursor MCP](https://cursor.com/docs/mcp).
-      </Step>
-    </Steps>
-  </Tab>
-  <Tab title="GitHub Copilot">
-  Use this tab for GitHub Copilot in Visual Studio, JetBrains IDEs, Xcode, or Eclipse. (For Copilot in VS Code, use the **VS Code** tab.)
-    <Steps>
-      <Step>
-        Register the Semgrep MCP server with your IDE's Copilot configuration. The JSON shape is the same across IDEs:
-
-        ```json
-          {
-            "servers": {
-              "semgrep": {
-                  "command": "semgrep",
-                  "args": ["mcp"]
-              }
-            }
-          }
-          ```
-        Follow your IDE's instructions for *where* to put this entry: [Extending Copilot Chat with MCP servers](https://docs.github.com/en/copilot/how-tos/provide-context/use-mcp-in-your-ide/extend-copilot-chat-with-mcp) covers Visual Studio, JetBrains, Xcode, and Eclipse.
-      </Step>
-      <Step>
-        Restart your IDE and open Copilot Chat. Semgrep tools become available in **Agent** mode.
-      </Step>
-    </Steps>
-    Copilot does not expose a post-write hook, so Semgrep tools are invoked when the agent calls them through MCP.
-  </Tab>
-
-  <Tab title="VS Code">
-    <Steps>
-      <Step>
-        Add the Semgrep MCP server to VS Code. Create `.vscode/mcp.json` in your workspace (or run the **MCP: Open User Configuration** command from the Command Palette for a user-wide entry) and paste the following:
-
-        ```json
-          {
-            "servers": {
-              "semgrep": {
-                  "command": "semgrep",
-                  "args": ["mcp"]
-              }
-            }
-          }
-          ```
-      </Step>
-      <Step>
-        Verify that you've installed the [latest version](https://github.com/semgrep/semgrep/releases) of Semgrep by running the following:
-
-        ```bash
-        semgrep --version
-        ```
-      </Step>
-      <Step>
-        Reload VS Code. Semgrep tools become available in the Copilot Chat **Agent** mode.
-      </Step>
-    </Steps>
-    VS Code does not expose a post-write hook today, so Semgrep tools are invoked when the agent calls them through MCP. Learn more about [adding and managing MCP servers in VS Code](https://code.visualstudio.com/docs/copilot/customization/mcp-servers).
-  </Tab>
-
-  <Tab title="Windsurf">
-    <Steps>
-      <Step>
-        Create a `hooks.json` file at `~/.codeium/windsurf/hooks.json` and paste the following configuration:
-
-        ```json
-        {
-          "hooks": {
-            "post_write_code": [
-              {
-                "command": "semgrep mcp -k post-tool-cli-scan -a windsurf",
-                "show_output": true
-              }
-            ]
-          }
-        }
-        ```
-      </Step>
-      <Step>
-      Restart Windsurf to apply hook configuration.
-    </Step>
-    </Steps>
-      The `post_write_code` event fires after Cascade writes or modifies any file. Learn more about [Windsurf Cascade hooks](https://docs.windsurf.com/windsurf/cascade/hooks).
-  </Tab>
-
-  <Tab title="Kiro">
-Kiro uses your locally installed Semgrep CLI to run Semgrep on your machine. Clicking the box below opens Kiro directly so you can add the server; it won’t open a new browser tab.
-
-[![Add to Kiro](https://kiro.dev/images/add-to-kiro.svg)](https://kiro.dev/launch/mcp/add?name=semgrep&config=%7B%22command%22%3A%22semgrep%22%2C%22args%22%3A%5B%22mcp%22%5D%2C%22env%22%3A%7B%22SEMGREP_APP_TOKEN%22%3A%22%24%7BSEMGREP_TOKEN%7D%22%7D%7D)
-
-Alternatively, follow the [Kiro MCP docs](https://kiro.dev/docs/mcp/) and add this file to your `.kiro/settings/mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "semgrep": {
-      "command": "semgrep",
-      "args": ["mcp"],
-      "env": {
-        "SEMGREP_APP_TOKEN": "${SEMGREP_TOKEN}"
-      }
-    }
-  }
-}
-```
-
-See [Kiro docs](https://kiro.dev/docs/mcp/) for more info.
-  </Tab>
-
-  <Tab title="Other IDEs">
-  Add the Semgrep MCP Server to your IDE. Semgrep provides [sample configuration information](https://github.com/semgrep/semgrep/tree/develop/cli/src/semgrep/mcp#integrations) that you can use as a starting point. Refer to your IDE's documentation for specific details on where to add the MCP server configuration.
-
-  If your IDE supports a post-write or post-tool hook, point it at `semgrep mcp -k post-tool-cli-scan -a <ide-name>` to scan generated code automatically. The Windsurf tab above shows this pattern.
-  </Tab>
-</Tabs>
 
 ## Scan your code
 

--- a/docs/guardian.mdx
+++ b/docs/guardian.mdx
@@ -21,8 +21,6 @@ This guide covers setup for each of the preceding products listed, but the plugi
 
 * A Semgrep account
 
-Claude Code uses Semgrep's hosted remote server by default, so no local install is required. Every other IDE runs Semgrep from your locally installed CLI; the steps for those IDEs link to [Install the Semgrep CLI](#install-the-semgrep-cli).
-
 ## Connect to your IDE
 
 <Tabs>
@@ -40,10 +38,24 @@ Claude Code uses Semgrep's hosted remote server by default, so no local install 
       <Step>
         Open the plugin marketplace, search for **Semgrep**, and install it.
       </Step>
+      <Step>
+        Tell Claude to load the plugin:
+
+        ```bash
+        /reload-plugins
+        ```
+      </Step>
+      <Step>
+        Start a new session in Claude to begin the Semgrep login flow:
+
+        ```bash
+        /clear
+        ```
+      </Step>
     </Steps>
     The plugin registers a post-tool hook so Claude Code scans every file it writes. Learn more about [Claude Code plugins](https://code.claude.com/docs/en/plugins) and [hooks](https://code.claude.com/docs/en/hooks).
 
-    <Accordion title="Legacy: run Semgrep from a local plugin">
+    <Accordion title="Legacy: Run Semgrep Guardian locally">
       The remote server is the recommended default. If you need to run Semgrep locally instead, you can install the legacy local plugin from the [`semgrep/guardian-local`](https://github.com/semgrep/guardian-local) repo.
 
       <Steps>

--- a/docs/guardian.mdx
+++ b/docs/guardian.mdx
@@ -36,7 +36,14 @@ This guide covers setup for each of the preceding products listed, but the plugi
         ```
       </Step>
       <Step>
-        Open the plugin marketplace, search for **Semgrep**, and install it.
+        Open the plugin manager:
+
+        ```bash
+        /plugin
+        ```
+      </Step>
+      <Step>
+        Go to **Discover**, search for **Semgrep**, and click **Install**.
       </Step>
       <Step>
         Tell Claude to load the plugin:


### PR DESCRIPTION
## Summary

- Updates the Semgrep Guardian docs so Claude Code install defaults to Semgrep's remote server. The Claude Code local plugin is reframed as a legacy fallback, and points at [`semgrep/guardian-local`](https://github.com/semgrep/guardian-local).

- **Non-Claude tabs** (Codex, Cursor, GitHub Copilot, VS Code, Windsurf, Kiro, Other IDEs) link to a new shared **Install the Semgrep CLI** section instead of repeating the steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)