### PR TITLE
docs: drop "legacy" label from Guardian local install option

### DIFF
--- a/docs/guardian.mdx
+++ b/docs/guardian.mdx
@@ -62,8 +62,8 @@ This guide covers setup for each of the preceding products listed, but the plugi
     </Steps>
     The plugin registers a post-tool hook so Claude Code scans every file it writes. Learn more about [Claude Code plugins](https://code.claude.com/docs/en/plugins) and [hooks](https://code.claude.com/docs/en/hooks).
 
-    <Accordion title="Legacy: Run Semgrep Guardian locally">
-      The remote server is the recommended default. If you need to run Semgrep locally instead, you can install the legacy local plugin from the [`semgrep/guardian-local`](https://github.com/semgrep/guardian-local) repo.
+    <Accordion title="Run Semgrep Guardian locally">
+      The remote server is the recommended default. If you need to run Semgrep locally instead, you can install the local plugin from the [`semgrep/guardian-local`](https://github.com/semgrep/guardian-local) repo.
 
       <Steps>
         <Step>


### PR DESCRIPTION
## Summary
Removes the "legacy" framing from the local install option on the Guardian page's Claude Code tab. The hosted remote server remains the recommended default; the local plugin is still a supported alternative, so labeling it "legacy" was misleading.

- Accordion title: "Legacy: Run Semgrep Guardian locally" → "Run Semgrep Guardian locally"
- Body: "install the legacy local plugin" → "install the local plugin"

🤖 Generated with [Claude Code](https://claude.com/claude-code)